### PR TITLE
fix: fail to execute profile task in VSCode

### DIFF
--- a/frontend/.vscode/launch.json
+++ b/frontend/.vscode/launch.json
@@ -62,8 +62,10 @@
         {
             "name": "AF: app_flowy (profile mode)",
             "request": "launch",
+            "program": "./lib/main.dart",
             "type": "dart",
-            "flutterMode": "profile"
+            "flutterMode": "profile",
+            "cwd": "${workspaceRoot}/app_flowy"
         },
     ]
 }

--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -52,6 +52,7 @@ RUST_COMPILE_TARGET = "aarch64-apple-darwin"
 BUILD_FLAG = "debug"
 FLUTTER_OUTPUT_DIR = "Debug"
 PRODUCT_EXT = "app"
+BUILD_ARCHS = "arm64"
 
 [env.development-mac-x86_64]
 RUST_LOG = "info"
@@ -60,6 +61,7 @@ RUST_COMPILE_TARGET = "x86_64-apple-darwin"
 BUILD_FLAG = "debug"
 FLUTTER_OUTPUT_DIR = "Debug"
 PRODUCT_EXT = "app"
+BUILD_ARCHS = "x86_64"
 
 [env.production-mac-arm64]
 BUILD_FLAG = "release"

--- a/frontend/app_flowy/macos/Runner.xcodeproj/project.pbxproj
+++ b/frontend/app_flowy/macos/Runner.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.appflowy.macos;
 				PRODUCT_NAME = AppFlowy;
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
1. fix the error when building the `app_flowy(profile)` task.
2. build the active arch only when building the `Profile scheme`.