### PR TITLE
fix: open the latest view when AppFlowy launch.

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/home/home_screen.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/home/home_screen.dart
@@ -122,7 +122,10 @@ class _HomeScreenState extends State<HomeScreen> {
     );
 
     final latestView = workspaceSetting.hasLatestView() ? workspaceSetting.latestView : null;
-    getIt<MenuSharedState>().latestOpenView = latestView;
+    if (getIt<MenuSharedState>().latestOpenView == null) {
+      /// AppFlowy will open the view that the last time the user opened it. The _buildHomeMenu will get called when AppFlowy's screen resizes. So we only set the latestOpenView when it's null.
+      getIt<MenuSharedState>().latestOpenView = latestView;
+    }
 
     return FocusTraversalGroup(child: RepaintBoundary(child: homeMenu));
   }

--- a/frontend/app_flowy/lib/workspace/presentation/home/menu/menu.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/home/menu/menu.dart
@@ -164,7 +164,9 @@ class MenuSharedState {
   ViewPB? get latestOpenView => _latestOpenView.value;
 
   set latestOpenView(ViewPB? view) {
-    _latestOpenView.value = view;
+    if (_latestOpenView.value != view) {
+      _latestOpenView.value = view;
+    }
   }
 
   VoidCallback addLatestViewListener(void Function(ViewPB?) callback) {


### PR DESCRIPTION
AppFlowy will open the view that the last time the user opened it. But the _buildHomeMenu  function will get called when AppFlowy's screen resizes. So we only set the latestOpenView when it's null.