### PR TITLE
Add unzip to requirements

### DIFF
--- a/doc/BUILD_ON_LINUX.md
+++ b/doc/BUILD_ON_LINUX.md
@@ -23,7 +23,7 @@ Note:
 ### Detail steps
 1. Install prerequisites 
 ```shell
-sudo apt-get install curl build-essential libsqlite3-dev libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev
+sudo apt-get install curl build-essential libsqlite3-dev libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev unzip
 # optional, for generating protobuf in step 8 only
 sudo apt-get install protobuf-compiler
 ```


### PR DESCRIPTION
When running Step 3 `flutter channel dev` got:
```
Missing "unzip" tool. Unable to extract Dart SDK.
Consider running "sudo apt-get install unzip".
```

Building on Ubuntu 20.04