### PR TITLE
fix: fixed hover color #685

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/footer/grid_footer.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/footer/grid_footer.dart
@@ -14,7 +14,7 @@ class GridAddRowButton extends StatelessWidget {
     final theme = context.watch<AppTheme>();
     return FlowyButton(
       text: const FlowyText.medium('New row', fontSize: 12),
-      hoverColor: theme.hover,
+      hoverColor: theme.shader6,
       onTap: () => context.read<GridBloc>().add(const GridEvent.createRow()),
       leftIcon: svgWidget("home/add"),
     );

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/grid_header.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/grid_header.dart
@@ -156,7 +156,7 @@ class CreateFieldButton extends StatelessWidget {
 
     return FlowyButton(
       text: const FlowyText.medium('New column', fontSize: 12),
-      hoverColor: theme.hover,
+      hoverColor: theme.shader6,
       onTap: () => FieldEditor(
         gridId: gridId,
         fieldName: "",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40403668/184405819-3354efc6-a3a6-4d04-aae5-8abdc75810f2.png)

Both New Column and New Row buttons now have the same background shade as other column headers on hover