### PR TITLE
feat: make Rust installation prompt default to No

### DIFF
--- a/frontend/scripts/install_dev_env/install_macos.sh
+++ b/frontend/scripts/install_dev_env/install_macos.sh
@@ -22,9 +22,9 @@ printError() {
 printMessage "The Rust programming language is required to compile AppFlowy."
 printMessage "We can install it now if you don't already have it on your system."
 
-read -p "$(printSuccess "Do you want to install Rust? [Y/N]") " installrust
+read -p "$(printSuccess "Do you want to install Rust? [y/N]") " installrust
 
-if [ ${installrust} == "Y" ] || [ ${installrust} == "y" ]; then
+if [[ "${installrust:-N}" == [Yy] ]]; then
    printMessage "Installing Rust."
    brew install rustup-init
    rustup-init -y --default-toolchain=stable
@@ -60,7 +60,7 @@ tar -zxv --directory .githooks/. -f ${GOLINT_FILENAME} gitlint
 rm ${GOLINT_FILENAME}
 
 # Change to the frontend directory
-cd frontend
+cd frontend || exit 1
 
 # Install cargo make
 printMessage "Installing cargo-make."


### PR DESCRIPTION
It's natural for me to hit ENTER at a prompt when I assume that the default response is to do the less-dangerous thing (which in this case, I would assume to be tied to the `N` response).  But if I do that, the script gets lots of errors.
So I'm adding a default of `N` to the prompt for installing Rust.

Also, adding an `|| exit 1` to the `cd` so that IDE/shellcheck warnings go away.