### PR TITLE
Increased height of ActionCell

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/widgets/pop_up_action.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/pop_up_action.dart
@@ -65,7 +65,7 @@ abstract class ActionItem {
 
 class ActionListSizes {
   static double itemHPadding = 10;
-  static double itemHeight = 16;
+  static double itemHeight = 20;
   static double padding = 6;
 }
 


### PR DESCRIPTION
Fixes #153 , the ActionCell height was too short and resulted in portions of a character getting cut-off