### PR TITLE
Changes language names to their respective languages

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -31,16 +31,16 @@ class _LanguageSelectorDropdownState extends State<LanguageSelectorDropdown> {
   @override
   Widget build(BuildContext context) {
     return DropdownButton<AppLanguage>(
-      value: fullStringFromLanguage(context.read<AppearanceSettingModel>().language),
+      value: context.read<AppearanceSettingModel>().language,
       onChanged: (val) {
         setState(() {
-          context.read<AppearanceSettingModel>().setLanguage(context, languageFromFullString(val!));
+          context.read<AppearanceSettingModel>().setLanguage(context, val!);
         });
       },
       autofocus: true,
       items: AppLanguage.values.map((language) {
         return DropdownMenuItem<AppLanguage>(
-          value: fullStringFromLanguage(language),
+          value: language,
           child: Text(describeEnum(language)),
         );
       }).toList(),

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -31,16 +31,16 @@ class _LanguageSelectorDropdownState extends State<LanguageSelectorDropdown> {
   @override
   Widget build(BuildContext context) {
     return DropdownButton<AppLanguage>(
-      value: context.read<AppearanceSettingModel>().language,
+      value: fullStringFromLanguage(context.read<AppearanceSettingModel>().language),
       onChanged: (val) {
         setState(() {
-          context.read<AppearanceSettingModel>().setLanguage(context, val!);
+          context.read<AppearanceSettingModel>().setLanguage(context, languageFromFullString(val!));
         });
       },
       autofocus: true,
       items: AppLanguage.values.map((language) {
         return DropdownMenuItem<AppLanguage>(
-          value: language,
+          value: fullStringFromLanguage(language),
           child: Text(describeEnum(language)),
         );
       }).toList(),

--- a/frontend/app_flowy/packages/flowy_infra/lib/language.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/language.dart
@@ -20,6 +20,19 @@ String stringFromLanguage(AppLanguage language) {
   }
 }
 
+string fullStringFromLanguage(AppLanguage language) {
+  switch (language) {
+    case AppLanguage.english:
+      return "english";
+    case AppLanguage.chinese:
+      return "汉语";
+    case AppLanguage.italian:
+      return "italiano";
+    case AppLanguage.french:
+      return "français";
+  }
+}
+
 AppLanguage languageFromString(String name) {
   AppLanguage language = AppLanguage.english;
   if (name == "ch") {
@@ -27,6 +40,19 @@ AppLanguage languageFromString(String name) {
   } else if (name == "it") {
     language = AppLanguage.italian;
   } else if (name == "fr") {
+    language = AppLanguage.french;
+  }
+
+  return language;
+}
+
+AppLanguage languageFromFullString(String name) {
+  AppLanguage language = AppLanguage.english;
+  if (name == "汉语") {
+    language = AppLanguage.chinese;
+  } else if (name == "italiano") {
+    language = AppLanguage.italian;
+  } else if (name == "français") {
     language = AppLanguage.french;
   }
 

--- a/frontend/app_flowy/packages/flowy_infra/lib/language.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/language.dart
@@ -20,7 +20,7 @@ String stringFromLanguage(AppLanguage language) {
   }
 }
 
-string fullStringFromLanguage(AppLanguage language) {
+String fullStringFromLanguage(AppLanguage language) {
   switch (language) {
     case AppLanguage.english:
       return "english";


### PR DESCRIPTION
Fixes #290

Some non-english speakers might find it hard to change their language
because they are all written in english.

This commit changes the language names in the selector to their
respective languages.

- Added two functions in `frontend/app_flowy/packages/flowy_infra/lib/language.dart`:
- - fullStringFromLanguage
- - languageFromFullString

These convert two and from the language's name and it's AppLanguage.

- '_LanguageSelectorDropdownState' now uses strings for the `value`
field, and converts using the afformentioned functions.