### PR TITLE
fix: ghost scrollbar in scrollviews using theme's ScrollBarTheme

### DIFF
--- a/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
@@ -165,6 +165,7 @@ class AppTheme {
       primaryIconTheme: IconThemeData(color: hover),
       iconTheme: IconThemeData(color: shader1),
       scrollbarTheme: ScrollbarThemeData(
+        interactive: false,
         thumbColor: MaterialStateProperty.all(Colors.transparent),
       ),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,


### PR DESCRIPTION
There is a ghost scrollbar even after making the thumb transparent. This seems to be the way to do it, as I've also tried setting the thickness to zero, trackVisibility to false and thumbVisibility to false, all to no avail.

https://user-images.githubusercontent.com/71320345/203930676-eb6dcb05-c513-4505-b9fa-e97d6235b3b6.mp4

