### PR TITLE
Bump sqlx-cli version to fix its compiling error when installing

### DIFF
--- a/backend/scripts/database/init_database.sh
+++ b/backend/scripts/database/init_database.sh
@@ -13,7 +13,7 @@ fi
 if ! [ -x "$(command -v sqlx)" ]; then
   echo >&2 "Error: `sqlx` is not installed."
   echo >&2 "Use:"
-  echo >&2 "    cargo install --version=0.5.5 sqlx-cli --no-default-features --features postgres"
+  echo >&2 "    cargo install --version=^0.5.6 sqlx-cli --no-default-features --features postgres"
   echo >&2 "to install it."
   exit 1
 fi


### PR DESCRIPTION
sqlx-cli 0.5.5 can not be installed on latest nightly Rust, which outputs errors like:

```
error: cannot find derive macro `Clap` in this scope
error: cannot find attribute `clap` in this scope
```

sqlx-cli 0.5.6 fixed it.

The PR use `^0.5.6` to retrive 0.5.6 <= ver < 0.6.0, while there should not be a very very tight requirement over sqlx-cli version.