### PR TITLE
Small fixes for `docker-compose up` command's error and warning

### DIFF
--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -5,8 +5,11 @@ services:
     build: .
     stdin_open: true 
     # tty: true
+    devices:
+      - "/dev/dri:/dev/dri"  # fixes MESA-LOADER error
     environment:
       - DISPLAY=${DISPLAY}
+      - NO_AT_BRIDGE=1  # fixes dbind-WARNING
     volumes:
       - $HOME/.Xauthority:/root/.Xauthority:rw
     network_mode: host

--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -3,13 +3,21 @@ version: "3"
 services:
   app:
     build: .
-    stdin_open: true 
+    image: appflowy/appflowy:latest
+    stdin_open: true
     # tty: true
     devices:
-      - "/dev/dri:/dev/dri"  # fixes MESA-LOADER error
+      - "/dev/dri:/dev/dri" # fixes MESA-LOADER error
     environment:
       - DISPLAY=${DISPLAY}
-      - NO_AT_BRIDGE=1  # fixes dbind-WARNING
+      - NO_AT_BRIDGE=1 # fixes dbind-WARNING
     volumes:
       - $HOME/.Xauthority:/root/.Xauthority:rw
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /dev/dri:/dev/dri
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+      - appflowy-data:/home/makepkg
     network_mode: host
+
+volumes:
+  appflowy-data:


### PR DESCRIPTION
When I run `docker-compose up` command I'm getting the following error:
```
app_1  | (app_flowy:1): dbind-WARNING **: 20:06:32.776: Couldn't register with accessibility bus: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
app_1  | libGL error: MESA-LOADER: failed to retrieve device information
app_1  | [xcb] Unknown sequence number while processing queue
app_1  | [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
app_1  | [xcb] Aborting, sorry about that.
app_1  | app_flowy: xcb_io.c:269: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
appflowy_app_1 exited with code 139
```
I searched on the Internet and found some solutions, feel free to use them if you consider them useful.

Lines below are fixing the `libGL error: MESA-LOADER: failed to retrieve device information` and following `[xcb]` messages
```
devices:
      - "/dev/dri:/dev/dri"  # fixes MESA-LOADER error
```
Line `- NO_AT_BRIDGE=1`  is fixing the `(app_flowy:1): dbind-WARNING **: 20:06:32.776: Couldn't register with accessibility bus: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.`

