### PR TITLE
fix: Theme toggle not updating UI

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -13,7 +13,7 @@ class SettingsAppearanceView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = context.read<AppTheme>();
+    final theme = context.watch<AppTheme>();
 
     return SingleChildScrollView(
       child: Column(


### PR DESCRIPTION
Fix the toggle not updating live in the settings UI when switching between Light/Dark mode