### PR TITLE
Code coverage for Rust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - id: rust_toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "stable-2022-01-20"
+          toolchain: "stable-2022-04-07"
 
       - id: flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/dart_lint.yml
+++ b/.github/workflows/dart_lint.yml
@@ -34,7 +34,7 @@ jobs:
           channel: "stable"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "stable-2022-01-20"
+          toolchain: "stable-2022-04-07"
 
       - name: Cache Cargo
         id: cache-cargo

--- a/.github/workflows/dart_test.yml
+++ b/.github/workflows/dart_test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "stable-2022-01-20"
+          toolchain: "stable-2022-04-07"
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup environment - Rust and Cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'stable-2022-01-20'
+          toolchain: 'stable-2022-04-07'
 
       - name: Setup environment - Flutter
         uses: subosito/flutter-action@v2
@@ -94,7 +94,7 @@ jobs:
       - name: Setup environment - Rust and Cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'stable-2022-01-20'
+          toolchain: 'stable-2022-04-07'
 
       - name: Setup environment - Flutter
         uses: subosito/flutter-action@v2
@@ -143,7 +143,7 @@ jobs:
       - name: Setup environment - Rust and Cargo
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'stable-2022-01-20'
+          toolchain: 'stable-2022-04-07'
 
       - name: Setup environment - Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "frontend/rustlib/**"
+      - "shared-lib/**"
+
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "frontend/rustlib/**"
+      - "shared-lib/**"
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - id: rust_toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 'stable-2022-04-07'
+
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with: 
+          path: |
+            ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}
+
+      - name: Cache Rust
+        uses: actions/cache@v2
+        with: 
+          path: |
+            frontend/rust-lib/target
+            shared-lib/target
+          key: ${{ runner.os }}-rust-rust-lib-share-lib-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
+
+      - name: Install cargo-make
+        working-directory: frontend
+        run: cargo install cargo-make
+
+      - name: Run Coverage tests and generate LCOV report
+        working-directory: frontend
+        run: cargo make get_ci_test_coverage

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -61,7 +61,10 @@ jobs:
 
       - name: Install cargo-make
         working-directory: frontend
-        run: cargo install cargo-make
+        run: |
+          cargo install cargo-make
+          cargo install grcov
+          rustup component add llvm-tools-preview
 
       - name: Run Coverage tests and generate LCOV report
         working-directory: frontend

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -46,6 +46,19 @@ jobs:
             shared-lib/target
           key: ${{ runner.os }}-rust-rust-lib-share-lib-${{ steps.rust_toolchain.outputs.rustc_hash }}-${{ hashFiles('./frontend/rust-lib/Cargo.toml') }}    
 
+      - name: Setup Environment
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo wget -qO /etc/apt/trusted.gpg.d/dart_linux_signing_key.asc https://dl-ssl.google.com/linux/linux_signing_key.pub
+            sudo wget -qO /etc/apt/sources.list.d/dart_stable.list https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list
+            sudo apt-get update
+            sudo apt-get install -y dart curl build-essential libsqlite3-dev libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev
+            sudo apt-get install keybinder-3.0
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            echo 'do nothing'
+          fi
+        shell: bash
+
       - name: Install cargo-make
         working-directory: frontend
         run: cargo install cargo-make

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -1,16 +1,18 @@
+name: Rust coverage tests
+
 on:
   push:
     branches:
       - "main"
     paths:
-      - "frontend/rustlib/**"
+      - "frontend/rust-lib/**"
       - "shared-lib/**"
 
   pull_request:
     branches:
       - "main"
     paths:
-      - "frontend/rustlib/**"
+      - "frontend/rust-lib/**"
       - "shared-lib/**"
 
 env:

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -59,7 +59,7 @@ jobs:
           fi
         shell: bash
 
-      - name: Install cargo-make
+      - name: Install cargo-make, grcov and llvm-tools-preview
         working-directory: frontend
         run: |
           cargo install cargo-make

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'stable-2022-01-20'
+          toolchain: 'stable-2022-04-07'
           override: true
       - uses: subosito/flutter-action@v1
         with:

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -28,7 +28,7 @@ jobs:
       - id: rust_toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 'stable-2022-01-20'
