### PR TITLE
Add some more commit prefixes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 // module.exports = {extends: ['@commitlint/config-conventional']}
 module.exports = {
     rules: {
-        'type-enum': [2, 'always', ['feat', 'refactor', 'style', 'fix', 'ci']],
+        'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'fix', 'refactor', 'style', 'test']],
         'body-leading-blank': [1, 'always'],
         'body-max-line-length': [2, 'always', 100],
         'footer-leading-blank': [1, 'always'],


### PR DESCRIPTION
My previous PR have a commit prefix (`chore: ...`) that doesn't follow `commitlint`, so I add some more (based on https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) and sort the list alphabetically.