### PR TITLE
fix appflowy version in dockerfile

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -35,4 +35,4 @@ cargo install --force cargo-make && \
 cargo install --force duckscript_cli && \
 cargo make flowy_dev && \
 cargo make -p production-linux-x86 appflowy-linux
-CMD ["appflowy/frontend/app_flowy/product/0.0.2/linux/Release/AppFlowy/app_flowy"]
+CMD ["appflowy/frontend/app_flowy/product/0.0.3/linux/Release/AppFlowy/app_flowy"]


### PR DESCRIPTION
Hi, based on #296, I debugged and found that the path is using the `0.0.2` version while the last tag is `0.0.3`. So this PR aims to fix that. 

Signed-off-by: Lays Rodrigues <laysrodriguessilva@gmail.com>