### PR TITLE
docs: Add Arch Linux dependence

### DIFF
--- a/doc/BUILD_ON_LINUX.md
+++ b/doc/BUILD_ON_LINUX.md
@@ -110,6 +110,12 @@ cargo make -p production-linux-x86 appflowy-linux
 ## Step 4: Run the application
 ------------------------------
 
+Arch Linux need install `xdg-user-dirs`:
+
+```shell
+sudo pacman -S xdg-user-dirs
+```
+
 ```
 cd [frontend/]app_flowy/product/0.0.2/linux/Debug/AppFlowy/app_flowy
 ./app_flowy


### PR DESCRIPTION
Arch Linux does not install xdg-user-dir by default. When I run app_flowy I got this error:

```shell
[ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: ProcessException: Failed to find "xdg-user-dir" in the search path.
  Command: xdg-user-dir 
#0      LocalProcessManager.runSync (package:process/src/interface/local_process_manager.dart:118)
#1      getUserDirectory (package:xdg_directories/xdg_directories.dart:154)
#2      PathProviderLinux.getApplicationDocumentsPath (package:path_provider_linux/path_provider_linux.dart:55)
#3      getApplicationDocumentsDirectory (package:path_provider/path_provider.dart:138)
#4      InitRustSDKTask.initialize (package:app_flowy/startup/tasks/init_sdk.dart:16)
#5      AppLauncher.launch (package:app_flowy/startup/launcher.dart:36)
#6      System.run (package:app_flowy/startup/startup.dart:54)
#7      main (package:app_flowy/main.dart:17)
<asynchronous suspension>
```