### PR TITLE
fix: Extra spacing in multiselect cell

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/select_option_cell/select_option_cell.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/select_option_cell/select_option_cell.dart
@@ -210,15 +210,17 @@ class _SelectOptionWrapState extends State<SelectOptionWrap> {
     } else {
       final children = widget.selectOptions.map(
         (option) {
-          return SelectOptionTag.fromOption(
-            context: context,
-            option: option,
+          return Padding(
+            padding: const EdgeInsets.only(right: 4),
+            child: SelectOptionTag.fromOption(
+              context: context,
+              option: option,
+            ),
           );
         },
       ).toList();
 
       child = Wrap(
-        spacing: 4,
         runSpacing: 2,
         children: children,
       );


### PR DESCRIPTION
This fixes #1186 .

`spacing` attribute of the `Wrap` being used in `SelectOptionWrap` seems to be causing the issue. I have just removed the use of the `spacing` from the wrap and instead I have used a `Padding` to provide spacing to the children of the `Wrap`.