### PR TITLE
Reduce docker image size by using docker multi-stage build

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/archlinux:base-devel
+FROM archlinux/archlinux:base-devel as builder
 
 RUN pacman -Syy
 
@@ -36,4 +36,25 @@ cargo install --force cargo-make && \
 cargo install --force duckscript_cli && \
 cargo make flowy_dev && \
 cargo make -p production-linux-x86 appflowy-linux
-CMD ["appflowy/frontend/app_flowy/product/0.0.3/linux/Release/AppFlowy/app_flowy"]
+
+CMD ["/home/makepkg/appflowy/frontend/app_flowy/build/linux/x64/release/bundle/app_flowy"]
+
+#################
+FROM archlinux/archlinux:base-devel
+
+RUN pacman -Syy
+RUN pacman -Syu --needed --noconfirm xdg-user-dirs
+RUN xdg-user-dirs-update
+
+ARG user=makepkg
+RUN useradd --system --create-home $user \
+  && echo "$user ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/$user
+USER $user
+WORKDIR /home/$user
+
+COPY --from=builder /usr/sbin/yay /usr/sbin/yay
+RUN yay -S --noconfirm gtk3
+
+COPY --from=builder /home/makepkg/appflowy/frontend/app_flowy/build/linux/x64/release/bundle ./AppFlowy
+
+CMD ["/home/makepkg/AppFlowy/app_flowy"]

--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   app:
     build: .
+    image: appflowy/appflowy:latest
     stdin_open: true
     # tty: true
     environment:


### PR DESCRIPTION
Previous image was 7.69GB which is somewhat heavy. Now the resulting image is 1.20GB thanks to multi-stage builds.
