### PR TITLE
Fix YAML syntax in rust_lint workflow

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           toolchain: 'stable-2022-01-20'
           override: true
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: '3.0.0'
+          channel: "stable"
 
       - name: Rust Deps
         working-directory: frontend

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 'stable-2022-01-20'
-        override: true
+        with:
+          toolchain: 'stable-2022-01-20'
+          override: true
 
       - name: Rust Deps
         working-directory: frontend
@@ -40,7 +40,7 @@ jobs:
 
 
       - run: rustup component add clippy
-          working-directory: frontend/rust-lib
+        working-directory: frontend/rust-lib
       - name: clippy
         run: cargo clippy --no-default-features
         working-directory: frontend/rust-lib

--- a/frontend/rust-lib/flowy-grid/src/entities/cell_entities.rs
+++ b/frontend/rust-lib/flowy-grid/src/entities/cell_entities.rs
@@ -1,4 +1,3 @@
-
 use flowy_derive::ProtoBuf;
 use flowy_error::ErrorCode;
 use flowy_grid_data_model::parser::NotEmptyStr;
@@ -21,7 +20,6 @@ pub struct CreateSelectOptionParams {
     pub field_id: String,
     pub grid_id: String,
     pub option_name: String,
-
 }
 
 impl TryInto<CreateSelectOptionParams> for CreateSelectOptionPayloadPB {

--- a/frontend/rust-lib/flowy-grid/src/entities/field_entities.rs
+++ b/frontend/rust-lib/flowy-grid/src/entities/field_entities.rs
@@ -155,8 +155,6 @@ pub struct GetEditFieldContextPayloadPB {
     pub field_type: FieldType,
 }
 
-
-
 #[derive(Debug, Default, ProtoBuf)]
 pub struct CreateFieldPayloadPB {
     #[pb(index = 1)]
@@ -191,8 +189,6 @@ impl TryInto<CreateFieldParams> for CreateFieldPayloadPB {
         })
     }
 }
-
-
 
 #[derive(Debug, Default, ProtoBuf)]
 pub struct EditFieldPayloadPB {
@@ -240,7 +236,6 @@ pub struct GridFieldTypeOptionIdPB {
     #[pb(index = 3)]
     pub field_type: FieldType,
 }
-
 
 pub struct GridFieldTypeOptionIdParams {
     pub grid_id: String,
@@ -619,7 +614,6 @@ pub struct DuplicateFieldPayloadPB {
     pub grid_id: String,
 }
 
-
 #[derive(Debug, Clone, Default, ProtoBuf)]
 pub struct GridFieldIdentifierPayloadPB {
     #[pb(index = 1)]
@@ -668,5 +662,3 @@ pub struct GridFieldIdParams {
     pub field_id: String,
     pub grid_id: String,
 }
-
-

--- a/frontend/rust-lib/flowy-grid/src/entities/row_entities.rs
+++ b/frontend/rust-lib/flowy-grid/src/entities/row_entities.rs
@@ -2,7 +2,6 @@ use flowy_derive::ProtoBuf;
 use flowy_error::ErrorCode;
 use flowy_grid_data_model::parser::NotEmptyStr;
 
-
 #[derive(Debug, Default, Clone, ProtoBuf)]
 pub struct GridRowIdPB {
     #[pb(index = 1)]

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option_entities.rs
@@ -1,5 +1,5 @@
 use crate::entities::CellChangesetPB;
-use crate::entities::{GridCellIdParams, GridCellIdPB};
+use crate::entities::{GridCellIdPB, GridCellIdParams};
 use crate::services::cell::{CellBytesParser, FromCellChangeset, FromCellString};
 use bytes::Bytes;
 

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/selection_type_option/select_option.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/selection_type_option/select_option.rs
@@ -1,4 +1,4 @@
-use crate::entities::{CellChangesetPB, GridCellIdParams, FieldType, GridCellIdPB};
+use crate::entities::{CellChangesetPB, FieldType, GridCellIdPB, GridCellIdParams};
 use crate::services::cell::{CellBytes, CellBytesParser, CellData, CellDisplayable, FromCellChangeset, FromCellString};
 use crate::services::field::{MultiSelectTypeOption, SingleSelectTypeOptionPB};
 use bytes::Bytes;

--- a/frontend/rust-lib/flowy-grid/tests/grid/block_test/script.rs
+++ b/frontend/rust-lib/flowy-grid/tests/grid/block_test/script.rs
@@ -2,7 +2,7 @@ use crate::grid::block_test::script::RowScript::{AssertCell, CreateRow};
 use crate::grid::block_test::util::GridRowTestBuilder;
 use crate::grid::grid_editor::GridEditorTest;
 
-use flowy_grid::entities::{GridCellIdParams, FieldType, GridRowPB};
+use flowy_grid::entities::{FieldType, GridCellIdParams, GridRowPB};
 use flowy_grid::services::field::*;
 use flowy_grid_data_model::revision::{
     GridBlockMetaRevision, GridBlockMetaRevisionChangeset, RowMetaChangeset, RowRevision,


### PR DESCRIPTION
Quick fix for the rust_lint GitHub workflow, since I noticed that the tests were failing due to invalid YAML syntax.