### PR TITLE
fix: FieldEditor not refresh its type-option data after switching to …

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/application/field/type_option/type_option_data_controller.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/field/type_option/type_option_data_controller.dart
@@ -80,7 +80,12 @@ class TypeOptionDataController {
   Future<void> switchToField(FieldType newFieldType) {
     return loader.switchToField(field.id, newFieldType).then((result) {
       return result.fold(
-        (_) {},
+        (_) {
+          // Should load the type-option data after switching to a new field.
+          // After loading the type-option data, the editor widget that uses
+          // the type-option data will be rebuild.
+          loadTypeOptionData();
+        },
         (err) => Log.error(err),
       );
     });

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
@@ -1,5 +1,6 @@
 import 'package:app_flowy/plugins/grid/application/field/field_editor_bloc.dart';
 import 'package:app_flowy/plugins/grid/application/field/type_option/type_option_context.dart';
+import 'package:app_flowy/plugins/grid/presentation/layout/sizes.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:dartz/dartz.dart' show none;
 import 'package:easy_localization/easy_localization.dart';
@@ -58,19 +59,22 @@ class _FieldEditorState extends State<FieldEditor> {
         isGroupField: widget.isGroupField,
         loader: widget.typeOptionLoader,
       )..add(const FieldEditorEvent.initial()),
-      child: ListView(
-        shrinkWrap: true,
-        children: [
-          FlowyText.medium(
-            LocaleKeys.grid_field_editProperty.tr(),
-            fontSize: 12,
-          ),
-          const VSpace(10),
-          _FieldNameTextField(popoverMutex: popoverMutex),
-          const VSpace(10),
-          ..._addDeleteFieldButton(),
-          _FieldTypeOptionCell(popoverMutex: popoverMutex),
-        ],
+      child: Padding(
+        padding: GridSize.typeOptionContentInsets,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            FlowyText.medium(
+              LocaleKeys.grid_field_editProperty.tr(),
+              fontSize: 12,
+            ),
+            const VSpace(10),
+            _FieldNameTextField(popoverMutex: popoverMutex),
+            const VSpace(10),
+            ..._addDeleteFieldButton(),
+            _FieldTypeOptionCell(popoverMutex: popoverMutex),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/text_type_option/text_type_option.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/text_type_option/text_type_option.rs
@@ -31,11 +31,13 @@ impl TypeOptionBuilder for RichTextTypeOptionBuilder {
     }
 }
 
+/// For the moment, the `RichTextTypeOptionPB` is empty. The `data` property is not
+/// used yet.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ProtoBuf)]
 pub struct RichTextTypeOptionPB {
     #[pb(index = 1)]
     #[serde(default)]
-    data: String, //It's not used yet
+    data: String,
 }
 impl_type_option!(RichTextTypeOptionPB, FieldType::RichText);
 

--- a/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
@@ -100,15 +100,15 @@ impl GridRevisionEditor {
     ///
     /// * `grid_id`: the id of the grid
     /// * `field_id`: the id of the field
-    /// * `type_option_data`: the updated type-option data.
-    ///
+    /// * `type_option_data`: the updated type-option data. The `type-option` data might be empty
+    /// if there is no type-option config for that field. For example, the `RichTextTypeOptionPB`.
+    ///  
     pub async fn update_field_type_option(
         &self,
         grid_id: &str,
         field_id: &str,
         type_option_data: Vec<u8>,
     ) -> FlowyResult<()> {
-        debug_assert!(!type_option_data.is_empty());
         if type_option_data.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
…a new field