### PR TITLE
fix: onPrimary and onPrimaryContainer colors

### DIFF
--- a/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
@@ -178,9 +178,9 @@ class AppTheme {
       colorScheme: ColorScheme(
         brightness: brightness,
         primary: main1,
-        onPrimary: shader7,
+        onPrimary: _white,
         primaryContainer: main2,
-        onPrimaryContainer: shader7,
+        onPrimaryContainer: _white,
         secondary: hover,
         onSecondary: shader1,
         secondaryContainer: selector,


### PR DESCRIPTION
The button text in a widget that has the blue fill color should be white instead of black in dark mode.
Also, sorry for the typo on the commit message