### PR TITLE
fix: improve look of share button dropdown menu

### DIFF
--- a/frontend/app_flowy/lib/plugins/doc/document.dart
+++ b/frontend/app_flowy/lib/plugins/doc/document.dart
@@ -15,6 +15,7 @@ import 'package:clipboard/clipboard.dart';
 import 'package:dartz/dartz.dart' as dartz;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/size.dart';
+import 'package:flowy_infra/theme.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/rounded_button.dart';
 import 'package:flowy_sdk/log.dart';
@@ -112,7 +113,6 @@ class DocumentShareButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double buttonWidth = 60;
     return BlocProvider(
       create: (context) => getIt<DocShareBloc>(param1: view),
       child: BlocListener<DocShareBloc, DocShareState>(
@@ -130,6 +130,7 @@ class DocumentShareButton extends StatelessWidget {
         },
         child: BlocBuilder<DocShareBloc, DocShareState>(
           builder: (context, state) {
+            final theme = context.watch<AppTheme>();
             return ChangeNotifierProvider.value(
               value: Provider.of<AppearanceSetting>(context, listen: true),
               child: Selector<AppearanceSetting, Locale>(
@@ -137,16 +138,15 @@ class DocumentShareButton extends StatelessWidget {
                 builder: (ctx, _, child) => ConstrainedBox(
                   constraints: const BoxConstraints.expand(
                     height: 30,
-                    // minWidth: buttonWidth,
                     width: 100,
                   ),
                   child: RoundedTextButton(
                     title: LocaleKeys.shareAction_buttonText.tr(),
                     fontSize: 12,
                     borderRadius: Corners.s6Border,
-                    color: Colors.lightBlue,
-                    onPressed: () => _showActionList(
-                        context, Offset(-(buttonWidth / 2), 10)),
+                    color: theme.main1,
+                    onPressed: () =>
+                        _showActionList(context, const Offset(0, 10)),
                   ),
                 ),
               ),
@@ -193,7 +193,7 @@ class DocumentShareButton extends StatelessWidget {
     });
     actionList.show(
       context,
-      anchorDirection: AnchorDirection.bottomWithCenterAligned,
+      anchorDirection: AnchorDirection.bottomWithRightAligned,
       anchorOffset: offset,
     );
   }

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/pop_up_action.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/pop_up_action.dart
@@ -97,10 +97,8 @@ class ActionCell<T extends ActionItem> extends StatelessWidget {
         child: SizedBox(
           height: itemHeight,
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              if (icon != null) icon,
-              HSpace(ActionListSizes.itemHPadding),
+              if (icon != null) ...[icon, HSpace(ActionListSizes.itemHPadding)],
               FlowyText.medium(action.name, fontSize: 12),
             ],
           ),


### PR DESCRIPTION
This patch does three things: 1. remove the padding between the icon and the text if there is no icon, 2. align the content of each row at the center along the crossaxis, and 3. align the dropdown menu with the right edge of the share button. The extra spacing to the right is not fixed yet and is tracked at #1206. Oh and changed the color of the button too!

Before:
![image](https://user-images.githubusercontent.com/71320345/193846282-6360806d-77ff-47ce-be17-cf92881fe71e.png)

After:
![image](https://user-images.githubusercontent.com/71320345/193846960-857a48fe-09f3-4318-9696-3d34d19a255f.png)

