### PR TITLE
Fix various small issues

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/home/menu/app/header/add_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/home/menu/app/header/add_button.dart
@@ -28,7 +28,7 @@ class AddButton extends StatelessWidget {
           onSelected: onSelected,
         ).show(context);
       },
-      icon: svgWidget("home/add").padding(horizontal: 3, vertical: 3),
+      icon: svgWidget("home/add", color: theme.iconColor).padding(horizontal: 3, vertical: 3),
     );
   }
 }

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/toolbar_icon_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/toolbar_icon_button.dart
@@ -29,9 +29,9 @@ class ToolbarIconButton extends StatelessWidget {
       iconPadding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
       onPressed: onPressed,
       width: width,
-      icon: isToggled == true ? svgWidget(iconName, color: Colors.white) : svgWidget(iconName),
+      icon: isToggled == true ? svgWidget(iconName, color: Colors.white) : svgWidget(iconName, color: theme.iconColor),
       fillColor: isToggled == true ? theme.main1 : theme.shader6,
-      hoverColor: isToggled == true ? theme.main1 : theme.shader5,
+      hoverColor: isToggled == true ? theme.main1 : theme.hover,
       tooltipText: tooltipText,
     );
   }

--- a/frontend/app_flowy/packages/flowy_infra/lib/text_style.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/text_style.dart
@@ -71,7 +71,7 @@ class TextStyles {
   static TextStyle get CalloutFocus => Callout.bold;
 
   // ignore: non_constant_identifier_names
-  static TextStyle get Btn => quicksand.bold.size(FontSizes.s14).letterSpace(1.75);
+  static TextStyle get Btn => quicksand.bold.size(FontSizes.s16).letterSpace(1.75);
 
   // ignore: non_constant_identifier_names
   static TextStyle get BtnSelected => quicksand.size(FontSizes.s14).letterSpace(1.75);

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/buttons/primary_button.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/buttons/primary_button.dart
@@ -15,7 +15,7 @@ class PrimaryTextButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle txtStyle = TextStyles.Footnote.textColor(Colors.white);
+    TextStyle txtStyle = TextStyles.Btn.textColor(Colors.white);
     return PrimaryButton(bigMode: bigMode, onPressed: onPressed, child: Text(label, style: txtStyle));
   }
 }

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/buttons/secondary_button.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/buttons/secondary_button.dart
@@ -17,7 +17,7 @@ class SecondaryTextButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = context.watch<AppTheme>();
-    TextStyle txtStyle = TextStyles.Footnote.textColor(theme.main1);
+    TextStyle txtStyle = TextStyles.Btn.textColor(theme.main1);
     return SecondaryButton(bigMode: bigMode, onPressed: onPressed, child: Text(label, style: txtStyle));
   }
 }


### PR DESCRIPTION
This quick PR just fixes a few issues that I noticed when I built and ran AppFlowy on my computer. These include:
 - Setting the color of the add page icon to the theme `iconColor`, which changes with light mode/dark mode.
 - Setting the color of the toolbar buttons in the workspace to the theme `iconColor`, which changes with light mode/dark mode.
 - Changing the background of the toolbar buttons in the workspace to the theme `hover`, which changes with light mode/dark mode.
 - Setting the font style of the primary and secondary button text to the `Btn` text style.
 - Changing the size of the `Btn` text style to `s16` from `s14`, as the text seemed a little small compared with the button size.