### PR TITLE
fix: NetworkType null safety issues

### DIFF
--- a/frontend/app_flowy/lib/core/network_monitor.dart
+++ b/frontend/app_flowy/lib/core/network_monitor.dart
@@ -40,11 +40,11 @@ class NetworkListener {
           return NetworkType.Ethernet;
         case ConnectivityResult.mobile:
           return NetworkType.Cell;
-        case ConnectivityResult.none:
-          return NetworkType.UnknownNetworkType;
         case ConnectivityResult.bluetooth:
-          return NetworkType.UnknownNetworkType;
+          return NetworkType.Bluetooth;
         case ConnectivityResult.vpn:
+          return NetworkType.VPN;
+        case ConnectivityResult.none:
           return NetworkType.UnknownNetworkType;
       }
     }();

--- a/frontend/app_flowy/lib/core/network_monitor.dart
+++ b/frontend/app_flowy/lib/core/network_monitor.dart
@@ -11,7 +11,8 @@ class NetworkListener {
   late StreamSubscription<ConnectivityResult> _connectivitySubscription;
 
   NetworkListener() {
-    _connectivitySubscription = _connectivity.onConnectivityChanged.listen(_updateConnectionStatus);
+    _connectivitySubscription =
+        _connectivity.onConnectivityChanged.listen(_updateConnectionStatus);
   }
 
   Future<void> start() async {
@@ -42,6 +43,8 @@ class NetworkListener {
         case ConnectivityResult.none:
           return NetworkType.UnknownNetworkType;
         case ConnectivityResult.bluetooth:
+          return NetworkType.UnknownNetworkType;
+        case ConnectivityResult.vpn:
           return NetworkType.UnknownNetworkType;
       }
     }();

--- a/frontend/app_flowy/pubspec.lock
+++ b/frontend/app_flowy/pubspec.lock
@@ -212,12 +212,12 @@ packages:
     source: hosted
     version: "1.2.4"
   connectivity_plus_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.3"
   connectivity_plus_web:
     dependency: transitive
     description:

--- a/frontend/app_flowy/pubspec.yaml
+++ b/frontend/app_flowy/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   # file_picker: ^4.2.1
   clipboard: ^0.1.3
   connectivity_plus: ^2.3.6+1
+  connectivity_plus_platform_interface: ^1.2.2
   easy_localization: ^3.0.0
   textfield_tags: ^2.0.0
   # The following adds the Cupertino Icons font to your application.

--- a/frontend/rust-lib/flowy-net/src/entities/network_state.rs
+++ b/frontend/rust-lib/flowy-net/src/entities/network_state.rs
@@ -6,15 +6,15 @@ pub enum NetworkType {
     Wifi = 1,
     Cell = 2,
     Ethernet = 3,
+    Bluetooth = 4,
+    VPN = 5,
 }
 
 impl NetworkType {
     pub fn is_connect(&self) -> bool {
         match self {
-            NetworkType::UnknownNetworkType => false,
-            NetworkType::Wifi => true,
-            NetworkType::Cell => true,
-            NetworkType::Ethernet => true,
+            NetworkType::UnknownNetworkType | NetworkType::Bluetooth => false,
+            NetworkType::Wifi | NetworkType::Cell | NetworkType::Ethernet | NetworkType::VPN => true,
         }
     }
 }


### PR DESCRIPTION
Networktype returns nulls when the connectivity result is vpn resulting to null safety issues. Implemented a case for when the connectivity result is vpn to resolve this issue.