### PR TITLE
fix : fix linux build on x86_64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            flutter_profile: development-linux-x86
+            flutter_profile: development-linux-x86_64
           - os: macos-latest
             flutter_profile: development-mac-x86_64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dart_lint.yml
+++ b/.github/workflows/dart_lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build FlowySDK
         working-directory: frontend
         run: |
-          cargo make --profile development-linux-x86 flowy-sdk-dev
+          cargo make --profile development-linux-x86_64 flowy-sdk-dev
 
       - name: Code Generation
         working-directory: frontend/app_flowy

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build FlowySDK
         working-directory: frontend
         run: |
-          cargo make --profile development-linux-x86 flowy-sdk-dev
+          cargo make --profile development-linux-x86_64 flowy-sdk-dev
 
       - name: Code Generation
         working-directory: frontend/app_flowy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-linux-desktop
-          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-linux-x86 appflowy
+          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-linux-x86_64 appflowy
 
       - name: Upload Release Asset
         id: upload-release-asset

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build FlowySDK
         working-directory: frontend
         run: |
-          cargo make --profile development-linux-x86 flowy-sdk-dev
+          cargo make --profile development-linux-x86_64 flowy-sdk-dev
 
       - run: rustup component add rustfmt
         working-directory: frontend/rust-lib

--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -100,7 +100,7 @@ CRATE_TYPE = "cdylib"
 SDK_EXT = "dll"
 APP_ENVIRONMENT = "production"
 
-[env.development-linux-x86]
+[env.development-linux-x86_64]
 TARGET_OS = "linux"
 RUST_COMPILE_TARGET = "x86_64-unknown-linux-gnu"
 BUILD_FLAG = "debug"
@@ -109,7 +109,7 @@ FLUTTER_OUTPUT_DIR = "Debug"
 SDK_EXT = "so"
 LINUX_ARCH = "x64"
 
-[env.production-linux-x86]
+[env.production-linux-x86_64]
 BUILD_FLAG = "release"
 TARGET_OS = "linux"
 RUST_COMPILE_TARGET = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
fix: Fix Linux build on x86_64.  The build script currently uses 'uname -m' which on most Linux systems returns 'x86_64'.