### PR TITLE
feat: native support for m1 mac

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           - os: ubuntu-latest
             flutter_profile: development-linux-x86
           - os: macos-latest
-            flutter_profile: development-mac
+            flutter_profile: development-mac-x86_64
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-macos-desktop
-          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-mac-x86 appflowy
+          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-mac-x86_64 appflowy
 
       - name: Archive macOS app
         working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}

--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -45,7 +45,15 @@ APP_ENVIRONMENT = "local"
 FLUTTER_FLOWY_SDK_PATH="app_flowy/packages/flowy_sdk"
 PROTOBUF_DERIVE_CACHE="../shared-lib/flowy-derive/src/derive_cache/derive_cache.rs"
 
-[env.development-mac]
+[env.development-mac-arm64]
+RUST_LOG = "info"
+TARGET_OS = "macos"
+RUST_COMPILE_TARGET = "aarch64-apple-darwin"
+BUILD_FLAG = "debug"
+FLUTTER_OUTPUT_DIR = "Debug"
+PRODUCT_EXT = "app"
+
+[env.development-mac-x86_64]
 RUST_LOG = "info"
 TARGET_OS = "macos"
 RUST_COMPILE_TARGET = "x86_64-apple-darwin"
@@ -53,7 +61,7 @@ BUILD_FLAG = "debug"
 FLUTTER_OUTPUT_DIR = "Debug"
 PRODUCT_EXT = "app"
 
-[env.production-mac-aarch64]
+[env.production-mac-arm64]
 BUILD_FLAG = "release"
 TARGET_OS = "macos"
 RUST_COMPILE_TARGET = "aarch64-apple-darwin"
@@ -61,7 +69,7 @@ FLUTTER_OUTPUT_DIR = "Release"
 PRODUCT_EXT = "app"
 APP_ENVIRONMENT = "production"
 
-[env.production-mac-x86]
+[env.production-mac-x86_64]
 BUILD_FLAG = "release"
 TARGET_OS = "macos"
 RUST_COMPILE_TARGET = "x86_64-apple-darwin"

--- a/frontend/app_flowy/macos/Runner.xcodeproj/project.pbxproj
+++ b/frontend/app_flowy/macos/Runner.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -553,7 +553,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -577,7 +577,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/frontend/scripts/build_sdk.sh
+++ b/frontend/scripts/build_sdk.sh
@@ -25,7 +25,7 @@ Linux-x86)
  ;;
 
 macOS)
- cargo make --profile development-mac flowy-sdk-dev
+ cargo make --profile "development-mac-$(uname -m)" flowy-sdk-dev
  ;;
 
 Windows) 


### PR DESCRIPTION
This PR is changing the build script for the people who use the M1 mac to build the native arm64 app on their MacBook.

**Notice:**

If you have built the x86 version of AppFlowy on your M1 mac, please follow these steps to clean your environment:

- Uninstall the CocoaPods installed by gem:

```
sudo gem uninstall cocoapods
```

- Install the CocoaPods with HomeBrew:

```
brew install cocoapods
```

- Run `flutter clean` in `AppFlowy/frontend/app_flowy`
- Rebuild the AppFlowy with the [official doc](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/environment-setup/building-on-macos)