### PR TITLE
fix: add missing padding between number format list and filter bar

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/number.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/number.dart
@@ -116,6 +116,7 @@ class NumberFormatList extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const _FilterTextField(),
+            const VSpace(10),
             BlocBuilder<NumberFormatBloc, NumberFormatState>(
               builder: (context, state) {
                 final cells = state.formats.map((format) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/71320345/190106166-a204beb2-9b41-4b66-9e1e-f3a5215be8ac.png)

After:
![image](https://user-images.githubusercontent.com/71320345/190106723-56274c6a-4d52-4eb3-8c0d-4350102dd473.png)

