### PR TITLE
Automate build sdk sh

### DIFF
--- a/frontend/app_flowy/.vscode/tasks.json
+++ b/frontend/app_flowy/.vscode/tasks.json
@@ -15,6 +15,9 @@
 			"command": "sh ./scripts/build_sdk.sh",
 			"windows": {
 				"options": {
+					"env": {
+						"FLOWY_DEV_ENV": "Windows",
+					},
 					"shell": {
 						"executable": "cmd.exe",
 						"args": [
@@ -22,6 +25,20 @@
 						]
 					}
 				}
+			},
+			"linux": {
+				"options": {
+					"env": {
+						"FLOWY_DEV_ENV": "Linux-x86",
+					}
+				},
+			},
+			"osx": {
+				"options": {
+					"env": {
+						"FLOWY_DEV_ENV": "macOS",
+					}
+				},
 			},
 			"group": "build",
 			"options": {
@@ -31,6 +48,6 @@
             //     "$rustc"
             // ],
 			"label": "build_flowy_sdk"
-		},
+		}
 	]
 }

--- a/frontend/scripts/build_sdk.sh
+++ b/frontend/scripts/build_sdk.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #!/usr/bin/env fish
 echo 'Start building rust sdk'
+
 rustup show
 
 #Env check
@@ -14,16 +15,26 @@ rustup show
 #   4. ~/.zshrc
 
 
-# TODO: Automatically exec the script base on the current system
+case "$FLOWY_DEV_ENV" in
+Linux-aarch64) 
+ cargo make --profile development-linux-aarch64 flowy-sdk-dev
+ ;;
 
-# for macOS
-cargo make --profile development-mac flowy-sdk-dev
+Linux-x86)
+ cargo make --profile development-linux-x86 flowy-sdk-dev
+ ;;
 
-# for Windows
-#cargo make --profile development-windows flowy-sdk-dev
+macOS)
+ cargo make --profile development-mac flowy-sdk-dev
+ ;;
 
-# for Linux x86
-#cargo make --profile development-linux-x86 flowy-sdk-dev
+Windows) 
+ cargo make --profile development-windows flowy-sdk-dev
+ ;;
 
-# for Linux aarch64
-#cargo make --profile development-linux-aarch64 flowy-sdk-dev
+*)
+ # All undefined cases
+ echo "[ERROR] The FLOWY_DEV_ENV environment variable must be set. Please see the GitHub wiki for instructions."
+ exit 1
+ ;;
+esac

--- a/frontend/scripts/build_sdk.sh
+++ b/frontend/scripts/build_sdk.sh
@@ -34,7 +34,7 @@ Windows)
 
 *)
  # All undefined cases
- echo "[ERROR] The FLOWY_DEV_ENV environment variable must be set. Please see the GitHub wiki for instructions."
+ echo "[ERROR] The FLOWY_DEV_ENV environment variable must be set. Please see the GitHub wiki for build instructions."
  exit 1
  ;;
 esac

--- a/frontend/scripts/build_sdk.sh
+++ b/frontend/scripts/build_sdk.sh
@@ -34,7 +34,7 @@ Windows)
 
 *)
  # All undefined cases
- echo "[ERROR] The FLOWY_DEV_ENV environment variable must be set. Please see the GitHub wiki for build instructions."
+ echo "[ERROR] The FLOWY_DEV_ENV environment variable must be set. Please see the GitHub wiki for instructions."
  exit 1
  ;;
 esac


### PR DESCRIPTION
Build system will now detect OS and pass it down to build_sdk.sh.

build_sdk.sh will now automatically choose the correct cargo-make command line based on