### PR TITLE
[FR] Create a new yellow theme for AppFlowy

### DIFF
--- a/frontend/app_flowy/lib/plugins/board/application/card/board_text_cell_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/board/application/card/board_text_cell_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:app_flowy/plugins/grid/application/cell/cell_service/cell_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'dart:async';

--- a/frontend/app_flowy/lib/plugins/board/presentation/board_page.dart
+++ b/frontend/app_flowy/lib/plugins/board/presentation/board_page.dart
@@ -20,7 +20,6 @@ import 'package:flowy_sdk/protobuf/flowy-grid/block_entities.pb.dart';
 import 'package:flowy_sdk/protobuf/flowy-grid/field_entities.pb.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../../grid/application/row/row_cache.dart';
 import '../application/board_bloc.dart';
 import 'card/card.dart';
 import 'card/card_cell_builder.dart';

--- a/frontend/app_flowy/lib/plugins/grid/application/field/field_service.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/field/field_service.dart
@@ -3,7 +3,6 @@ import 'package:flowy_sdk/dispatch/dispatch.dart';
 import 'package:flowy_sdk/protobuf/flowy-error/errors.pb.dart';
 import 'package:flowy_sdk/protobuf/flowy-grid/field_entities.pb.dart';
 import 'package:flowy_sdk/protobuf/flowy-grid/grid_entities.pb.dart';
-import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'field_service.freezed.dart';

--- a/frontend/app_flowy/lib/workspace/application/appearance.dart
+++ b/frontend/app_flowy/lib/workspace/application/appearance.dart
@@ -26,12 +26,12 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
 
   /// Updates the current theme and notify the listeners the theme was changed.
   /// Do nothing if the passed in themeType equal to the current theme type.
-  void setTheme(Brightness brightness) {
-    if (state.theme.brightness == brightness) {
+  void setTheme(ThemeType themeType) {
+    if (state.theme.brightness == themeType) {
       return;
     }
 
-    _setting.theme = themeTypeToString(brightness);
+    _setting.theme = themeTypeToString(themeType);
     _saveAppearanceSettings();
 
     emit(state.copyWith(

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -47,7 +47,7 @@ class SettingsAppearanceView extends StatelessWidget {
       case ThemeType.dark:
         return LocaleKeys.settings_appearance_darkLabel.tr();
       case ThemeType.anne:
-        return "Anne";
+        return "Anne Mode";
       default:
         return "Try Me";
     }

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -1,12 +1,9 @@
 import 'package:app_flowy/generated/locale_keys.g.dart';
 import 'package:app_flowy/workspace/application/appearance.dart';
-import 'package:app_flowy/workspace/presentation/widgets/toggle/toggle_style.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flowy_infra_ui/style_widget/text.dart';
+import 'package:flowy_infra/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import '../../widgets/toggle/toggle.dart';
 
 class SettingsAppearanceView extends StatelessWidget {
   const SettingsAppearanceView({Key? key}) : super(key: key);
@@ -17,27 +14,46 @@ class SettingsAppearanceView extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              FlowyText.medium(LocaleKeys.settings_appearance_lightLabel.tr()),
-              Toggle(
-                value: Theme.of(context).brightness == Brightness.dark,
-                onChanged: (_) => setTheme(context),
-                style: ToggleStyle.big,
-              ),
-              FlowyText.medium(LocaleKeys.settings_appearance_darkLabel.tr())
-            ],
+          SizedBox(
+            height: 500,
+            child: ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: ThemeType.values.length,
+              itemBuilder: (context, index) {
+                final itemAppTheme = ThemeType.values[index];
+                return Card(
+                  color: Colors.amber,
+                  child: ListTile(
+                    title: Text(
+                      getThemeName(itemAppTheme),
+                    ),
+                    onTap: () {
+                      setTheme(context, itemAppTheme);
+                    },
+                  ),
+                );
+              },
+            ),
           ),
         ],
       ),
     );
   }
 
-  void setTheme(BuildContext context) {
-    if (Theme.of(context).brightness == Brightness.dark) {
-      context.read<AppearanceSettingsCubit>().setTheme(Brightness.light);
-    } else {
-      context.read<AppearanceSettingsCubit>().setTheme(Brightness.dark);
+  String getThemeName(ThemeType ty) {
+    switch (ty) {
+      case ThemeType.light:
+        return LocaleKeys.settings_appearance_lightLabel.tr();
+      case ThemeType.dark:
+        return LocaleKeys.settings_appearance_darkLabel.tr();
+      case ThemeType.anne:
+        return "Anne";
+      default:
+        return "Try Me";
     }
+  }
+
+  void setTheme(BuildContext context, ThemeType ty) {
+    context.read<AppearanceSettingsCubit>().setTheme(ty);
   }
 }

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -53,19 +53,6 @@ class SettingsAppearanceView extends StatelessWidget {
     }
   }
 
