### PR TITLE
fix: build_sdk script to use nightly version of cargo

### DIFF
--- a/frontend/scripts/build_sdk.sh
+++ b/frontend/scripts/build_sdk.sh
@@ -17,7 +17,8 @@ rustup show
 # TODO: Automatically exec the script base on the current system
 
 # for macos
-cargo make --profile development-mac flowy-sdk-dev
+# cargo make --profile development-mac flowy-sdk-dev
+rustup run nightly cargo make --profile development-mac flowy-sdk-dev
 
 # for window
 #cargo make --profile development-windows flowy-sdk-dev


### PR DESCRIPTION
https://github.com/AppFlowy-IO/appflowy/issues/68#issuecomment-976448988

ps:
I don't know why `cargo +nightly` doesn't work