### PR TITLE
fix:  flutter build error - The getter 'imports' isn't defined for the class 'PrefixElement' 

### DIFF
--- a/frontend/app_flowy/pubspec.yaml
+++ b/frontend/app_flowy/pubspec.yaml
@@ -85,6 +85,9 @@ dev_dependencies:
   freezed:
   bloc_test: ^9.0.2
 
+dependency_overrides:
+  analyzer: ">=4.2.0 <5.0.0"
+
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
 when I launch build_runner, it displays this :

``` 
*  Executing task: flutter pub run build_runner build --delete-conflicting-outputs 

[INFO] Generating build script...
[INFO] Generating build script completed, took 414ms

[INFO] Precompiling build script......
[WARNING] ../../../../../development/flutter/.pub-cache/hosted/pub.flutter-io.cn/freezed-2.0.4/lib/src/tools/type.dart:27:16: Error: The getter 'imports' isn't defined for the class 'PrefixElement'.
 - 'PrefixElement' is from 'package:analyzer/dart/element/element.dart' ('../../../../../development/flutter/.pub-cache/hosted/pub.flutter-io.cn/analyzer-3.4.1/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'imports'.
      return e.imports.any((l) {
               ^^^^^^^
[INFO] Precompiling build script... completed, took 4.8s

[SEVERE] Failed to precompile build script .dart_tool/build/entrypoint/build.dart.
This is likely caused by a misconfigured builder definition.

pub finished with exit code 78```

Request to update generator analyser to analyser ^4.x 