### PR TITLE
Fix githooks and remove Husky

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# An example hook script to check the commit log message.
+# Called by "git commit" with one argument, the name of the file
+# that has the commit message.  The hook should exit with non-zero
+# status after issuing an appropriate message if it wants to stop the
+# commit.  The hook is allowed to edit the commit message file.
+
+echo "Running the AppFlowy commit-msg hook."
+
+# This example catches duplicate Signed-off-by lines.
+
+test "" = "$(grep '^Signed-off-by: ' "$1" |
+	 sort | uniq -c | sed -e '/^[ 	]*1[ 	]/d')" || {
+	echo >&2 Duplicate Signed-off-by lines.
+	exit 1
+}
+
+npx --no -- commitlint --edit $1
+
+if [ $? -ne 0 ]
+then
+    echo "Please fix your commit message to match AppFlowy coding standards"
+    exit 1
+fi
+

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Running local AppFlowy pre-commit hook."
+
 #flutter format .
 ##https://gist.github.com/benmccallum/28e4f216d9d72f5965133e6c43aaff6e
 limit=$(( 1 * 2**20 )) # 1MB

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+echo "Running local AppFlowy pre-push hook."
+
 if [[ `git status --porcelain` ]]; then
   printf "\e[31;1m%s\e[0m\n" 'This script needs to run against committed code only. Please commit or stash you changes.'
   exit 1
 fi
+
 printf "\e[33;1m%s\e[0m\n" 'Running the Flutter analyzer'
 flutter analyze
+
 if [ $? -ne 0 ]; then
   printf "\e[31;1m%s\e[0m\n" 'Flutter analyzer error'
   exit 1
 fi
+
 printf "\e[33;1m%s\e[0m\n" 'Finished running the Flutter analyzer'
 printf "\e[33;1m%s\e[0m\n" 'Running unit tests'
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no -- commitlint --edit 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
-    "@commitlint/config-conventional": "^16.0.0",
-    "husky": "7.0.4"
+    "@commitlint/config-conventional": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "@commitlint/cli": "16.1.0",
-    "@commitlint/config-conventional": "16.0.0",
+    "@commitlint/cli": "^16.1.0",
+    "@commitlint/config-conventional": "^16.0.0",
     "husky": "7.0.4"
   }
 }


### PR DESCRIPTION
Our current implementation of githooks and Husky did not work. They did nothing.
My research showed that Husky is a JS script tool, and didn't really fit for our needs. So I removed it.
Native githooks will work fine, but require one line of code to be executed, I will document this in the Environment Setup documentation.

I enabled all of the hooks that @appflowy had setup, they all work now.  However, I think that the pre-push hook might be too much and might need to be removed.

CommitLint also now works, I will add the documentation for that too.