### PR TITLE
Updated Flutter Quill to 5.0.4 and fixed the dependencies and imports

### DIFF
--- a/frontend/app_flowy/lib/workspace/application/markdown/src/delta_markdown_decoder.dart
+++ b/frontend/app_flowy/lib/workspace/application/markdown/src/delta_markdown_decoder.dart
@@ -1,8 +1,8 @@
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:flutter_quill/models/documents/attribute.dart';
-import 'package:flutter_quill/models/quill_delta.dart';
+import 'package:flutter_quill/src/models/documents/attribute.dart';
+import 'package:flutter_quill/src/models/quill_delta.dart';
 
 import 'ast.dart' as ast;
 import 'document.dart';

--- a/frontend/app_flowy/lib/workspace/application/markdown/src/delta_markdown_encoder.dart
+++ b/frontend/app_flowy/lib/workspace/application/markdown/src/delta_markdown_encoder.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:flutter_quill/models/documents/attribute.dart';
-import 'package:flutter_quill/models/documents/nodes/embed.dart';
-import 'package:flutter_quill/models/documents/style.dart';
-import 'package:flutter_quill/models/quill_delta.dart';
+import 'package:flutter_quill/src/models/documents/attribute.dart';
+import 'package:flutter_quill/src/models/documents/nodes/embeddable.dart';
+import 'package:flutter_quill/src/models/documents/style.dart';
+import 'package:flutter_quill/src/models/quill_delta.dart';
 
 class DeltaMarkdownEncoder extends Converter<String, String> {
   static const _lineFeedAsciiCode = 0x0A;

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/styles.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/styles.dart
@@ -59,10 +59,12 @@ DefaultStyles customStyles(BuildContext context) {
       small: const TextStyle(fontSize: 12, color: Colors.black45),
       underline: const TextStyle(decoration: TextDecoration.underline),
       strikeThrough: const TextStyle(decoration: TextDecoration.lineThrough),
-      inlineCode: TextStyle(
+      inlineCode: InlineCodeStyle(
+        style: TextStyle(
         color: Colors.blue.shade900.withOpacity(0.9),
         fontFamily: fontFamily,
         fontSize: 13,
+        ),
       ),
       link: TextStyle(
         color: themeData.colorScheme.secondary,

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/check_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/check_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_quill/models/documents/style.dart';
+import 'package:flutter_quill/src/models/documents/style.dart';
 import 'package:flutter/material.dart';
 
 import 'toolbar_icon_button.dart';

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/color_picker.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/color_picker.dart
@@ -1,8 +1,8 @@
 import 'package:flowy_infra_ui/widget/dialog/styled_dialogs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_quill/models/documents/style.dart';
-import 'package:flutter_quill/utils/color.dart';
+import 'package:flutter_quill/src/models/documents/style.dart';
+import 'package:flutter_quill/src/utils/color.dart';
 import 'package:app_flowy/generated/locale_keys.g.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'toolbar_icon_button.dart';

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/header_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/header_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_quill/models/documents/style.dart';
+import 'package:flutter_quill/src/models/documents/style.dart';
 import 'package:flutter/material.dart';
 import 'package:app_flowy/generated/locale_keys.g.dart';
 import 'package:easy_localization/easy_localization.dart';

--- a/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/toggle_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/plugins/doc/src/widget/toolbar/toggle_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_quill/flutter_quill.dart';
-import 'package:flutter_quill/models/documents/style.dart';
+import 'package:flutter_quill/src/models/documents/style.dart';
 import 'package:flutter/material.dart';
 
 import 'toolbar_icon_button.dart';

--- a/frontend/app_flowy/pubspec.lock
+++ b/frontend/app_flowy/pubspec.lock
@@ -425,7 +425,7 @@ packages:
       name: flutter_colorpicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "1.0.3"
   flutter_inappwebview:
     dependency: transitive
     description:
@@ -476,12 +476,10 @@ packages:
   flutter_quill:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "306fd78b7a134abdde0fed6be67f59e8a6068509"
-      resolved-ref: "306fd78b7a134abdde0fed6be67f59e8a6068509"
-      url: "https://github.com/appflowy/flutter-quill.git"
-    source: git
-    version: "2.0.13"
+      name: flutter_quill
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.4"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -527,6 +525,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  gallery_saver:
+    dependency: transitive
+    description:
+      name: gallery_saver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.2"
   get_it:
     dependency: "direct main"
     description:
@@ -589,7 +594,7 @@ packages:
       name: i18n_extension
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "5.0.0"
   image_picker:
     dependency: transitive
     description:
@@ -897,7 +902,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/frontend/app_flowy/pubspec.yaml
+++ b/frontend/app_flowy/pubspec.yaml
@@ -37,10 +37,10 @@ dependencies:
     path: packages/flowy_infra_ui
   flowy_infra:
     path: packages/flowy_infra
-  flutter_quill:
-    git:
-      url: https://github.com/appflowy/flutter-quill.git
-      ref: 306fd78b7a134abdde0fed6be67f59e8a6068509
+  flutter_quill: ^5.0.4
+    #    git:
+    #      url: https://github.com/appflowy/flutter-quill.git
+    #      ref: 306fd78b7a134abdde0fed6be67f59e8a6068509
 
   #  third party packages
   intl: ^0.17.0
@@ -60,7 +60,7 @@ dependencies:
   styled_widget: "^0.3.1"
   expandable: ^5.0.1
   flutter_svg: ^0.22.0
-  flutter_colorpicker: ^0.6.0
+  flutter_colorpicker: ^1.0.3
   package_info_plus: ^1.3.0
   url_launcher: ^6.0.2
   # file_picker: ^4.2.1


### PR DESCRIPTION
as mentioned in #530, AppFlowy currently uses an old version of Flutter Quill, that has some Bugs that affect AppFlowy. 

In this PR I updated Flutter Quill to ^5.0.4 and fixed the resulting import errors.

Moving forward, it might be a good Idea to stop importing those directly if possible: https://dart-lang.github.io/linter/lints/implementation_imports.html, however I was unable to implement this. 

Changes/Suggestions are welcome.

Best Regards,

Johannes

