### PR TITLE
#19 - [FR] Successfully to build workable version for windows (Rust t…

### DIFF
--- a/doc/BUILD_ON_WNIDOWS.md
+++ b/doc/BUILD_ON_WNIDOWS.md
@@ -1,0 +1,56 @@
+## How to build on Windows 10, please follow these simple steps.
+
+**Step 1:**
+
+```shell
+git clone https://github.com/AppFlowy-IO/appflowy.git
+```
+
+**Step 2:**
+
+Note: Please run the commands in windows cmd rather than powershell
+
+1. Install Visual Studio 2019 community. See: https://visualstudio.microsoft.com/downloads/
+    - Note: Didn't test Visual Studio 2022. It should also work.
+2. Install choco according to https://chocolatey.org/install
+3. Install vcpkg according to https://github.com/microsoft/vcpkg#quick-start-windows. Make sure to add vcpkg installation folder to PATH env var.
+4. Install flutter according to https://docs.flutter.dev/get-started/install/windows
+```shell
+flutter channel dev
+```
+5. Install rust
+```shell
+choco install rustup.install
+rustup toolchain install nightly
+```
+6. Install cargo make
+```shell
+cd appflowy
+cargo install --force cargo-make
+```
+7. Install duckscript
+```shell
+cargo install --force duckscript_cli
+```
+8. Check pre-request
+```shell
+cargo make flowy_dev
+```
+9. Generate protobuf for dart
+```shell
+cargo make -p development-windows pb
+```
+10. Build flowy-sdk-dev (dart-ffi)
+```shell
+cargo make --profile development-windows flowy-sdk-dev
+```
+11. Build app_flowy
+```shell
+cargo make -p development-windows appflowy-windows
+```
+
+**Step 3:**  Server side application
+
+Note: You can launch postgresql server by using docker container
+
+TBD

