### PR TITLE
fix: some improvements for when including time in a date cell

### DIFF
--- a/frontend/app_flowy/assets/translations/en.json
+++ b/frontend/app_flowy/assets/translations/en.json
@@ -222,8 +222,8 @@
   "document": {
     "menuName": "Doc",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   },
   "board": {

--- a/frontend/app_flowy/assets/translations/es-VE.json
+++ b/frontend/app_flowy/assets/translations/es-VE.json
@@ -210,8 +210,8 @@
   "document": {
     "menuName": "Doc",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   },
   "sideBar": {

--- a/frontend/app_flowy/assets/translations/fr-FR.json
+++ b/frontend/app_flowy/assets/translations/fr-FR.json
@@ -208,8 +208,8 @@
   "document": {
     "menuName": "Doc",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   }
 }

--- a/frontend/app_flowy/assets/translations/id-ID.json
+++ b/frontend/app_flowy/assets/translations/id-ID.json
@@ -211,8 +211,8 @@
   "document": {
     "menuName": "Doc",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   },
   "sideBar": {

--- a/frontend/app_flowy/assets/translations/ru-RU.json
+++ b/frontend/app_flowy/assets/translations/ru-RU.json
@@ -200,8 +200,8 @@
       "searchOption": "Поиск"
     },
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   },
   "sideBar": {

--- a/frontend/app_flowy/assets/translations/zh-CN.json
+++ b/frontend/app_flowy/assets/translations/zh-CN.json
@@ -215,8 +215,8 @@
   "document": {
     "menuName": "文档",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   }
 }

--- a/frontend/app_flowy/assets/translations/zh-TW.json
+++ b/frontend/app_flowy/assets/translations/zh-TW.json
@@ -211,8 +211,8 @@
   "document": {
     "menuName": "檔案",
     "date": {
-      "timeHintTextInTwelveHour": "12:00 AM",
-      "timeHintTextInTwentyFourHour": "12:00"
+      "timeHintTextInTwelveHour": "01:00 PM",
+      "timeHintTextInTwentyFourHour": "13:00"
     }
   },
   "sideBar": {

--- a/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
@@ -119,13 +119,13 @@ class DateCalBloc extends Bloc<DateCalEvent, DateCalState> {
   }
 
   String timeFormatPrompt(FlowyError error) {
-    String msg = "${LocaleKeys.grid_field_invalidTimeFormat.tr()}. ";
+    String msg = "${LocaleKeys.grid_field_invalidTimeFormat.tr()}.";
     switch (state.dateTypeOptionPB.timeFormat) {
       case TimeFormat.TwelveHour:
-        msg = "${msg}e.g. 01: 00 AM";
+        msg = "$msg e.g. 01:00 PM";
         break;
       case TimeFormat.TwentyFourHour:
-        msg = "${msg}e.g. 13: 00";
+        msg = "$msg e.g. 13:00";
         break;
       default:
         break;

--- a/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
@@ -108,7 +108,7 @@ class DateCalBloc extends Bloc<DateCalEvent, DateCalState> {
         (err) {
           switch (ErrorCode.valueOf(err.code)!) {
             case ErrorCode.InvalidDateTimeFormat:
-              updateCalData(none(), Some(timeFormatPrompt(err)));
+              updateCalData(state.calData, Some(timeFormatPrompt(err)));
               break;
             default:
               Log.error(err);

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/date_cell/date_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/date_cell/date_editor.dart
@@ -261,6 +261,7 @@ class _TimeTextFieldState extends State<_TimeTextField> {
             child: RoundedInputField(
               height: 40,
               focusNode: _focusNode,
+              autoFocus: true,
               hintText: state.timeHintText,
               controller: _controller,
               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_tests.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_tests.rs
@@ -141,7 +141,9 @@ mod tests {
             .unwrap();
 
         if type_option.include_time {
-            format!("{}{}", decoded_data.date, decoded_data.time)
+            format!("{} {}", decoded_data.date, decoded_data.time)
+                .trim_end()
+                .to_owned()
         } else {
             decoded_data.date
         }

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option.rs
@@ -52,7 +52,7 @@ impl DateTypeOptionPB {
 
         let mut time = "".to_string();
         if has_time && self.include_time {
-            let fmt = format!("{} {}", self.date_format.format_str(), self.time_format.format_str());
+            let fmt = format!("{}{}", self.date_format.format_str(), self.time_format.format_str());
             time = format!("{}", utc.format_with_items(StrftimeItems::new(&fmt))).replace(&date, "");
         }
 

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/date_type_option/date_type_option.rs
@@ -51,7 +51,7 @@ impl DateTypeOptionPB {
         let date = format!("{}", utc.format_with_items(StrftimeItems::new(fmt)));
 
         let mut time = "".to_string();
-        if has_time {
+        if has_time && self.include_time {
             let fmt = format!("{} {}", self.date_format.format_str(), self.time_format.format_str());
             time = format!("{}", utc.format_with_items(StrftimeItems::new(&fmt))).replace(&date, "");
         }


### PR DESCRIPTION
- I think one o'clock is better than noon for time format hinting
- the cell's time should show/hide immediately according to the switch
- I added autofocus to the text field when the switch is toggled
- prevent the date from disappearing when the time input is invalid. (see below)
- prevent the time field from showing a whitespace at the front after submitting (see below). The cell's date and time spacing is actually reduced by one space as well, but it can be re-added separately.

https://user-images.githubusercontent.com/71320345/190865573-0af932d2-135b-47ea-9139-f450d9bbaecc.mp4

