### PR TITLE
fix: Fix the launch configuration and tasks

### DIFF
--- a/frontend/.vscode/launch.json
+++ b/frontend/.vscode/launch.json
@@ -11,8 +11,8 @@
             "program": "./lib/main.dart",
             "type": "dart",
             "preLaunchTask": "AF: build_flowy_sdk",
-            "env":{
-                "RUST_LOG":"info"
+            "env": {
+                "RUST_LOG": "info"
             },
             "cwd": "${workspaceRoot}/app_flowy"
         },
@@ -20,12 +20,12 @@
             //  This task only builds the Dart code of AppFlowy.
             "name": "AF: Build Dart Only",
             "request": "launch",
-            "program": "${workspaceRoot}/lib/main.dart",
+            "program": "./lib/main.dart",
             "type": "dart",
             "env": {
                 "RUST_LOG": "debug"
             },
-            "cwd": "${workspaceRoot}"
+            "cwd": "${workspaceRoot}/app_flowy"
         },
         {
             // This task builds will:
@@ -37,20 +37,19 @@
             "program": "./lib/main.dart",
             "type": "dart",
             "preLaunchTask": "AF: Clean + Rebuild All",
-            "env":{
-                "RUST_LOG":"info"
+            "env": {
+                "RUST_LOG": "info"
             },
             "cwd": "${workspaceRoot}/app_flowy"
         },
-
         {
             "name": "AF: Build All (rustlog: trace)",
             "request": "launch",
             "program": "./lib/main.dart",
             "type": "dart",
             "preLaunchTask": "AF: build_flowy_sdk",
-            "env":{
-                "RUST_LOG":"trace"
+            "env": {
+                "RUST_LOG": "trace"
             },
             "cwd": "${workspaceRoot}/app_flowy"
         },

--- a/frontend/.vscode/tasks.json
+++ b/frontend/.vscode/tasks.json
@@ -15,21 +15,16 @@
 			"dependsOrder": "sequence",
 			"dependsOn": [
 				"AF: Clean",
-				"AF: Flutter Pub",
+				"AF: Flutter Pub Get",
 				"AF: Flutter Package Get",
 				"AF: Generate Language Files",
 				"AF: Generate Freezed Files",
 				"AF: build_flowy_sdk"
 			],
-			"group": {
-				"kind": "build",
-				"isDefault": true,
-			},
 			"presentation": {
 				"reveal": "always",
 				"panel": "new"
 			}
-
 		},
 		{
 			"label": "AF: build_flowy_sdk",
@@ -74,14 +69,14 @@
 			"type": "shell",
 			"dependsOrder": "sequence",
 			"dependsOn": [
-				"AF: Flutter Pub",
+				"AF: Flutter Pub Get",
 				"AF: Flutter Package Get",
 				"AF: Generate Language Files",
 				"AF: Generate Freezed Files"
 			],
 			"group": {
 				"kind": "build",
-				"isDefault": true,
+				"isDefault": true
 			},
 			"presentation": {
 				"reveal": "always",
@@ -89,7 +84,7 @@
 			}
 		},
 		{
-			"label": "AF: Flutter Pub",
+			"label": "AF: Flutter Pub Get",
 			"type": "shell",
 			"command": "flutter pub get",
 			"options": {


### PR DESCRIPTION
Fixed the "AF: Build Dart Only" launch configuration.

Renamed the "Flutter Pub" task to "Flutter Pub Get" so it's clearer

Fixed the default build task