--- a/scripts/flowy-tool/Cargo.toml
+++ b/scripts/flowy-tool/Cargo.toml
@@ -12,7 +12,7 @@ syn = { version = "1.0.60", features = ["extra-traits", "parsing", "derive", "fu
 tera = { version = "1.5.0" }
 log = "0.4.11"
 env_logger = "0.8.2"
-shell = { git="https://github.com/google/rust-shell.git"}
+#shell = { git="https://github.com/google/rust-shell.git"}
 cmd_lib = "1.1"
 flowy-ast = { path = "../../rust-lib/flowy-ast" }
 console = "0.14.0"

--- a/scripts/flowy-tool/src/proto/proto_gen.rs
+++ b/scripts/flowy-tool/src/proto/proto_gen.rs
@@ -159,10 +159,7 @@ fn run_flutter_protoc(crate_infos: &Vec<CrateProtoInfo>, package_info: &FlutterP
 
 fn remove_everything_in_dir(dir: &str) {
     if Path::new(dir).exists() {
-        if cmd_lib::run_cmd! {
-            rm -rf ${dir}
-        }
-        .is_err()
+        if std::fs::remove_dir_all(dir).is_err()
         {
             panic!("Reset protobuf directory failed")
         };

--- a/scripts/flowy-tool/src/util/file.rs
+++ b/scripts/flowy-tool/src/util/file.rs
@@ -97,8 +97,13 @@ pub fn get_tera(directory: &str) -> Tera {
         .as_path()
         .display()
         .to_string();
+    let mut template_path = format!("{}/**/*.tera", root_absolute_path);
+    if cfg!(windows)
+    {
+        // remove "\\?\" prefix on windows
+        template_path = format!("{}/**/*.tera", &root_absolute_path[4..]);
+    }
 
-    let template_path = format!("{}/**/*.tera", root_absolute_path);
     match Tera::new(template_path.as_ref()) {
         Ok(t) => t,
         Err(e) => {

--- a/scripts/makefile/env.toml
+++ b/scripts/makefile/env.toml
@@ -1,10 +1,63 @@
 [tasks.flowy_dev]
-run_task = { name = ["install_targets","install_diesel", "install_protobuf"] }
+run_task = { name = ["install_prerequests","install_diesel", "install_protobuf"] }
+
+[tasks.install_windows_deps.windows]
+dependencies=["check_duckscript_installation", "check_visual_studio_installation", "check_vcpkg", "install_rust_vcpkg_cli"]
+
+[tasks.check_visual_studio_installation.windows]
+script = """
+output = exec powershell -Command "Get-CimInstance MSFT_VSInstance | select -ExpandProperty Version"
+stdout = set ${output.stdout}
+pos = last_indexof ${stdout} .
+new_str = substring ${stdout} 0 ${pos}
+newer = semver_is_newer ${new_str} 16.11.0
+assert ${newer} "Visual studio 2019 is not installed or version is lower than 16.11.0"
+"""
+script_runner = "@duckscript"
+
+[tasks.check_duckscript_installation.windows]
+script = """
+@echo off
+@duck -h > nul
+if %errorlevel% GTR 0 (
+  echo Please install duckscript at first: cargo install --force duckscript_cli
+  exit -1
+)
+"""
+
+[tasks.check_vcpkg.windows]
+script = """
+ret = which vcpkg
+if is_empty ${ret}
+    echo "Please install vcpkg on windows at first. Make sure to put it into PATH env var"
+    echo "See: https://github.com/microsoft/vcpkg#quick-start-windows"
+    exit -1
+end
+"""
+script_runner = "@duckscript"
+
+[tasks.install_rust_vcpkg_cli.windows]
+script = """
+exec cargo install vcpkg_cli
+output = exec vcpkg_cli probe sqlite3
+stdout = set ${output.stdout}
+stderr = set ${output.stderr}
+ret = indexof ${stdout} "Failed:"
+assert_eq ${ret} "" ${stdout}
+"""
+script_runner = "@duckscript"
 
 [tasks.install_diesel]
 script = """
 cargo install diesel_cli --no-default-features --features sqlite
 """
+
+[tasks.install_diesel.windows]
+script = """
+vcpkg install sqlite3:x64-windows-static-md
+cargo install diesel_cli --no-default-features --features sqlite
+"""
+dependencies = ["check_vcpkg"]
 
 [tasks.install_targets]
 script = """
@@ -12,7 +65,14 @@ rustup target add x86_64-apple-ios
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-ios
 rustup target add aarch64-apple-darwin
+rustup target add x86_64-pc-windows-msvc
 """
+
+[tasks.install_prerequests]
+dependencies=["install_targets"]
+
+[tasks.install_prerequests.windows]
+dependencies=["install_targets", "install_windows_deps"]
 
 [tasks.install_protobuf]
 script = """
@@ -26,6 +86,24 @@ dart pub global activate protoc_plugin
 
 cargo install --version 2.20.0 protobuf-codegen
 """
+
+[tasks.install_protobuf.windows]
+script = """
+ret = which dart
+if is_empty ${ret}
+    echo Please make sure flutter/dart is properly installed and in PATH env var
+    exit -1
+end
+ret = which protoc-gen-dart
+if is_empty ${ret}
+    dart pub global activate protoc_plugin
+    home_dir = get_home_dir
+    echo Please add '${home_dir}\\\\AppData\\\\Local\\\\Pub\\\\Cache\\\\bin' into PATH env var
+    exit -1
+end
+exec cargo install --version 2.22.1 protobuf-codegen
+"""
+script_runner = "@duckscript"
 
 [tasks.install_tools]
 script = """
@@ -64,9 +142,12 @@ brew install fish
 
 [tasks.install_flutter]
 script = """
-echo "[❤️] Follow the https://flutter.dev/docs/get-started/install instructions to install the flutter, skip if you already installed."
-echo "Switch to dev channel with command: flutter channel dev"
+ret = which flutter
+if is_empty ${ret}
+    echo "[❤️] Follow the https://flutter.dev/docs/get-started/install instructions to install the flutter, skip if you already installed."
+    echo "Switch to dev channel with command: flutter channel dev"
+    exit -1
+end
 """
-
-
+script_runner = "@duckscript"
 

--- a/scripts/makefile/flutter.toml
+++ b/scripts/makefile/flutter.toml
@@ -9,7 +9,7 @@ script_runner = "@shell"
 
 [tasks.appflowy-windows]
 dependencies = ["flowy-sdk-release"]
-run_task = { name = ["flutter-build", "copy-to-product"] }
+run_task = { name = ["flutter-build", "copy-dll-to-build-folder", "copy-to-product"] }
 
 [tasks.copy-to-product]
 mac_alias = "copy-to-product-macos"
@@ -32,12 +32,23 @@ script = [
 ]
 script_runner = "@shell"
 
+[tasks.copy-dll-to-build-folder]
+script = [
+  """
+    cp ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/rust-lib/target/${RUST_COMPILE_TARGET}/${BUILD_FLAG}/${CARGO_MAKE_CRATE_FS_NAME}.${SDK_EXT} \
+    ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/app_flowy/build/${TARGET_OS}/runner/${BUILD_FLAG}/${CARGO_MAKE_CRATE_FS_NAME}.${SDK_EXT}
+  """,
+]
+script_runner = "@duckscript"
+
 [tasks.copy-to-product-windows]
 script = [
   """
+  # TODO:
+  echo TBD...
   """,
 ]
-script_runner = "@powershell"
+script_runner = "@duckscript"
 
 
 [tasks.flutter-build]
@@ -50,6 +61,17 @@ script = [
   """,
 ]
 script_runner = "@shell"
+
+[tasks.flutter-build.windows]
+script = [
+  """
+  cd app_flowy
+  exec cmd.exe /c flutter clean
+  exec cmd.exe /c flutter pub get
+  exec cmd.exe /c flutter build ${TARGET_OS} --${BUILD_FLAG}
+  """,
+]
+script_runner = "@duckscript"
 
 [tasks.freeze_setup]
 script = [

--- a/scripts/makefile/protobuf.toml
+++ b/scripts/makefile/protobuf.toml
@@ -23,6 +23,27 @@ script = [
 script_runner = "@shell"
 
 
+[tasks.gen_pb_file.windows]
+script = [
+    """
+    flowy_tool=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/scripts/flowy-tool/Cargo.toml
+    rust_source=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/rust-lib/
+    rust_lib=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/rust-lib
+    flutter_lib=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/app_flowy/packages
+
+    derive_meta=set ${rust_lib}/flowy-derive/src/derive_cache/derive_cache.rs
+    flutter_package_lib=set ${flutter_lib}/flowy_sdk/lib
+
+    exec cmd /c cargo run \
+     --manifest-path ${flowy_tool} pb-gen \
+     --rust_source=${rust_source} \
+     --derive_meta=${derive_meta} \
+     --flutter_package_lib=${flutter_package_lib}
+    """,
+]
+script_runner = "@duckscript"
+
+
 [tasks.gen_dart_event]
 script = [
     """
@@ -39,3 +60,20 @@ script = [
     """,
 ]
 script_runner = "@shell"
+
+[tasks.gen_dart_event.windows]
+script = [
+    """
+    flowy_tool=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/scripts/flowy-tool/Cargo.toml
+    flutter_lib=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/app_flowy/packages
+
+    rust_source=set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/rust-lib/
+    output=set ${flutter_lib}/flowy_sdk/lib/dispatch/code_gen.dart
+
+    exec cmd.exe /c cargo run \
+     --manifest-path ${flowy_tool} dart-event \
+     --rust_source=${rust_source} \
+     --output=${output}
+    """,
+]
+script_runner = "@duckscript"


### PR DESCRIPTION
For issue #19 

1. scripts\flowy-tool\Cargo.toml
  - Remove shell dependency which does not support windows
2. scripts\makefile\env.toml
  - Enhance environment checking for building app on windows
3. scripts\flowy-tool\src\util\file.rs
  - Trim unnecessary prefix "\\?\" for std::fs::canonicalize(root) on windows
4.  scripts\makefile\flutter.toml
  - add dependency for "tasks.appflowy-windows" to copy dart_ffi.dll from rust build folder to flutter build folder
5. scripts\flowy-tool\src\proto\proto_gen.rs
  - Remove dir by using platform independent code rather than calling *nix shell command
6. scripts\makefile\protobuf.toml
  - tasks.gen_dart_event: call duckscript to gen_dart_event on windows platform