### PR TITLE
Kanban/Board View

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/kanban_view/board_page.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/kanban_view/board_page.dart
@@ -1,0 +1,162 @@
+// import 'package:boardview/board_item.dart';
+// import 'package:boardview/board_list.dart';
+// import 'package:boardview/boardview_controller.dart';
+// import 'package:flutter/material.dart';
+
+// import 'package:boardview/boardview.dart';
+
+// class BoardListObject {
+//   final String title;
+//   List<BoardItemObject>? items = [];
+
+//   BoardListObject({this.items, required this.title});
+// }
+
+// class BoardItemObject {
+//   final String title;
+//   final String from;
+
+//   const BoardItemObject({this.title = "", this.from = ""});
+// }
+
+// class BoardPage extends StatefulWidget {
+//   BoardPage({Key? key}) : super(key: key);
+
+//   @override
+//   _BoardPageState createState() => _BoardPageState();
+// }
+
+// class _BoardPageState extends State<BoardPage> {
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         backgroundColor: Color(0xffffffff),
+//         elevation: 0,
+//         title: Row(
+//           children: <Widget>[
+//             Icon(
+//               Icons.view_column,
+//               color: Color(0xff2F334B),
+//             ),
+//             SizedBox(
+//               width: 20,
+//             ),
+//             Text(
+//               'Pedidos',
+//               style: TextStyle(fontWeight: FontWeight.bold, color: Color(0xff2F334B)),
+//             ),
+//           ],
+//         ),
+//         bottom: PreferredSize(
+//             child: Container(
+//               color: Colors.grey[300],
+//               height: 1.0,
+//             ),
+//             preferredSize: Size.fromHeight(1.0)),
+//       ),
+//       body: BoardViewExample(),
+//     );
+//   }
+// }
+
+// class BoardViewExample extends StatelessWidget {
+//   final List<BoardListObject> _listData = [
+//     BoardListObject(title: "Pedidos nuevos", items: [
+//       BoardItemObject(title: '27 Pares de Zapatos Modelo SDF-234d', from: 'Ruben'),
+//       BoardItemObject(title: '7 Pares de Bota Modelo SDF-234d', from: 'Martha')
+//     ]),
+//     BoardListObject(title: "En Proceso"),
+//     BoardListObject(title: "Enviados"),
+//     BoardListObject(title: "Cancelados"),
+//   ];
+
+//   //Can be used to animate to different sections of the BoardView
+//   final BoardViewController boardViewController = BoardViewController();
+
+//   @override
+//   Widget build(BuildContext context) {
+//     List<BoardList> _lists = <BoardList>[];
+
+//     for (int i = 0; i < _listData.length; i++) {
+//       _lists.add(_createBoardList(_listData[i]));
+//     }
+
+//     return Padding(
+//       padding: const EdgeInsets.all(16.0),
+//       child: BoardView(
+//         lists: _lists,
+//         boardViewController: boardViewController,
+//       ),
+//     );
+//   }
+
+//   BoardItem buildBoardItem(BoardItemObject itemObject) {
+//     return BoardItem(
+//         onStartDragItem: (int? listIndex, int? itemIndex, BoardItemState state) {},
+//         onDropItem: (int? listIndex, int? itemIndex, int? oldListIndex, int? oldItemIndex, BoardItemState state) {
+//           //Used to update our local item data
+//           var item = _listData[oldListIndex!].items![oldItemIndex!];
+
+//           _listData[oldListIndex].items!.removeAt(oldItemIndex);
+
+//           _listData[listIndex!].items!.insert(itemIndex!, item);
+//         },
+//         onTapItem: (int? listIndex, int? itemIndex, BoardItemState state) async {},
+//         item: Container(
+//           margin: EdgeInsets.fromLTRB(8, 0, 8, 8),
+//           child: Card(
+//             elevation: 0,
+//             child: Padding(
+//                 padding: const EdgeInsets.all(16.0),
+//                 child: Column(
+//                   crossAxisAlignment: CrossAxisAlignment.start,
+//                   children: <Widget>[
+//                     Text(
+//                       itemObject.from,
+//                       style:
+//                           TextStyle(height: 1.5, color: Color(0xff2F334B), fontSize: 16, fontWeight: FontWeight.bold),
+//                     ),
+//                     SizedBox(
+//                       height: 10.0,
+//                     ),
+//                     Text(
+//                       itemObject.title,
+//                       style: TextStyle(height: 1.5, color: Color(0xff2F334B), fontSize: 16),
+//                     ),
+//                   ],
+//                 )),
+//           ),
+//         ));
+//   }
+
+//   BoardList _createBoardList(BoardListObject list) {
+//     List<BoardItem> items = [];
+//     for (int i = 0; i < list.items!.length; i++) {
+//       items.insert(i, buildBoardItem(list.items![i]));
+//     }
+
+//     return BoardList(
+//       onStartDragList: (int? listIndex) {},
+//       onTapList: (int? listIndex) async {},
+//       onDropList: (int? listIndex, int? oldListIndex) {
+//         //Update our local list data
+//         var list = _listData[oldListIndex!];
+//         _listData.removeAt(oldListIndex);
+//         _listData.insert(listIndex!, list);
+//       },
+//       headerBackgroundColor: Colors.transparent,
+//       backgroundColor: Color(0xffECEDFC),
+//       header: [
+//         Expanded(
+//             child: Container(
+//                 padding: EdgeInsets.all(10),
+//                 child: Text(
+//                   list.title,
+//                   style: TextStyle(fontSize: 23, fontWeight: FontWeight.bold, color: Color(0xff2F334B)),
+//                 ))),
+//       ],
+//       items: items,
+//     );
+//   }
+// }

