### PR TITLE
Fix various typos

### DIFF
--- a/frontend/app_flowy/lib/workspace/domain/page_stack/page_stack.dart
+++ b/frontend/app_flowy/lib/workspace/domain/page_stack/page_stack.dart
@@ -70,7 +70,7 @@ class HomeStackNotifier extends ChangeNotifier {
   HomeStackContext get context => stackContext;
 }
 
-// HomeStack is initialized as singleton to controll the page stack.
+// HomeStack is initialized as singleton to control the page stack.
 class HomeStackManager {
   final HomeStackNotifier _notifier = HomeStackNotifier();
   HomeStackManager();

--- a/frontend/app_flowy/lib/workspace/infrastructure/markdown/src/delta_markdown_decoder.dart
+++ b/frontend/app_flowy/lib/workspace/infrastructure/markdown/src/delta_markdown_decoder.dart
@@ -114,7 +114,7 @@ class _DeltaVisitor implements ast.NodeVisitor {
         // TODO(kolja): Determine which behavior we really want here.
         // We can either insert an additional newline or just have the
         // paragraphs as single lines. Zefyr will by default render two lines
-        // are different paragraphs so for now we will not add an additonal
+        // are different paragraphs so for now we will not add an additional
         // newline here.
         //
         // if (previousToplevelElement != null &&

--- a/frontend/app_flowy/lib/workspace/infrastructure/markdown/src/inline_parser.dart
+++ b/frontend/app_flowy/lib/workspace/infrastructure/markdown/src/inline_parser.dart
@@ -154,7 +154,7 @@ abstract class InlineSyntax {
 
   /// Tries to match at the parser's current position.
   ///
-  /// The parser's position can be overriden with [startMatchPos].
+  /// The parser's position can be overridden with [startMatchPos].
   /// Returns whether or not the pattern successfully matched.
   bool tryMatch(InlineParser parser, [int? startMatchPos]) {
     startMatchPos ??= parser.pos;
@@ -609,7 +609,7 @@ class LinkSyntax extends TagSyntax {
   //
   // Once we have parsed `Text [`, there is one (pending) link in the state
   // stack.  It is, by default, active. Once we parse the next possible link,
-  // `[more](links)`, as a real link, we must deactive the pending links (just
+  // `[more](links)`, as a real link, we must deactivate the pending links (just
   // the one, in this case).
   var _pendingStatesAreActive = true;
 
@@ -933,7 +933,7 @@ class LinkSyntax extends TagSyntax {
             // followed by mystery characters; no longer a link.
             return null;
           }
-          // [_parseTitle] made sure the title was follwed by a closing `)`
+          // [_parseTitle] made sure the title was followed by a closing `)`
           // (but it's up to the code here to examine the balance of
           // parentheses).
           parenCount--;

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/config.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/config.dart
@@ -35,7 +35,7 @@ class Config {
   /// Can be smaller due to screen size and amount of columns
   final double emojiSizeMax;
 
-  /// Verical spacing between emojis
+  /// Vertical spacing between emojis
   final double verticalSpacing;
 
   /// Horizontal spacing between emojis
@@ -57,7 +57,7 @@ class Config {
   /// The color of the category icon when selected
   final Color iconColorSelected;
 
-  /// The color of the loading indicator during initalization
+  /// The color of the loading indicator during initialization
   final Color progressIndicatorColor;
 
   /// The color of the backspace icon button

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_picker.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_picker.dart
@@ -40,7 +40,7 @@ enum Category {
   /// Travel emojis
   TRAVEL,
 
-  /// Ojects emojis
+  /// Objects emojis
   OBJECTS,
 
   /// Sumbol emojis
@@ -179,7 +179,7 @@ class _EmojiPickerState extends State<EmojiPicker> {
     };
   }
 
-  // Initalize emoji data
+  // Initialize emoji data
   Future<void> _updateEmojis() async {
     categoryEmoji.clear();
     if (widget.config.showRecentsTab) {

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_picker_builder.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_picker_builder.dart
@@ -4,7 +4,7 @@ import 'config.dart';
 import 'emoji_view_state.dart';
 
 /// Template class for custom implementation
-/// Inhert this class to create your own EmojiPicker
+/// Inherit this class to create your own EmojiPicker
 abstract class EmojiPickerBuilder extends StatefulWidget {
   /// Constructor
   const EmojiPickerBuilder(this.config, this.state, {Key? key}) : super(key: key);

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/menu/menu.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/menu/menu.dart
@@ -90,7 +90,7 @@ class HomeMenu extends StatelessWidget {
   }
 
   Widget _renderBody(BuildContext context) {
-    // nested cloumn: https://siddharthmolleti.com/flutter-box-constraints-nested-column-s-row-s-3dfacada7361
+    // nested column: https://siddharthmolleti.com/flutter-box-constraints-nested-column-s-row-s-3dfacada7361
     final theme = context.watch<AppTheme>();
     return Container(
       color: theme.bg1,

--- a/frontend/app_flowy/packages/flowy_infra_ui/flowy_infra_ui_platform_interface/lib/flowy_infra_ui_platform_interface.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/flowy_infra_ui_platform_interface/lib/flowy_infra_ui_platform_interface.dart
@@ -18,10 +18,10 @@ abstract class FlowyInfraUIPlatform extends PlatformInterface {
   }
 
   Stream<bool> get onKeyboardVisibilityChange {
-    throw UnimplementedError('`onKeyboardChange` should be overrided by subclass.');
+    throw UnimplementedError('`onKeyboardChange` should be overridden by subclass.');
   }
 
   Future<String?> getPlatformVersion() {
-    throw UnimplementedError('`getPlatformVersion` should be overrided by subclass.');
+    throw UnimplementedError('`getPlatformVersion` should be overridden by subclass.');
   }
 }

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/src/flowy_overlay/flowy_overlay.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/src/flowy_overlay/flowy_overlay.dart
@@ -37,7 +37,7 @@ enum OverlapBehaviour {
   /// Maintain overlay size, which may cover the anchor widget.
   none,
 
-  /// Resize overlay to avoid overlaping the anchor widget.
+  /// Resize overlay to avoid overlapping the anchor widget.
   stretch,
 }
 

--- a/frontend/app_flowy/web/index.html
+++ b/frontend/app_flowy/web/index.html
@@ -82,7 +82,7 @@
           });
 
         // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
+        // fallback to plain <script> tag.
         setTimeout(() => {
           if (!scriptLoaded) {
             console.warn(


### PR DESCRIPTION
Found via `codespell -q 3 -S *.svg,./frontend/app_flowy/assets/translations -L bloc,crate,homestate,nd,ot,ser`