### PR TITLE
fix: several grid ui improvements

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/date_cell/date_cell.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/date_cell/date_cell.dart
@@ -68,7 +68,7 @@ class _DateCellState extends GridCellState<GridDateCell> {
             controller: _popover,
             triggerActions: PopoverTriggerFlags.none,
             direction: PopoverDirection.bottomWithLeftAligned,
-            constraints: BoxConstraints.loose(const Size(320, 500)),
+            constraints: BoxConstraints.loose(const Size(320, 520)),
             margin: EdgeInsets.zero,
             child: SizedBox.expand(
               child: GestureDetector(

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/date.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/date.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import '../../../layout/sizes.dart';
+import '../../common/text_field.dart';
 import '../field_type_option_editor.dart';
 import 'builder.dart';
 
@@ -53,11 +54,14 @@ class DateTypeOptionWidget extends TypeOptionWidget {
         listener: (context, state) =>
             typeOptionContext.typeOption = state.typeOption,
         builder: (context, state) {
-          return Column(children: [
-            _renderDateFormatButton(context, state.typeOption.dateFormat),
-            _renderTimeFormatButton(context, state.typeOption.timeFormat),
-            const _IncludeTimeButton(),
-          ]);
+          return Column(
+            children: [
+              const TypeOptionSeparator(),
+              _renderDateFormatButton(context, state.typeOption.dateFormat),
+              _renderTimeFormatButton(context, state.typeOption.timeFormat),
+              const _IncludeTimeButton(),
+            ],
+          );
         },
       ),
     );

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/number.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/number.dart
@@ -31,7 +31,12 @@ class NumberTypeOptionWidgetBuilder extends TypeOptionWidgetBuilder {
         );
 
   @override
-  Widget? build(BuildContext context) => _widget;
+  Widget? build(BuildContext context) {
+    return Column(children: [
+      const TypeOptionSeparator(),
+      _widget,
+    ]);
+  }
 }
 
 class NumberTypeOptionWidget extends TypeOptionWidget {

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/select_option.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/type_option/select_option.dart
@@ -66,12 +66,17 @@ class OptionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = context.read<AppTheme>();
     return BlocBuilder<SelectOptionTypeOptionBloc, SelectOptionTypeOptionState>(
       builder: (context, state) {
         List<Widget> children = [
-          FlowyText.medium(LocaleKeys.grid_field_optionTitle.tr(), fontSize: 12)
+          FlowyText.medium(
+            LocaleKeys.grid_field_optionTitle.tr(),
+            fontSize: 12,
+            color: theme.shader3,
+          )
         ];
-        if (state.options.isNotEmpty) {
+        if (state.options.isNotEmpty && !state.isEditingOption) {
           children.add(const Spacer());
           children.add(const _OptionTitleButton());
         }


### PR DESCRIPTION
- Add separator in edit property for date and number properties
![image](https://user-images.githubusercontent.com/71320345/197442667-bbd8509f-a54f-4821-bcc0-99f39c62e6b1.png)
![image](https://user-images.githubusercontent.com/71320345/197442729-7f01095d-a174-45c5-ba7a-ce7ee6e39617.png)

- Hide "Add option button" when the input field is shown. Also changed text color of "Options"
![image](https://user-images.githubusercontent.com/71320345/197442924-ac5fc6f9-4737-42f9-89ca-2540eb21c350.png)

- Increase size of appflowy popover for date editor because it gets cut off when "include time" is enabled
![image](https://user-images.githubusercontent.com/71320345/197443561-70a1ca2c-2e5e-44f6-94b9-037d562a300a.png)