--- a/frontend/app_flowy/lib/workspace/presentation/kanban_view/kanban_page.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/kanban_view/kanban_page.dart
@@ -1,0 +1,337 @@
+// import 'dart:collection';
+
+// import 'package:flutter/material.dart';
+
+// void main() => runApp(new MyApp());
+
+// class MyApp extends StatelessWidget {
+//   @override
+//   Widget build(BuildContext context) {
+//     return new MaterialApp(
+//       title: 'Kanban test',
+//       theme: new ThemeData(
+//           primaryColor: Color.fromRGBO(58, 66, 86, 1.0), fontFamily: 'Raleway'),
+//       home: new Kanban(),
+//       // home: DetailPage(),
+//     );
+//   }
+// }
+
+// class Item {
+//   final String? id;
+//   final String? listId;
+//   final String? title;
+
+//   Item({this.id, this.listId, this.title});
+// }
+
+// class Kanban extends StatefulWidget {
+//   final double tileHeight = 100;
+//   final double headerHeight = 80;
+//   final double tileWidth = 300;
+
+//   @override
+//   _KanbanState createState() => _KanbanState();
+// }
+
+// class _KanbanState extends State<Kanban> {
+//   late LinkedHashMap<String, List<Item>> board;
+
+//   @override
+//   void initState() {
+//     board = LinkedHashMap();
+//     board.addAll({
+//       "1": [
+//         Item(id: "1", listId: "1", title: "Pear"),
+//         Item(id: "2", listId: "1", title: "Potato"),
+//       ],
+//       "2": [
+//         Item(id: "3", listId: "2", title: "Car"),
+//         Item(id: "4", listId: "2", title: "Bycicle"),
+//         Item(id: "5", listId: "2", title: "On foot"),
+//       ],
+//       "3": [
+//         Item(id: "6", listId: "3", title: "Chile"),
+//         Item(id: "7", listId: "3", title: "Madagascar"),
+//         Item(id: "8", listId: "3", title: "Japan"),
+//       ]
+//     });
+
+//     super.initState();
+//   }
+
+//   buildItemDragTarget(listId, targetPosition, double height) {
+//     return DragTarget<Item>(
+//       // Will accept others, but not himself
+//       onWillAccept: (Item data) {
+//         return board[listId].isEmpty ||
+//             data.id != board[listId][targetPosition].id;
+//       },
+//       // Moves the card into the position
+//       onAccept: (Item data) {
+//         setState(() {
+//           board[data.listId].remove(data);
+//           data.listId = listId;
+//           if (board[listId].length > targetPosition) {
+//             board[listId].insert(targetPosition + 1, data);
+//           } else {
+//             board[listId].add(data);
+//           }
+//         });
+//       },
+//       builder:
+//           (BuildContext context, List<Item> data, List<dynamic> rejectedData) {
+//         if (data.isEmpty) {
+//           // The area that accepts the draggable
+//           return Container(
+//             height: height,
+//           );
+//         } else {
+//           return Column(
+//             // What's shown when hovering on it
+//             children: [
+//               Container(
+//                 height: height,
+//               ),
+//               ...data.map((Item item) {
+//                 return Opacity(
+//                   opacity: 0.5,
+//                   child: ItemWidget(item: item),
+//                 );
+//               }).toList()
+//             ],
+//           );
+//         }
+//       },
+//     );
+//   }
+
+//   buildHeader(String listId) {
+//     Widget header = Container(
+//       height: widget.headerHeight,
+//       child: HeaderWidget(title: listId),
+//     );
+
+//     return Stack(
+//       // The header
+//       children: [
+//         Draggable<String>(
+//           data: listId,
+//           child: header, // A header waiting to be dragged
+//           childWhenDragging: Opacity(
+//             // The header that's left behind
+//             opacity: 0.2,
+//             child: header,
+//           ),
+//           feedback: FloatingWidget(
+//             child: Container(
+//               // A header floating around
+//               width: widget.tileWidth,
+//               child: header,
+//             ),
+//           ),
+//         ),
+//         buildItemDragTarget(listId, 0, widget.headerHeight),
+//         DragTarget<String>(
+//           // Will accept others, but not himself
+//           onWillAccept: (String incomingListId) {
+//             return listId != incomingListId;
+//           },
+//           // Moves the card into the position
+//           onAccept: (String incomingListId) {
+//             setState(
+//               () {
+//                 LinkedHashMap<String, List<Item>> reorderedBoard =
+//                     LinkedHashMap();
+//                 for (String key in board.keys) {
+//                   if (key == incomingListId) {
+//                     reorderedBoard[listId] = board[listId];
+//                   } else if (key == listId) {
+//                     reorderedBoard[incomingListId] = board[incomingListId];
+//                   } else {
+//                     reorderedBoard[key] = board[key];
+//                   }
+//                 }
+//                 board = reorderedBoard;
+//               },
+//             );
+//           },
+
+//           builder: (BuildContext context, List<String> data,
+//               List<dynamic> rejectedData) {
+//             if (data.isEmpty) {
+//               // The area that accepts the draggable
+//               return Container(
+//                 height: widget.headerHeight,
+//                 width: widget.tileWidth,
+//               );
+//             } else {
+//               return Container(
+//                 decoration: BoxDecoration(
+//                   border: Border.all(
+//                     width: 3,
+//                     color: Colors.blueAccent,
+//                   ),
+//                 ),
+//                 height: widget.headerHeight,
+//                 width: widget.tileWidth,
+//               );
+//             }
+//           },
+//         )
+//       ],
+//     );
+//   }
+
+//   @override
+//   Widget build(BuildContext context) {
+//     buildKanbanList(String listId, List<Item> items) {
+//       return SingleChildScrollView(
+//         scrollDirection: Axis.vertical,
+//         child: Column(
+//           children: [
+//             buildHeader(listId),
+//             ListView.builder(
+//               scrollDirection: Axis.vertical,
+//               shrinkWrap: true,
+//               itemCount: items.length,
+//               itemBuilder: (BuildContext context, int index) {
+//                 // A stack that provides:
+//                 // * A draggable object
+//                 // * An area for incoming draggables
+//                 return Stack(
+//                   children: [
+//                     Draggable<Item>(
+//                       data: items[index],
+//                       child: ItemWidget(
+//                         item: items[index],
+//                       ), // A card waiting to be dragged
+//                       childWhenDragging: Opacity(
+//                         // The card that's left behind
+//                         opacity: 0.2,
+//                         child: ItemWidget(item: items[index]),
+//                       ),
+//                       feedback: Container(
+//                         // A card floating around
+//                         height: widget.tileHeight,
+//                         width: widget.tileWidth,
+//                         child: FloatingWidget(
+//                             child: ItemWidget(
+//                           item: items[index],
+//                         )),
+//                       ),
+//                     ),
+//                     buildItemDragTarget(listId, index, widget.tileHeight),
+//                   ],
+//                 );
+//               },
+//             ),
+//           ],
+//         ),
+//       );
+//     }
+
+//     return Scaffold(
+//       backgroundColor: Color.fromRGBO(58, 66, 86, 1.0),
+//       appBar: AppBar(title: Text("Kanban test")),
+//       body: SingleChildScrollView(
+//         scrollDirection: Axis.horizontal,
+//         child: Row(
+//             crossAxisAlignment: CrossAxisAlignment.start,
+//             children: board.keys.map((String key) {
+//               return Container(
+//                 width: widget.tileWidth,
+//                 child: buildKanbanList(key, board[key]),
+//               );
+//             }).toList()),
+//       ),
+//     );
+//   }
+// }
+
+// // The list header (static)
+// class HeaderWidget extends StatelessWidget {
+//   final String title;
+
+//   const HeaderWidget({Key key, this.title}) : super(key: key);
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return Card(
+//       color: Colors.teal,
+//       child: ListTile(
+//         dense: true,
+//         contentPadding: EdgeInsets.symmetric(
+//           horizontal: 20.0,
+//           vertical: 10.0,
+//         ),
+//         title: Text(
+//           title,
+//           style: TextStyle(
+//             color: Colors.white,
+//           ),
+//         ),
+//         trailing: Icon(
+//           Icons.sort,
+//           color: Colors.white,
+//           size: 30.0,
+//         ),
+//         onTap: () {},
+//       ),
+//     );
+//   }
+// }
+
+// // The card (static)
+// class ItemWidget extends StatelessWidget {
+//   final Item item;
+
+//   const ItemWidget({Key key, this.item}) : super(key: key);
+//   ListTile makeListTile(Item item) => ListTile(
+//         contentPadding: EdgeInsets.symmetric(
+//           horizontal: 20.0,
+//           vertical: 10.0,
+//         ),
+//         title: Text(
+//           item.title,
+//           style: TextStyle(
+//             color: Colors.white,
+//           ),
+//         ),
+//         subtitle: Text("listId: ${item.listId}"),
+//         trailing: Icon(
+//           Icons.sort,
+//           color: Colors.white,
+//           size: 30.0,
+//         ),
+//         onTap: () {},
+//       );
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return Card(
+//       elevation: 8.0,
+//       margin: new EdgeInsets.symmetric(horizontal: 10.0, vertical: 6.0),
+//       child: Container(
+//         decoration: BoxDecoration(
+//           color: Color.fromRGBO(64, 75, 96, .9),
+//         ),
+//         child: makeListTile(item),
+//       ),
+//     );
+//   }
+// }
+
+// class FloatingWidget extends StatelessWidget {
+//   final Widget child;
+
+//   const FloatingWidget({Key key, this.child}) : super(key: key);
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return Transform.rotate(
+//       angle: 0.1,
+//       child: child,
+//     );
+//   }
+// }

--- a/frontend/app_flowy/lib/workspace/presentation/kanban_view/kanban_view_page.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/kanban_view/kanban_view_page.dart
@@ -1,0 +1,404 @@
+import 'package:boardview/board_item.dart';
+import 'package:boardview/board_list.dart';
+import 'package:boardview/boardview_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:boardview/boardview.dart' hide OnDropList, OnDropItem;
+
+import './models.dart';
+
+class KanbanPage extends StatelessWidget {
+  const KanbanPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Padding(
+        padding: EdgeInsets.only(top: 32, left: 16, right: 16),
+        child: KanbanView(),
+      ),
+    );
+  }
+}
+
+class KanbanView extends StatefulWidget {
+  const KanbanView({Key? key}) : super(key: key);
+
+  @override
+  _KanbanViewState createState() => _KanbanViewState();
+}
+
+class _KanbanViewState extends State<KanbanView> {
+// class KanbanView extends StatelessWidget {
+  // KanbanView({Key? key}) : super(key: key);
+
+  final List<BoardColumn> _boardColumns = _defaultBoardColumns;
+
+  //Can be used to animate to different sections of the BoardView
+  final _boardViewController = BoardViewController();
+  final _columnController = TextEditingController();
+  final _cardController = TextEditingController();
+
+  @override
+  void dispose() {
+    _columnController.dispose();
+    _cardController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List<BoardList> _lists = [];
+    for (int i = 0; i < _boardColumns.length; i++) {
+      _lists.add(_boardList(context, _boardColumns[i], i));
+    }
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('Kanban', style: Theme.of(context).textTheme.headline6),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  _boardColumns.add(BoardColumn(title: '', newColumn: true));
+                });
+              },
+              child: Text('Add Column'),
+            ),
+          ],
+        ),
+        SizedBox(height: 16),
+        Expanded(
+          child: BoardView(
+            boardViewController: _boardViewController,
+            scrollbar: true,
+            lists: _lists,
+          ),
+        ),
+      ],
+    );
+  }
+
+  BoardList _boardList(BuildContext context, BoardColumn column, int columnIndex) {
+    if (column.newColumn) {
+      return BoardList(
+        margin: const EdgeInsets.only(right: 32),
+        header: Container(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12),
+            child: TextField(
+              onSubmitted: (value) {
+                setState(() {
+                  _boardColumns[columnIndex] = BoardColumn(title: value, newColumn: false);
+                });
+              },
+              controller: _columnController,
+              autofocus: true,
+              scrollPadding: EdgeInsets.zero,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.zero,
+                border: InputBorder.none,
+                isDense: true,
+                hintText: 'Type a name...',
+              ),
+              style: Theme.of(context).textTheme.bodyText1!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              // cursorColor: widget.cursorColor,
+              // obscureText: widget.enableObscure,
+            ),
+          ),
+        ),
+      );
+    }
+
+    List<BoardItem> items = [];
+    for (int i = 0; i < column.cards.length; i++) {
+      items.insert(i, _boardItem(column.cards[i], columnIndex, i));
+    }
+
+    return BoardList(
+      onStartDragList: (int? index) {},
+      onTapList: (int? index) async {},
+      onDropList: (int? index, int? oldIndex) {
+        //Update our local list data
+        var list = _boardColumns[oldIndex!];
+        _boardColumns.removeAt(oldIndex);
+        _boardColumns.insert(index!, list);
+      },
+      margin: const EdgeInsets.only(right: 32),
+      header: Container(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Row(
+          // mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              column.title,
+              style: Theme.of(context).textTheme.bodyText1!.copyWith(
+                    color: column.color,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(width: 8),
+            _CardCount(count: column.cards.length, color: column.color),
+            const Spacer(),
+            IconButton(
+                padding: EdgeInsets.symmetric(horizontal: 4),
+                hoverColor: Colors.transparent,
+                constraints: BoxConstraints(),
+                // splashColor: Colors.transparent,
+                highlightColor: Colors.transparent,
+                onPressed: () {},
+                icon: Icon(Icons.more_horiz_rounded),
+                iconSize: 16),
+            const SizedBox(width: 4),
+            IconButton(
+                padding: EdgeInsets.symmetric(horizontal: 4),
+                hoverColor: Colors.transparent,
+                // splashColor: Colors.transparent,
+                highlightColor: Colors.transparent,
+                constraints: BoxConstraints(),
+                onPressed: () {
+                  setState(() {
+                    _boardColumns[columnIndex].cards.insert(0, BoardCard(title: '', newCard: true));
+                  });
+                },
+                icon: Icon(Icons.add),
+                iconSize: 16),
+          ],
+        ),
+      ),
+      items: items,
+    );
+  }
+
+  BoardItem _boardItem(BoardCard card, int columnIndex, int cardIndex) {
+    if (card.newCard) {
+      // setState(() {
+      //   _boardColumns[columnIndex].cards[cardIndex].copyWith(newCard: false);
+      // });
+
+      return BoardItem(
+        item: Card(
+          margin: EdgeInsets.symmetric(vertical: 4),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 12),
+            child: TextField(
+              onSubmitted: (value) {
+                setState(() {
+                  _boardColumns[columnIndex].cards[cardIndex] = BoardCard(title: value, newCard: false);
+                });
+              },
+              controller: _cardController,
+              autofocus: true,
+              scrollPadding: EdgeInsets.zero,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.zero,
+                border: InputBorder.none,
+                isDense: true,
+                hintText: 'Type a name...',
+              ),
+              style: Theme.of(context).textTheme.bodyText1!.copyWith(
+                    // color: theme.textColor,
+                    // fontSize: 14,
+                    // fontWeight: FontWeight.w500,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              // cursorColor: widget.cursorColor,
+              // obscureText: widget.enableObscure,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return BoardItem(
+      onStartDragItem: (int? listIndex, int? itemIndex, BoardItemState? state) {},
+      onDropItem: (int? listIndex, int? itemIndex, int? oldListIndex, int? oldItemIndex, BoardItemState? state) {
+        //Used to update our local item data
+        // FIXME: Bug when dragging.
+        var item = _boardColumns[oldListIndex!].cards[oldItemIndex!];
+        _boardColumns[oldListIndex].cards.removeAt(oldItemIndex);
+        _boardColumns[listIndex!].cards.insert(itemIndex!, item);
+      },
+      onTapItem: (int? listIndex, int? itemIndex, BoardItemState? state) async {},
+      item: Card(
+        margin: EdgeInsets.symmetric(vertical: 4),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(card.title),
+        ),
+      ),
+    );
+  }
+}
+
+// class _BoardColumn extends StatefulWidget {
+//   const _BoardColumn({
+//     Key? key,
+//     required this.column,
+//     this.onDropList,
+//     this.onDropItem,
+//   }) : super(key: key);
+
+//   final BoardColumn column;
+//   final OnDropList? onDropList;
+//   final OnDropItem? onDropItem;
+
+//   @override
+//   __BoardColumnState createState() => __BoardColumnState();
+// }
+
+// class __BoardColumnState extends State<_BoardColumn> {
+//   bool _isIconsHidden = true;
+
+//   @override
+//   Widget build(BuildContext context) {
+//     // return BoardList _boardList(BuildContext context, BoardColumn column) {
+//     List<BoardItem> items = [];
+//     for (int i = 0; i < widget.column.cards.length; i++) {
+//       items.insert(i, _boardItem(widget.column.cards[i]) as BoardItem);
+//     }
+
+//     return BoardList(
+//       onStartDragList: (int? index) {},
+//       onTapList: (int? index) async {},
+//       onDropList: widget.onDropList,
+//       // onDropList: (int? index, int? oldIndex) {
+//       //   //Update our local list data
+//       //   var list = _boardColumns[oldIndex!];
+//       //   _boardColumns.removeAt(oldIndex);
+//       //   _boardColumns.insert(index!, list);
+//       // },
+//       margin: const EdgeInsets.symmetric(horizontal: 16),
+//       header: MouseRegion(
+//         onEnter: (_) => setState(() => _isIconsHidden = false),
+//         onExit: (_) => setState(() => _isIconsHidden = true),
+//         child: Container(
+//           padding: const EdgeInsets.symmetric(vertical: 16),
+//           child: Row(
+//             // mainAxisAlignment: MainAxisAlignment.spaceBetween,
+//             children: [
+//               Text(
+//                 widget.column.title,
+//                 style: Theme.of(context).textTheme.bodyText1!.copyWith(
+//                       fontWeight: FontWeight.w700,
+//                     ),
+//               ),
+//               const SizedBox(width: 4),
+//               _CardCount(count: widget.column.cards.length, color: Colors.grey),
+//               const Spacer(),
+//               Visibility(
+//                 maintainSize: true,
+//                 maintainAnimation: true,
+//                 maintainState: true,
+//                 visible: _isIconsHidden,
+//                 child: Row(
+//                   children: [
+//                     IconButton(
+//                         padding: EdgeInsets.symmetric(horizontal: 4),
+//                         hoverColor: Colors.transparent,
+//                         constraints: BoxConstraints(),
+//                         // splashColor: Colors.transparent,
+//                         highlightColor: Colors.transparent,
+//                         onPressed: () {},
+//                         icon: Icon(Icons.more_horiz_rounded),
+//                         iconSize: 16),
+//                     const SizedBox(width: 4),
+//                     IconButton(
+//                         padding: EdgeInsets.symmetric(horizontal: 4),
+//                         hoverColor: Colors.transparent,
+//                         // splashColor: Colors.transparent,
+//                         highlightColor: Colors.transparent,
+//                         constraints: BoxConstraints(),
+//                         onPressed: () {},
+//                         icon: Icon(Icons.add),
+//                         iconSize: 16),
+//                   ],
+//                 ),
+//               ),
+//             ],
+//           ),
+//         ),
+//       ),
+//       items: items,
+//     );
+//   }
+
+//   Widget _boardItem(BoardCard card) {
+//     return BoardItem(
+//       onStartDragItem: (int? listIndex, int? itemIndex, BoardItemState? state) {},
+//       onDropItem: widget.onDropItem,
+//       // onDropItem: (int? listIndex, int? itemIndex, int? oldListIndex, int? oldItemIndex,
+//       //     BoardItemState? state) {
+//       //   //Used to update our local item data
+//       //   // FIXME: Bug when dragging.
+//       //   var item = _boardColumns[oldListIndex!].cards[oldItemIndex!];
+//       //   _boardColumns[oldListIndex].cards.removeAt(oldItemIndex);
+//       //   _boardColumns[listIndex!].cards.insert(itemIndex!, item);
+//       // },
+//       onTapItem: (int? listIndex, int? itemIndex, BoardItemState? state) async {},
+//       item: Card(
+//         margin: EdgeInsets.symmetric(vertical: 4),
+//         child: Padding(
+//           padding: const EdgeInsets.all(8.0),
+//           child: Text(card.title),
+//         ),
+//       ),
+//     );
+//   }
+// }
+
+class _CardCount extends StatelessWidget {
+  const _CardCount({Key? key, required this.count, required this.color}) : super(key: key);
+
+  final int count;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(color: color, width: 2),
+      ),
+      child: Text(
+        '$count',
+        style: Theme.of(context).textTheme.bodyText2!.copyWith(
+              fontSize: 12,
+              color: Colors.grey.shade300,
+              fontWeight: FontWeight.w700,
+            ),
+      ),
+    );
+  }
+}
+
+final _defaultBoardColumns = [
+  BoardColumn(title: '✋🏻 Open', colorHex: Colors.blue.value, cards: [
+    BoardCard(title: 'Grid View'),
+    BoardCard(title: 'Board View'),
+    BoardCard(title: 'iOS App'),
+    BoardCard(title: 'Android App'),
+    BoardCard(title: 'Sync'),
+  ]),
+  BoardColumn(title: '🚧  In Progress', colorHex: Colors.yellow.value, cards: [
+    BoardCard(title: 'Emoji Picker'),
+    BoardCard(title: 'Drag and Move Block'),
+  ]),
+  BoardColumn(title: '📛  Blocked', colorHex: Colors.red.value, cards: [
+    BoardCard(title: 'Formatting Toolbar'),
+  ]),
+  BoardColumn(title: '✅  Complete', colorHex: Colors.green.value, cards: [
+    BoardCard(title: 'Dark Mode'),
+  ]),
+  BoardColumn(title: '🚀  Releases', colorHex: Colors.purple.value, cards: [
+    BoardCard(title: 'Windows App'),
+    BoardCard(title: 'Linux App'),
+    BoardCard(title: 'MacOS App'),
+  ]),
+];