-  Color getCardColor(ThemeType ty) {
-    switch (ty) {
-      case ThemeType.light:
-        return const Color(0xfff7f8fc);
-      case ThemeType.dark:
-        return const Color(0xff000000);
-      case ThemeType.anne:
-        return const Color(0xFFFFCE31);
-      default:
-        return const Color(0xffedeef2);
-    }
-  }
-
   void setTheme(BuildContext context, ThemeType ty) {
     context.read<AppearanceSettingsCubit>().setTheme(ty);
   }

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -22,7 +22,7 @@ class SettingsAppearanceView extends StatelessWidget {
               itemBuilder: (context, index) {
                 final itemAppTheme = ThemeType.values[index];
                 return Card(
-                  color: Colors.amber,
+                  color: getCardColor(itemAppTheme),
                   child: ListTile(
                     title: Text(
                       getThemeName(itemAppTheme),
@@ -50,6 +50,19 @@ class SettingsAppearanceView extends StatelessWidget {
         return "Anne";
       default:
         return "Try Me";
+    }
+  }
+
+  Color getCardColor(ThemeType ty) {
+    switch (ty) {
+      case ThemeType.light:
+        return const Color(0xfff7f8fc);
+      case ThemeType.dark:
+        return const Color(0xff000000);
+      case ThemeType.anne:
+        return const Color(0xFFFFCE31);
+      default:
+        return const Color(0xffedeef2);
     }
   }
 

--- a/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_user_view.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/settings/widgets/settings_user_view.dart
@@ -79,7 +79,7 @@ class _CurrentIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    _setIcon(String iconUrl) {
+    setIcon(String iconUrl) {
       context
           .read<SettingsUserViewBloc>()
           .add(SettingsUserEvent.updateUserIcon(iconUrl));
@@ -100,7 +100,7 @@ class _CurrentIcon extends StatelessWidget {
                     ),
                     children: <Widget>[
                       SizedBox(
-                          height: 300, width: 300, child: IconGallery(_setIcon))
+                          height: 300, width: 300, child: IconGallery(setIcon))
                     ]);
               },
             );

--- a/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_button.dart
+++ b/frontend/app_flowy/lib/workspace/presentation/widgets/emoji_picker/src/emoji_button.dart
@@ -4,7 +4,6 @@ import 'package:app_flowy/workspace/presentation/widgets/emoji_picker/emoji_pick
 class FlowyEmojiStyleButton extends StatefulWidget {
   // final Attribute attribute;
   final String normalIcon;
-  // TODO: enable insert emoji in appflowy_editor
   // final QuillController controller;
   final String tooltipText;
 

--- a/frontend/app_flowy/packages/appflowy_board/lib/src/rendering/board_overlay.dart
+++ b/frontend/app_flowy/packages/appflowy_board/lib/src/rendering/board_overlay.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';

--- a/frontend/app_flowy/packages/appflowy_editor_plugins/lib/src/code_block/code_block_node_widget.dart
+++ b/frontend/app_flowy/packages/appflowy_editor_plugins/lib/src/code_block/code_block_node_widget.dart
@@ -162,7 +162,7 @@ class __CodeBlockNodeWidgeState extends State<_CodeBlockNodeWidge>
     var currentSpans = spans;
     List<List<TextSpan>> stack = [];
 
-    _traverse(highlight.Node node) {
+    traverse(highlight.Node node) {
       if (node.value != null) {
         currentSpans.add(node.className == null
             ? TextSpan(text: node.value)
@@ -177,7 +177,7 @@ class __CodeBlockNodeWidgeState extends State<_CodeBlockNodeWidge>
         currentSpans = tmp;
 
         for (var n in node.children!) {
-          _traverse(n);
+          traverse(n);
           if (n == node.children!.last) {
             currentSpans = stack.isEmpty ? spans : stack.removeLast();
           }
@@ -186,7 +186,7 @@ class __CodeBlockNodeWidgeState extends State<_CodeBlockNodeWidge>
     }
 
     for (var node in nodes) {
-      _traverse(node);
+      traverse(node);
     }
 
     return spans;

--- a/frontend/app_flowy/packages/appflowy_editor_plugins/lib/src/math_ equation/math_equation_node_widget.dart
+++ b/frontend/app_flowy/packages/appflowy_editor_plugins/lib/src/math_ equation/math_equation_node_widget.dart
@@ -6,7 +6,6 @@ import 'package:flutter_math_fork/flutter_math.dart';
 const String kMathEquationType = 'math_equation';
 const String kMathEquationAttr = 'math_equation';
 
-// TODO: l10n
 SelectionMenuItem mathEquationMenuItem = SelectionMenuItem(
   name: () => 'Math Equation',
   icon: (editorState, onSelected) => Icon(

--- a/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
@@ -4,20 +4,26 @@ import 'package:flutter/material.dart';
 
 import 'color_extension.dart';
 
-Brightness themeTypeFromString(String name) {
-  Brightness themeType = Brightness.light;
+enum ThemeType { light, dark, anne }
+
+ThemeType themeTypeFromString(String name) {
+  ThemeType themeType = ThemeType.light;
   if (name == "dark") {
-    themeType = Brightness.dark;
+    themeType = ThemeType.dark;
+  } else if (name == "anne") {
+    themeType = ThemeType.anne;
   }
   return themeType;
 }
 
-String themeTypeToString(Brightness brightness) {
-  switch (brightness) {
-    case Brightness.light:
+String themeTypeToString(ThemeType themeType) {
+  switch (themeType) {
+    case ThemeType.light:
       return "light";
-    case Brightness.dark:
+    case ThemeType.dark:
       return "dark";
+    case ThemeType.anne:
+      return "anne";
   }
 }
 
@@ -79,7 +85,7 @@ class AppTheme {
     required String monospaceFont,
   }) {
     switch (themeTypeFromString(themeName)) {
-      case Brightness.light:
+      case ThemeType.light:
         return AppTheme(brightness: Brightness.light)
           ..surface = Colors.white
           ..hover = const Color(0xFFe0f8ff)
@@ -116,7 +122,7 @@ class AppTheme {
           ..font = font
           ..monospaceFont = monospaceFont;
 
-      case Brightness.dark:
+      case ThemeType.dark:
         return AppTheme(brightness: Brightness.dark)
           ..surface = const Color(0xff292929)
           ..hover = const Color(0xff1f1f1f)
@@ -148,6 +154,42 @@ class AppTheme {
           ..main2 = const Color(0xff009cc7)
           ..textColor = _white
           ..iconColor = _white
+          ..shadow = _black
+          ..disableIconColor = const Color(0xff333333)
+          ..font = font
+          ..monospaceFont = monospaceFont;
+      case ThemeType.anne:
+        return AppTheme(brightness: Brightness.light)
+          ..surface = Colors.white
+          ..hover = const Color(0xFFe0f8ff) //
+          ..selector = const Color(0xfff2fcff)
+          ..red = const Color(0xfffb006d)
+          ..yellow = const Color(0xffffd667)
+          ..green = const Color(0xff66cf80)
+          ..shader1 = const Color(0xff333333)
+          ..shader2 = const Color(0xff4f4f4f)
+          ..shader3 = const Color(0xff828282)
+          ..shader4 = const Color(0xffbdbdbd)
+          ..shader5 = const Color(0xffe0e0e0)
+          ..shader6 = const Color(0xfff2f2f2)
+          ..shader7 = const Color(0xffffffff)
+          ..bg1 = const Color(0xFFFFCE31)
+          ..bg2 = const Color(0xffedeef2)
+          ..bg3 = const Color(0xffe2e4eb)
+          ..bg4 = const Color(0xff2c144b)
+          ..tint1 = const Color(0xffe8e0ff)
+          ..tint2 = const Color(0xffffe7fd)
+          ..tint3 = const Color(0xffffe7ee)
+          ..tint4 = const Color(0xffffefe3)
+          ..tint5 = const Color(0xfffff2cd)
+          ..tint6 = const Color(0xfff5ffdc)
+          ..tint7 = const Color(0xffddffd6)
+          ..tint8 = const Color(0xffdefff1)
+          ..tint9 = const Color(0xffe1fbff)
+          ..main1 = const Color(0xffe21f74)
+          ..main2 = const Color(0xffe21f74)
+          ..textColor = _black
+          ..iconColor = const Color(0xff9327ff)
           ..shadow = _black
           ..disableIconColor = const Color(0xff333333)
           ..font = font

--- a/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
+++ b/frontend/app_flowy/packages/flowy_infra/lib/theme.dart
@@ -6,6 +6,19 @@ import 'color_extension.dart';
 
 enum ThemeType { light, dark, anne }
 
+Color getCardColor(ThemeType ty) {
+  switch (ty) {
+    case ThemeType.light:
+      return const Color.fromARGB(255, 214, 214, 218);
+    case ThemeType.dark:
+      return const Color(0xff000000);
+    case ThemeType.anne:
+      return const Color(0xFFFFCE31);
+    default:
+      return const Color.fromARGB(255, 214, 214, 218);
+  }
+}
+
 ThemeType themeTypeFromString(String name) {
   ThemeType themeType = ThemeType.light;
   if (name == "dark") {
@@ -187,7 +200,7 @@ class AppTheme {
           ..tint8 = const Color(0xffdefff1)
           ..tint9 = const Color(0xffe1fbff)
           ..main1 = const Color(0xffe21f74)
-          ..main2 = const Color(0xffe21f74)
+          ..main2 = const Color.fromARGB(255, 224, 25, 111)
           ..textColor = _black
           ..iconColor = const Color(0xff9327ff)
           ..shadow = _black

--- a/frontend/app_flowy/packages/flowy_infra_ui/flowy_infra_ui_platform_interface/lib/src/method_channel_flowy_infra_ui.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/flowy_infra_ui_platform_interface/lib/src/method_channel_flowy_infra_ui.dart
@@ -1,16 +1,16 @@
 import 'package:flowy_infra_ui_platform_interface/flowy_infra_ui_platform_interface.dart';
 import 'package:flutter/services.dart';
 
-import '../flowy_infra_ui_platform_interface.dart';
-
 // ignore_for_file: constant_identifier_names
 const INFRA_UI_METHOD_CHANNEL_NAME = 'flowy_infra_ui_method';
 const INFRA_UI_KEYBOARD_EVENT_CHANNEL_NAME = 'flowy_infra_ui_event/keyboard';
 const INFRA_UI_METHOD_GET_PLATFORM_VERSION = 'getPlatformVersion';
 
 class MethodChannelFlowyInfraUI extends FlowyInfraUIPlatform {
-  final MethodChannel _methodChannel = const MethodChannel(INFRA_UI_METHOD_CHANNEL_NAME);
-  final EventChannel _keyboardChannel = const EventChannel(INFRA_UI_KEYBOARD_EVENT_CHANNEL_NAME);
+  final MethodChannel _methodChannel =
+      const MethodChannel(INFRA_UI_METHOD_CHANNEL_NAME);
+  final EventChannel _keyboardChannel =
+      const EventChannel(INFRA_UI_KEYBOARD_EVENT_CHANNEL_NAME);
 
   late final Stream<bool> _onKeyboardVisibilityChange =
       _keyboardChannel.receiveBroadcastStream().map((event) => event as bool);
@@ -20,7 +20,8 @@ class MethodChannelFlowyInfraUI extends FlowyInfraUIPlatform {
 
   @override
   Future<String> getPlatformVersion() async {
-    String? version = await _methodChannel.invokeMethod<String>(INFRA_UI_METHOD_GET_PLATFORM_VERSION);
+    String? version = await _methodChannel
+        .invokeMethod<String>(INFRA_UI_METHOD_GET_PLATFORM_VERSION);
     return version ?? 'unknow';
   }
 }


### PR DESCRIPTION
## Description

### Solves #1475 
### Tasks

- [x] Create a mechanism to select from multiple theme options
- [x] Create a new all-colored theme that utilizes all the colors in AppFlowy's logo.


### Impact

### _The previous AppFlowys app only allowed two themes. This theme control was taken care of by the following approach:_
1. User opens the settings page where he can toggle between the light theme and dark theme.

### _After the PR is merged, changing the theme will be handled in the following steps:_
1. User opens the settings page where he sees a list of different themes, from which he selects any one.

### _Adding more themes will become much easier._

#### Naming
This PR adds a new ThemeType to the app. It adds the requested yellow theme. I have named the theme "Anne" because when I showed her a bunch of themes, this was the theme she liked the most. Also, she has been very supportive and welcoming during my journey of making my first contribution to AppFlowy. This is my way of saying Thanks.




