### PR TITLE
[Instruction] Enhance BUILD_ON_WINDOWS.md to remove choco dependency

### DIFF
--- a/doc/BUILD_ON_WINDOWS.md
+++ b/doc/BUILD_ON_WINDOWS.md
@@ -19,44 +19,46 @@ Note:
     - [ ] Windows 11 arm64
 
 ### Detail steps
-1. Install Visual Studio 2019 community. See: https://visualstudio.microsoft.com/downloads/
-    - Note: Didn't test Visual Studio 2022. It should also work.
-2. Install choco according to https://chocolatey.org/install
-3. Install vcpkg according to https://github.com/microsoft/vcpkg#quick-start-windows. Make sure to add vcpkg installation folder to PATH env var.
-4. Install flutter according to https://docs.flutter.dev/get-started/install/windows
+1. Install Visual Studio 2022 build tools. Download from https://visualstudio.microsoft.com/downloads/
+    - In section of "All Downloads" => "Tools for Visual Studio 2022" => Build Tools for Visual Studio 2022, hit Download button to get it.
+    - Launch "vs_BuildTools.exe" to install
+2. Install vcpkg according to https://github.com/microsoft/vcpkg#quick-start-windows. Make sure to add vcpkg installation folder to PATH env var.
+3. Install flutter according to https://docs.flutter.dev/get-started/install/windows
 ```shell
 flutter channel dev
+flutter doctor
 ```
-5. Install rust
+4. Install rust
 ```shell
-choco install rustup.install
-rustup toolchain install nightly
+# Download rustup.exe from https://win.rustup.rs/x86_64
+# Call rustup.exe from powershell or cmd
+rustup.exe toolchain install nightly
 ```
-6. Install cargo make
+5. Install cargo make
 ```shell
 cd appflowy/frontend
 cargo install --force cargo-make
 ```
-7. Install duckscript
+6. Install duckscript
 ```shell
 cargo install --force duckscript_cli
 ```
-8. Check pre-request
+7. Check pre-request
 ```shell
 cargo make flowy_dev
 ```
-9. Generate protobuf for dart (optional, if you modify the shared-lib's entities)
+8. [Optional] Generate protobuf for dart (optional, if you modify the shared-lib's entities)
 ```shell
 cargo make -p development-windows pb
 ```
-10. Build flowy-sdk (dart-ffi)
+9. [Optional] Build flowy-sdk (dart-ffi)
 ```shell
 # for development
 cargo make --profile development-windows-x86 flowy-sdk-dev
 # for production
 cargo make --profile production-windows-x86 flowy-sdk-release
 ```
-11. Build app_flowy
+10. Build app_flowy
 ```shell
 # for development
 cargo make -p development-windows-x86 appflowy-windows-dev

--- a/frontend/scripts/makefile/env.toml
+++ b/frontend/scripts/makefile/env.toml
@@ -64,15 +64,21 @@ cargo install diesel_cli --no-default-features --features sqlite
 """
 dependencies = ["check_vcpkg"]
 
-[tasks.install_targets]
+[tasks.install_targets.mac]
 script = """
-# TODO: download the targets with corresponding platform. For example:
-# It's not necessary to download aarch64-apple-ios when compiling the Flowy-SDK on windows.
 rustup target add x86_64-apple-ios
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-ios
 rustup target add aarch64-apple-darwin
+"""
+
+[tasks.install_targets.windows]
+script = """
 rustup target add x86_64-pc-windows-msvc
+"""
+
+[tasks.install_targets.linux]
+script = """
 rustup target add x86_64-unknown-linux-gnu
 """
 


### PR DESCRIPTION
1. doc\BUILD_ON_WINDOWS.md
2. frontend\scripts\makefile\env.toml
  - break down install_targets task into 3 platform specific tasks
  - only install necessary targets for specfic platform