--- a/frontend/app_flowy/lib/workspace/presentation/kanban_view/models.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/kanban_view/models.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'models.freezed.dart';
+part 'models.g.dart';
+
+@freezed
+class BoardColumn with _$BoardColumn {
+  const BoardColumn._();
+  const factory BoardColumn({
+    required String title,
+    @Default(0xFFffffff) int colorHex,
+    @Default([]) List<BoardCard> cards,
+    @Default(false) bool newColumn,
+  }) = _BoardColumn;
+
+  factory BoardColumn.fromJson(Map<String, dynamic> json) => _$BoardColumnFromJson(json);
+
+  Color get color => Color(colorHex);
+}
+
+@freezed
+class BoardCard with _$BoardCard {
+  const factory BoardCard({
+    required String title,
+    @Default(false) bool newCard,
+  }) = _BoardCard;
+
+  factory BoardCard.fromJson(Map<String, dynamic> json) => _$BoardCardFromJson(json);
+}

--- a/frontend/app_flowy/pubspec.lock
+++ b/frontend/app_flowy/pubspec.lock
@@ -43,6 +43,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.2"
+  boardview:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: master
+      resolved-ref: fcf5e67e6f23da4cc4c22430aa685b6552a82cd9
+      url: "git://github.com/hieugao/boardview.git"
+    source: git
+    version: "0.2.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -688,13 +697,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -1084,7 +1086,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.3"
   textstyle_extensions:
     dependency: transitive
     description:
