### PR TITLE
Adjust commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,20 +1,24 @@
 // module.exports = {extends: ['@commitlint/config-conventional']}
 module.exports = {
     rules: {
-        'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'fix', 'refactor', 'style', 'test']],
-        'body-leading-blank': [1, 'always'],
-        'body-max-line-length': [2, 'always', 100],
-        'footer-leading-blank': [1, 'always'],
-        'footer-max-line-length': [2, 'always', 100],
         'header-max-length': [2, 'always', 100],
+
+        'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'fix', 'refactor', 'style', 'test']],
+        'type-empty': [2, 'never'],
+        'type-case': [2, 'always', 'lower-case'],
+
         'subject-case': [
             2,
             'never',
             ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
         ],
         'subject-empty': [2, 'never'],
-        'type-empty': [2, 'never'],
-        'type-case': [2, 'always', 'lower-case'],
-        'body-case': [2, 'never', []]
+
+        'body-leading-blank': [1, 'always'],
+        'body-max-line-length': [2, 'always', 100],
+        'body-case': [2, 'never', []],
+
+        'footer-leading-blank': [1, 'always'],
+        'footer-max-line-length': [2, 'always', 100]
     },
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,20 +3,20 @@ module.exports = {
     rules: {
         'header-max-length': [2, 'always', 100],
 
-        'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'fix', 'refactor', 'style', 'test']],
+        'type-enum': [2, 'always', ['build', 'chore', 'ci', 'docs', 'feat', 'feature', 'fix', 'refactor', 'style', 'test']],
         'type-empty': [2, 'never'],
         'type-case': [2, 'always', 'lower-case'],
 
+        'subject-empty': [2, 'never'],
         'subject-case': [
-            2,
+            0,
             'never',
             ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
         ],
-        'subject-empty': [2, 'never'],
 
-        'body-leading-blank': [1, 'always'],
-        'body-max-line-length': [2, 'always', 100],
-        'body-case': [2, 'never', []],
+        'body-leading-blank': [2, 'always'],
+        'body-max-line-length': [2, 'always', 200],
+        'body-case': [0, 'never', []],
 
         'footer-leading-blank': [1, 'always'],
         'footer-max-line-length': [2, 'always', 100]


### PR DESCRIPTION
Added types: build, feature
no longer checks subject's case
now forces a leading blank before body (This is required by Github)
Increased body length to 200