### PR TITLE
chore: use actions-cache to speed up dart & rust test.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - id: rust_toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
       
       - id: flutter
         uses: subosito/flutter-action@v2
@@ -47,7 +47,8 @@ jobs:
         with: 
           path: |
             frontend/rust-lib/target
-          key: ${{ runner.os }}-rust-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
+            shared-lib/target
+          key: ${{ runner.os }}-rust-rust-lib-share-lib-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
 
       - name: Setup Environment
         run:   |

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -2,9 +2,12 @@ name: Unit test(Flutter)
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - 'main'
+      
   pull_request:
-    branches: [ main ]
+    branches:
+      - 'main'
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,36 +16,56 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: "stable"
+      - uses: actions/checkout@v2
+      
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
+      
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with: 
+          path: |
+            ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}
+
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with: 
+          path: |
+            frontend/rust-lib/target
+            shared-lib/target
+          key: ${{ runner.os }}-rust-rust-lib-share-lib-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
+
       - name: Deps Flutter
+        working-directory: frontend/app_flowy
         run: |
           flutter config --enable-linux-desktop
-          flutter doctor
-        working-directory: frontend/app_flowy
+        
       - name: Deps Rust
         working-directory: frontend
         run: |
-          cargo install --force cargo-make
-          cargo install --force duckscript_cli
+          cargo install cargo-make
+          cargo install duckscript_cli
           cargo make flowy_dev
-          echo PATH="$PATH":"$HOME/.pub-cache/bin" >> $GITHUB_PATH
+      
       - name: Code Generation
         working-directory: frontend/app_flowy
         run: |
           flutter packages pub get
           flutter packages pub run easy_localization:generate -S ./assets/translations -f keys -O lib/generated -o locale_keys.g.dart
           flutter packages pub run build_runner build --delete-conflicting-outputs
+      
       - name: Build FlowySDK
         working-directory: frontend
         run: |
           cargo make --profile development-linux-x86 flowy-sdk-dev
+      
       - name: Run bloc tests
         working-directory: frontend/app_flowy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup environment - Rust and Cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
 
       - name: Setup environment - Flutter
         uses: subosito/flutter-action@v2
@@ -92,7 +92,7 @@ jobs:
       - name: Setup environment - Rust and Cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
 
       - name: Setup environment - Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
           override: true
       - run: rustup component add rustfmt
         working-directory: frontend/rust-lib
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 'stable-2022-01-20'
           override: true
       - run: rustup component add clippy
         working-directory: frontend/rust-lib

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -2,12 +2,14 @@ name: Unit test(Rust)
 
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - 'main'
     paths:
       - 'frontend/rust-lib'
       - 'shared-lib'
   pull_request:
-    branches: [ main ]
+    branches: 
+      - 'main'
     paths:
       - 'frontend/rust-lib'
       - 'shared-lib'
@@ -21,19 +23,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Rust
-        run: |
-          curl \
-            --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup toolchain install stable
-          rustup default stable
+      
+      - id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 'stable-2022-01-20'
+
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with: 
+          path: |
+            ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}
+
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with: 
+          path: |
+            frontend/rust-lib/target
+            shared-lib/target
+          key: ${{ runner.os }}-rust-rust-lib-share-lib-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
+
       - name: Install cargo-make
-        run: cargo install --force cargo-make
         working-directory: frontend
+        run: cargo install cargo-make
+        
       - name: Run rust-lib tests
-        run: cargo test --no-default-features
         working-directory: frontend/rust-lib
-      - name: Run shared-lib tests
         run: cargo test --no-default-features
+        
+      - name: Run shared-lib tests
         working-directory: shared-lib
+        run: cargo test --no-default-features


### PR DESCRIPTION
1. Speed up dart and rust test workflows. And update the rust cache key.
2. Specify the rust version at all workflows.