@@ -1218,6 +1220,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.6"
+  vs_scrollbar:
+    dependency: transitive
+    description:
+      name: vs_scrollbar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   watcher:
     dependency: transitive
     description:

--- a/frontend/app_flowy/pubspec.yaml
+++ b/frontend/app_flowy/pubspec.yaml
@@ -45,6 +45,10 @@ dependencies:
       ref: dbc309f5e382963fa0122409a0aaf8e1417d51c1
 
   #  third party packages
+  boardview:
+    git:
+      url: git://github.com/hieugao/boardview.git
+      ref: master
   intl: ^0.17.0
   time: "^2.0.0"
   equatable: "^2.0.3"
@@ -95,7 +99,7 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
   # Automatic code generation for l10n and i18n
-  generate: true
+  generate: false
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in


### PR DESCRIPTION
I implemented some of the basic (front-end only) for Board View, it's very primitive at this point and also I have zero knowledge about the back-end. So if anyone is interested please help me to finish the feature.

### Current state

https://user-images.githubusercontent.com/13729196/153836842-e5a08131-48b0-4d31-8b2e-762f606ba202.mp4

### Tasks
- [x] Moving (reordering) Column and Card - _the heaviest work is already done thanks to [`boardview`](https://pub.dev/packages/boardview)_
- [x] Add new Column and Card
- [ ] Edit Column and Card
- [ ] Delete Column and Card
- [ ] Add more Card's properties beside `title` like `tags`, `image`, etc
- [ ] Scrolling using mouse
- [ ] Focus on new Column when it is out of sight - _maybe [this](https://pub.dev/packages/ensure_visible_when_focused) could help_
- [ ] Polish the UI to match [the design](https://images.squarespace-cdn.com/content/v1/617f6f16b877c06711e87373/1636772749116-RB01WX0STUQOATFOS3QT/project-management-task) (including enhancement if the design has some flaws) - _I'm currently focusing on the logic (function) side first_

Backend:

- [ ] Glue the front-end code with the back-end

### Contributing
- __Issue or Discussion__ - you could open it side this PR
- __PR__ - I think you should open it to:
  - https://github.com/hieugao/appflowy/tree/feat/kanban-view
  - https://github.com/hieugao/boardview

### Big Thanks To
_(I don't know if tagging them is appropriate so I removed @ sign)_

- jakebonk - for [`boardview`](https://github.com/jakebonk/FlutterBoardView)
- invoiceninja - for the [reference](https://github.com/invoiceninja/admin-portal/search?q=kanban)