### PR TITLE
fix: empty create option in select/multi-select properties

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/application/cell/select_option_editor_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/select_option_editor_bloc.dart
@@ -146,8 +146,7 @@ class SelectOptionCellEditorBloc
 
           return name.contains(lFilter);
         });
-      }
-      else {
+      } else {
         createOption = none();
       }
     });

--- a/frontend/app_flowy/lib/plugins/grid/application/cell/select_option_editor_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/select_option_editor_bloc.dart
@@ -103,19 +103,11 @@ class SelectOptionCellEditorBloc
   void _filterOption(String optionName, Emitter<SelectOptionEditorState> emit) {
     final _MakeOptionResult result =
         _makeOptions(Some(optionName), state.allOptions);
-    if (optionName.isEmpty) {
-      emit(state.copyWith(
-        filter: Some(optionName),
-        options: result.options,
-        createOption: none(),
-      ));
-    } else {
-      emit(state.copyWith(
-        filter: Some(optionName),
-        options: result.options,
-        createOption: result.createOption,
-      ));
-    }
+    emit(state.copyWith(
+      filter: Some(optionName),
+      options: result.options,
+      createOption: result.createOption,
+    ));
   }
 
   void _loadOptions() {
@@ -154,6 +146,9 @@ class SelectOptionCellEditorBloc
 
           return name.contains(lFilter);
         });
+      }
+      else {
+        createOption = none();
       }
     });
 


### PR DESCRIPTION
An empty create option sometimes appears in grid and kanban select/multi-select. To reproduce, type something into the text box, clear it, and then choose an option.


https://user-images.githubusercontent.com/71320345/189468722-56fbebab-7b61-457f-9bd6-263d391f82ec.mp4

