### PR TITLE
Fix docker build

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -1,12 +1,12 @@
 FROM archlinux/archlinux:base-devel
 
-RUN pacman -Syy 
+RUN pacman -Syy
 
 RUN pacman -Syu --needed --noconfirm git xdg-user-dirs
 
 # makepkg user and workdir
 ARG user=makepkg
-ENV PATH="/home/makepkg/.local/flutter/bin:/home/makepkg/.local/flutter/bin/cache/dart-sdk/bin:${PATH}"
+ENV PATH="/home/makepkg/.pub-cache/bin:/home/makepkg/.local/flutter/bin:/home/makepkg/.local/flutter/bin/cache/dart-sdk/bin:${PATH}"
 RUN useradd --system --create-home $user \
   && echo "$user ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/$user
 USER $user
@@ -17,7 +17,7 @@ RUN git clone https://aur.archlinux.org/yay.git \
   && cd yay \
   && makepkg -sri --needed --noconfirm \
   && cd \
-  && rm -rf .cache yay 
+  && rm -rf .cache yay
 
 RUN yay -S --noconfirm curl base-devel sqlite openssl clang cmake ninja pkg-config gtk3 unzip
 RUN xdg-user-dirs-update
@@ -25,8 +25,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN source $HOME/.cargo/env && rustup toolchain install stable && rustup default stable
 RUN git clone https://github.com/flutter/flutter.git $HOME/.local/flutter
 RUN flutter channel stable
-RUN flutter config --enable-linux-desktop 
-RUN flutter doctor 
+RUN flutter config --enable-linux-desktop
+RUN flutter doctor
+RUN dart pub global activate protoc_plugin
 
 RUN git clone https://github.com/AppFlowy-IO/appflowy.git && \
 cd appflowy/frontend && \

--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -3,10 +3,13 @@ version: "3"
 services:
   app:
     build: .
-    stdin_open: true 
+    stdin_open: true
     # tty: true
     environment:
       - DISPLAY=${DISPLAY}
     volumes:
       - $HOME/.Xauthority:/root/.Xauthority:rw
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - /dev/dri:/dev/dri
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     network_mode: host

--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -12,4 +12,8 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /dev/dri:/dev/dri
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+      - appflowy-data:/home/makepkg
     network_mode: host
+
+volumes:
+  appflowy-data:


### PR DESCRIPTION
Fix error:

```
❌ The protoc-gen-dart was not installed correctly.
✅ You can fix that by adding "dart pub global activate protoc_plugin" to your shell's config file.(.bashrc, .bash, etc.)
```

Also mount other required volumes in docker-compose