### PR TITLE
fix: Application name in Windows taskbar.

### DIFF
--- a/frontend/app_flowy/windows/runner/Runner.rc
+++ b/frontend/app_flowy/windows/runner/Runner.rc
@@ -90,7 +90,7 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "A new Flutter project." "\0"
+            VALUE "FileDescription", "app_flowy" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "app_flowy" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2021 com.example. All rights reserved." "\0"

--- a/frontend/app_flowy/windows/runner/Runner.rc
+++ b/frontend/app_flowy/windows/runner/Runner.rc
@@ -90,7 +90,7 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "app_flowy" "\0"
+            VALUE "FileDescription", "AppFlowy" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "app_flowy" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2021 com.example. All rights reserved." "\0"


### PR DESCRIPTION
# Issue
Name of the application was displayed as ``A new flutter project`` in Windows Taskbar when right clicking on the app.

This PR fixes issue #1416 by setting the ``FileDescription`` property to application name.

# Before

![image](https://user-images.githubusercontent.com/57485073/200118007-1632e444-12d3-4031-91e3-2608cbbca822.png)
# After

![image](https://user-images.githubusercontent.com/59292838/201461415-9582dbcd-6542-4392-9501-8fe3addbfa04.png)

# More Info
In any case the description doesn't change for any existing users even after reinstalling. Manually deleting the app_flowy windows registry keys from ``HKEY_CLASSES_ROOT\Local Settings\Software\Microsoft\Windows\Shell\MuiCache`` fixes the issue.