+          toolchain: 'stable-2022-04-07'
 
       - name: Cache Cargo
         uses: actions/cache@v2

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -12,6 +12,8 @@ use tracing_bunyan_formatter::JsonStorageLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
+// Revert this.
+
 lazy_static! {
     static ref LOG_GUARD: RwLock<Option<WorkerGuard>> = RwLock::new(None);
 }

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -12,8 +12,6 @@ use tracing_bunyan_formatter::JsonStorageLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
-// Revert this.
-
 lazy_static! {
     static ref LOG_GUARD: RwLock<Option<WorkerGuard>> = RwLock::new(None);
 }

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -12,7 +12,7 @@ use tracing_bunyan_formatter::JsonStorageLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
-// Revert this.
+// Revert this again.
 
 lazy_static! {
     static ref LOG_GUARD: RwLock<Option<WorkerGuard>> = RwLock::new(None);

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -12,7 +12,7 @@ use tracing_bunyan_formatter::JsonStorageLayer;
 use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
-// Revert this again.
+// Revert this.
 
 lazy_static! {
     static ref LOG_GUARD: RwLock<Option<WorkerGuard>> = RwLock::new(None);

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -4,8 +4,6 @@ use log::LevelFilter;
 
 use tracing::subscriber::set_global_default;
 
-// Revert this.
-
 use crate::layer::*;
 use lazy_static::lazy_static;
 use std::sync::RwLock;

--- a/frontend/rust-lib/lib-log/src/lib.rs
+++ b/frontend/rust-lib/lib-log/src/lib.rs
@@ -4,6 +4,8 @@ use log::LevelFilter;
 
 use tracing::subscriber::set_global_default;
 
+// Revert this.
+
 use crate::layer::*;
 use lazy_static::lazy_static;
 use std::sync::RwLock;

--- a/frontend/rust-lib/rust-toolchain.toml
+++ b/frontend/rust-lib/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable-2022-01-20"
+channel = "stable-2022-04-07"

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -16,6 +16,22 @@ cd ../shared-lib
 RUST_LOG=info cargo test --no-default-features
 '''
 
+[tasks.check_grcov]
+description = "Check if `grcov` is installled"
+script_runner = "@shell"
+script = '''
+if command -v z > /dev/null; then
+  echo "Found 'grcov' executable."
+else
+  echo "[!] Could not find 'grcov' executable."
+  echo "[!] Please install 'grcov' by running 'cargo install grcov'."
+  echo "[!] You may also need to install 'llvm-tools-preview' using 'rustup component add llvm-tools-preview'."
+  echo "[!] If installed, check if 'grcov' is in PATH."
+  echo "[!] Exiting..."
+  exit -1
+fi
+'''
+
 [tasks.clean_profraw_files]
 description = "Cleans profraw files that are created by `cargo test`"
 script_runner = "@duckscript"
@@ -181,6 +197,7 @@ run_task = { name = [
 [tasks.get_ci_test_coverage]
 description = "Get LCOV coverage reports for CI"
 run_task = { name = [
+    "check_grcov",
     "run_rustlib_coverage_tests",
     "run_sharedlib_coverage_tests",
     "get_lcov_report",
@@ -190,6 +207,7 @@ run_task = { name = [
 [tasks.get_test_coverage]
 description = "Get human readable test coverage reports"
 run_task = { name = [
+    "check_grcov",
     "run_rustlib_coverage_tests",
     "run_sharedlib_coverage_tests",
     "get_grcov_report",

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -42,7 +42,11 @@ script_runner = "@shell"
 script = [
   """
   echo --- Running coverage tests ---
+
+  # Install Protobuf compiler
+  cargo make install_protobuf_compiler
   export PATH="$PATH":"$HOME/.pub-cache/bin"
+
   cd rust-lib/
 
   CARGO_INCREMENTAL=0 \
@@ -59,6 +63,11 @@ script_runner = "@shell"
 script = [
   """
   echo --- Running coverage tests ---
+
+  # Install Protobuf compiler
+  cargo make install_protobuf_compiler
+  export PATH="$PATH":"$HOME/.pub-cache/bin"
+
   cd ../shared-lib
 
   CARGO_INCREMENTAL=0 \

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -21,7 +21,7 @@ description = "Check if `grcov` is installled"
 script_runner = "@shell"
 script = '''
 export PATH=$PATH:"$HOME/.cargo/bin/"
-if command -v z > /dev/null; then
+if command -v grcov > /dev/null; then
   echo "Found 'grcov' executable."
 else
   echo "[!] Could not find 'grcov' executable."

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -16,3 +16,173 @@ cd ../shared-lib
 RUST_LOG=info cargo test --no-default-features
 '''
 
+[tasks.clean_profraw_files]
+description = "Cleans profraw files that are created by `cargo test`"
+# private = true
+script_runner = "@duckscript"
+script = [
+  """
+  rust_lib_profs = glob_array ./rust-lib/**/*.profraw
+  for prof in ${rust_lib_profs}
+    full_path = canonicalize ${prof}
+    rm ${full_path}
+  end
+
+  shared_lib_profs = glob_array ../shared-lib/**/*.profraw
+  for prof in ${shared_lib_profs}
+    full_path = canonicalize ${prof}
+    rm ${full_path}
+  end
+
+  """
+]
+
+[tasks.run_rustlib_coverage_tests]
+description = "Run tests with coverage instrumentation"
+script_runner = "@shell"
+script = [
+  """
+  echo --- Running coverage tests ---
+  cd rust-lib/
+
+  CARGO_INCREMENTAL=1 \
+  RUSTFLAGS='-C instrument-coverage' \
+  LLVM_PROFILE_FILE='prof-%p-%m.profraw' \
+  cargo test --no-default-features --features="sync"
+
+  """
+]
+
+[tasks.run_sharedlib_coverage_tests]
+description = "Run tests with coverage instrumentation"
+script_runner = "@shell"
+script = [
+  """
+  echo --- Running coverage tests ---
+  cd ../shared-lib
+
+  CARGO_INCREMENTAL=1 \
+  RUSTFLAGS='-C instrument-coverage' \
+  LLVM_PROFILE_FILE='prof-%p-%m.profraw' \
+  cargo test --no-default-features 
+
+  """
+]
+
+[tasks.get_rustlib_grcov_report]
+description = "Get `grcov` HTML report for test coverage for rust-lib"
+script_runner = "@shell"
+script = [
+  """
+  echo --- Getting 'grcov' results for 'rust-lib' --- 
+  cd rust-lib/
+
+  grcov . \
+  --binary-path target/debug/deps \
+  --source-dir . \
+  --output-type html \
+  --branch \
+  --ignore-not-existing \
+  --log-level WARN \
+  --output-path target/coverage-html
+
+  echo "--- Done! Generated HTML report under 'target/coverage-html' for rustlib."
+  """
+]
+
+[tasks.get_sharedlib_grcov_report]
+description = "Get `grcov` HTML report for test coverage shared-lib"
+script_runner = "@shell"
+script = [
+  """
+  echo --- Getting 'grcov' results 'shared-lib' --- 
+  cd ../shared-lib
+
+  grcov . \
+  --binary-path target/debug/deps \
+  --source-dir . \
+  --output-type html \
+  --branch \
+  --ignore-not-existing \
+  --log-level WARN \
+  --output-path target/coverage-html
+
+  echo "--- Done! Generated HTML report under 'target/coverage-html' for sharedlib."
+  """
+]
+
+[tasks.get_grcov_report]
+description = "Get `grcov` HTML report for test coverage"
+run_task = { name = [
+  "get_rustlib_grcov_report",
+  "get_sharedlib_grcov_report"
+], parallel = true }
+
+[tasks.get_sharedlib_lcov_report]
+description = "Generates `lcov` report for `shared-lib`"
+script_runner = "@shell"
+script = [
+  """
+  echo Getting 'lcov' results for 'shared-lib'
+
+  cd ../shared-lib
+
+  grcov . \
+  --binary-path target/debug/deps \
+  --source-dir . \
+  --output-type lcov \
+  --branch \
+  --ignore-not-existing \
+  --log-level WARN \
+  --output-path target/coverage.lcov
+
+  echo "--- Done! Generated 'target/coverage.lcov' sharedlib."
+  """
+]
+
+[tasks.get_rustlib_lcov_report]
+description = "Generates `lcov` report for `rust-lib`"
+script_runner = "@shell"
+script = [
+  """
+  echo Getting 'lcov' results for 'rust-lib'
+
+  cd rust-lib/
+
+  grcov . \
+  --binary-path target/debug/deps \
+  --source-dir . \
+  --output-type lcov \
+  --branch \
+  --ignore-not-existing \
+  --log-level WARN \
+  --output-path target/coverage.lcov
+
+  echo "--- Done! Generated 'target/coverage.lcov' for rustlib."
+  """
+]
+
+[tasks.get_lcov_report]
+description = "Get `lcov` reports for test coverage"
+run_task = { name = [
+  "get_sharedlib_lcov_report",
+  "get_rustlib_lcov_report"
+], parallel = true }
+
+[tasks.get_ci_test_coverage]
+description = "Get LCOV coverage reports for CI"
+run_task = { name = [
+    "run_rustlib_coverage_tests",
+    "run_sharedlib_coverage_tests",
+    "get_lcov_report",
+    "clean_profraw_files"
+  ]}
+
+[tasks.get_test_coverage]
+description = "Get human readable test coverage reports"
+run_task = { name = [
+    "run_rustlib_coverage_tests",
+    "run_sharedlib_coverage_tests",
+    "get_grcov_report",
+    "clean_profraw_files"
+  ]}

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -18,7 +18,6 @@ RUST_LOG=info cargo test --no-default-features
 
 [tasks.clean_profraw_files]
 description = "Cleans profraw files that are created by `cargo test`"
-# private = true
 script_runner = "@duckscript"
 script = [
   """
@@ -43,9 +42,10 @@ script_runner = "@shell"
 script = [
   """
   echo --- Running coverage tests ---
+  export PATH="$PATH":"$HOME/.pub-cache/bin"
   cd rust-lib/
 
-  CARGO_INCREMENTAL=1 \
+  CARGO_INCREMENTAL=0 \
   RUSTFLAGS='-C instrument-coverage' \
   LLVM_PROFILE_FILE='prof-%p-%m.profraw' \
   cargo test --no-default-features --features="sync"
@@ -61,7 +61,7 @@ script = [
   echo --- Running coverage tests ---
   cd ../shared-lib
 
-  CARGO_INCREMENTAL=1 \
+  CARGO_INCREMENTAL=0 \
   RUSTFLAGS='-C instrument-coverage' \
   LLVM_PROFILE_FILE='prof-%p-%m.profraw' \
   cargo test --no-default-features 

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -20,6 +20,7 @@ RUST_LOG=info cargo test --no-default-features
 description = "Check if `grcov` is installled"
 script_runner = "@shell"
 script = '''
+export PATH=$PATH:"$HOME/.cargo/bin/"
 if command -v z > /dev/null; then
   echo "Found 'grcov' executable."
 else
@@ -62,6 +63,7 @@ script = [
   # Install Protobuf compiler
   cargo make install_protobuf_compiler
   export PATH="$PATH":"$HOME/.pub-cache/bin"
+  export PATH="$PATH":"$HOME/.cargo/bin/"
 
   cd rust-lib/
 
@@ -83,6 +85,7 @@ script = [
   # Install Protobuf compiler
   cargo make install_protobuf_compiler
   export PATH="$PATH":"$HOME/.pub-cache/bin"
+  export PATH="$PATH":"$HOME/.cargo/bin/"
 
   cd ../shared-lib
 

--- a/shared-lib/rust-toolchain.toml
+++ b/shared-lib/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable-2022-01-20"
+channel = "stable-2022-04-07"


### PR DESCRIPTION
Implements #1169.

## Summary of changes

- Bumped `rustc` to `2022-04-07`, that is version `1.60.0` as that version introduces coverage instrumentation. These bumps are in the `rust-toolchain.toml` files in the projects and also in the CI workflow files.
- In `frontend/scripts/makefile/tests.toml`, created two `cargo make` tasks (among other supporting ones):
  - `get_test_coverage` - Tests both projects with `-C instrument-coverage` flag with `rustc`. Further, runs `grcov` to create an HTML report of the total coverage. The report is stored in each project's directory under `target/coverage-html/`, main HTML file being `index.html`.
  - `get_ci_test_coverage` - Tests the same way as above, but generates `lcov` test reports instead of human readable HTML. These can be integrated in CI using various actions on the Github Marketplace. Each project will have a file called `target/coverage.lcov` that will contain the coverage data.
- Created the `rust-coverage.yml` workflow that runs the `get_ci_test_coverage` task. This is intended to give a test report for each pull-request and push to `main`. I need some direction on what Github action should be used to display that. 

## Further help

This PR will give coverage capabilities, however they are not visible in the Github CI. There are multiple Github actions on the marketplace that will solve this problem if we just point them to the test coverage `lcov` file. I hope you can tell me what would be the best way to go here. Here's a list of actions that I found on the internet -

- https://github.com/marketplace/actions/report-lcov - Comments the test coverage on the relevant PR
- https://github.com/marketplace/actions/comment-lcov-code-coverage-report similar to above, but slightly prettier 

#### Note

You may see a lot of commits being made and reverted in the history. I mostly did those to trigger the CI.