### PR TITLE
fix: prevent select property from having identical options

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/application/field/type_option/multi_select_type_option.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/field/type_option/multi_select_type_option.dart
@@ -51,7 +51,11 @@ class MultiSelectAction with ISelectOptionAction {
           (option) {
             typeOption.freeze();
             typeOption = typeOption.rebuild((typeOption) {
-              typeOption.options.insert(0, option);
+              final exists = typeOption.options
+                  .any((element) => element.name == option.name);
+              if (!exists) {
+                typeOption.options.insert(0, option);
+              }
             });
 
             return typeOption.options;

--- a/frontend/app_flowy/lib/plugins/grid/application/field/type_option/single_select_type_option.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/field/type_option/single_select_type_option.dart
@@ -48,7 +48,11 @@ class SingleSelectAction with ISelectOptionAction {
           (option) {
             typeOption.freeze();
             typeOption = typeOption.rebuild((typeOption) {
-              typeOption.options.insert(0, option);
+              final exists = typeOption.options
+                  .any((element) => element.name == option.name);
+              if (!exists) {
+                typeOption.options.insert(0, option);
+              }
             });
 
             return typeOption.options;


### PR DESCRIPTION
When using the edit property menu (from the grid header or the grid settings buttons at the top) to edit single or multi-select properties, identical options can be created, as shown below:

https://user-images.githubusercontent.com/71320345/189540529-cf73f8f2-aa7d-4316-8647-29376186cf1d.mp4

