### PR TITLE
Add libkeybinder3 to Dockerfile

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -47,7 +47,7 @@ RUN pacman -Syy && \
 RUN xdg-user-dirs-update
 
 COPY --from=builder /usr/sbin/yay /usr/sbin/yay
-RUN yay -S --noconfirm gtk3
+RUN yay -S --noconfirm gtk3 libkeybinder3
 
 ARG user=appflowy
 ARG uid=1000


### PR DESCRIPTION
When running in Docker, the error described in #1022 appeared. This commit fixes that by adding libkeybinder3 as a dependency installed in the final container.