### PR TITLE
feat: use pre-commit for development convenience

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+default_stages: [commit]
+fail_fast: true
+
+repos:
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v8.0.0
+    hooks:
+        - id: commitlint
+          stages: [commit-msg]


### PR DESCRIPTION
pre-commit is a great tool for development which can run some prepared hooks during `git commit`. This change allows pre-commit usage to check commit messages format using commitlint.

Instructions to enable:

```
pip install pre-commit --user
pre-commit install
pre-commit install --hook-type commit-msg
```

Documentation PR: https://github.com/AppFlowy-IO/docs/pull/6