### PR TITLE
[Build] Enhance windows build instruction and cargo make scripts

### DIFF
--- a/doc/BUILD_ON_WINDOWS.md
+++ b/doc/BUILD_ON_WINDOWS.md
@@ -51,13 +51,15 @@ cargo make -p development-windows pb
 ```
 10. Build flowy-sdk (dart-ffi)
 ```shell
-# TODO: for development
+# for development
+cargo make --profile development-desktop-windows-x86 flowy-sdk-dev
 # for production
 cargo make --profile production-desktop-windows-x86 flowy-sdk-release
 ```
 11. Build app_flowy
 ```shell
-# TODO: for development
+# for development
+cargo make -p development-desktop-windows-x86 appflowy-windows-dev
 # for production
 cargo make -p production-desktop-windows-x86 appflowy-windows
 ```

--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -42,7 +42,7 @@ FLUTTER_OUTPUT_DIR = "Release"
 PRODUCT_EXT = "app"
 
 
-[env.development-windows]
+[env.development-desktop-windows-x86]
 TARGET_OS = "windows"
 RUST_COMPILE_TARGET = "x86_64-pc-windows-msvc"
 BUILD_FLAG = "debug"

--- a/frontend/app_flowy/.vscode/tasks.json
+++ b/frontend/app_flowy/.vscode/tasks.json
@@ -2,7 +2,7 @@
 	"version": "2.0.0",
 	// https://code.visualstudio.com/docs/editor/tasks
 			//https://gist.github.com/deadalusai/9e13e36d61ec7fb72148
-			
+
 			// ${workspaceRoot}: the root folder of the team
 			// ${file}: the current opened file
 			// ${fileBasename}: the current opened file's basename
@@ -13,6 +13,16 @@
 		{
 			"type": "shell",
 			"command": "sh ./scripts/build_sdk.sh",
+			"windows": {
+				"options": {
+					"shell": {
+						"executable": "cmd.exe",
+						"args": [
+							"/d", "/c", ".\\scripts\\build_sdk.cmd"
+						]
+					}
+				}
+			},
 			"group": "build",
 			"options": {
 				"cwd": "${workspaceFolder}/../"

--- a/frontend/scripts/build_sdk.cmd
+++ b/frontend/scripts/build_sdk.cmd
@@ -1,0 +1,3 @@
+echo "Start building rust sdk"
+rustup show
+cargo make --profile development-desktop-windows-x86 flowy-sdk-dev

--- a/frontend/scripts/makefile/desktop.toml
+++ b/frontend/scripts/makefile/desktop.toml
@@ -41,6 +41,18 @@ script = [
 ]
 script_runner = "@shell"
 
+[tasks.sdk-build.windows]
+private = true
+script = [
+  """
+    cd rust-lib
+    echo cargo build --package=dart-ffi --target ${RUST_COMPILE_TARGET} --features=${FEATURES}
+    exec cargo build --package=dart-ffi --target ${RUST_COMPILE_TARGET} --features=${FEATURES}
+    cd ..
+  """,
+]
+script_runner = "@duckscript"
+
 #
 [tasks.flowy-sdk-release]
 description = "Build flowy sdk in release mode"

--- a/frontend/scripts/makefile/env.toml
+++ b/frontend/scripts/makefile/env.toml
@@ -10,6 +10,7 @@ output = exec powershell -Command "Get-CimInstance MSFT_VSInstance | select -Exp
 stdout = set ${output.stdout}
 pos = last_indexof ${stdout} .
 new_str = substring ${stdout} 0 ${pos}
+# TODO: will raise error if there are more than 1 visual studio installation
 newer = semver_is_newer ${new_str} 16.11.0
 assert ${newer} "Visual studio 2019 is not installed or version is lower than 16.11.0"
 """
@@ -101,7 +102,7 @@ if is_empty ${ret}
 end
 ret = which protoc-gen-dart
 if is_empty ${ret}
-    dart pub global activate protoc_plugin
+    exec cmd.exe /c dart pub global activate protoc_plugin
     home_dir = get_home_dir
     echo Please add '${home_dir}\\\\AppData\\\\Local\\\\Pub\\\\Cache\\\\bin' into PATH env var
     exit -1


### PR DESCRIPTION
1. doc\BUILD_ON_WINDOWS.md
  - add command for building development version
2. .vscode\tasks.json
  - Enable vscode to launch debug session on windows
3. frontend\scripts\makefile\env.toml
  - Fix "Command : dart not found." on windows
4. frontend\Makefile.toml
  - Change profile name "env.development-windows" to "env.development-desktop-windows-x86"