### PR TITLE
fix: divider colors for top and bottom border widgets

### DIFF
--- a/frontend/app_flowy/lib/workspace/presentation/home/home_stack.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/home/home_stack.dart
@@ -219,7 +219,7 @@ class HomeTopBar extends StatelessWidget {
           .padding(
             horizontal: HomeInsets.topBarTitlePadding,
           )
-          .bottomBorder(color: Colors.grey.shade300),
+          .bottomBorder(color: Theme.of(context).dividerColor),
     );
   }
 }

--- a/frontend/app_flowy/lib/workspace/presentation/home/menu/app/create_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/home/menu/app/create_button.dart
@@ -28,7 +28,7 @@ class NewAppButton extends StatelessWidget {
     return SizedBox(
       height: HomeSizes.menuAddButtonHeight,
       child: child,
-    ).topBorder(color: Colors.grey.shade300);
+    ).topBorder(color: Theme.of(context).dividerColor);
   }
 
   Future<void> _showCreateAppDialog(BuildContext context) async {

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/extension.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/extension.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 export 'package:styled_widget/styled_widget.dart';
 
 extension FlowyStyledWidget on Widget {
-  Widget bottomBorder({double width = 0.5, Color color = Colors.grey}) {
+  Widget bottomBorder({double width = 1.0, Color color = Colors.grey}) {
     return Container(
       decoration: BoxDecoration(
         border: Border(
@@ -13,7 +13,7 @@ extension FlowyStyledWidget on Widget {
     );
   }
 
-  Widget topBorder({double width = 0.5, Color color = Colors.grey}) {
+  Widget topBorder({double width = 1.0, Color color = Colors.grey}) {
     return Container(
       decoration: BoxDecoration(
         border: Border(


### PR DESCRIPTION
(sidebar color changed in the screenshot so outlines are visible) 

main:

![image](https://user-images.githubusercontent.com/71320345/202894480-d28106f8-070b-4559-8e94-cc17e2bc01aa.png)

this patch:

![image](https://user-images.githubusercontent.com/71320345/202894438-d524100c-dce7-44ed-afb1-ba647c1f1378.png)
