### PR TITLE
fix: location of popover wrt the grid cell (select and checklist)

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/checklist_cell/checklist_cell.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/checklist_cell/checklist_cell.dart
@@ -40,10 +40,7 @@ class GridChecklistCellState extends State<GridChecklistCell> {
         alignment: AlignmentDirectional.center,
         fit: StackFit.expand,
         children: [
-          Padding(
-            padding: GridSize.cellContentInsets,
-            child: _wrapPopover(const ChecklistProgressBar()),
-          ),
+          _wrapPopover(const ChecklistProgressBar()),
           InkWell(onTap: () => _popover.show()),
         ],
       ),
@@ -66,7 +63,10 @@ class GridChecklistCellState extends State<GridChecklistCell> {
         );
       },
       onClose: () => widget.onCellEditing.value = false,
-      child: child,
+      child: Padding(
+        padding: GridSize.cellContentInsets,
+        child: child,
+      ),
     );
   }
 }

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/select_option_cell/select_option_cell.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/select_option_cell/select_option_cell.dart
@@ -168,10 +168,7 @@ class _SelectOptionWrapState extends State<SelectOptionWrap> {
       alignment: AlignmentDirectional.center,
       fit: StackFit.expand,
       children: [
-        Padding(
-          padding: GridSize.cellContentInsets,
-          child: _wrapPopover(child),
-        ),
+        _wrapPopover(child),
         InkWell(onTap: () => _popover.show()),
       ],
     );
@@ -196,7 +193,10 @@ class _SelectOptionWrapState extends State<SelectOptionWrap> {
         );
       },
       onClose: () => widget.onFocus?.call(false),
-      child: child,
+      child: Padding(
+        padding: GridSize.cellContentInsets,
+        child: child,
+      ),
     );
   }
 


### PR DESCRIPTION
| before | after |
| :---:| :-----:|
|![before](https://user-images.githubusercontent.com/71320345/206192780-caf1af89-7ec3-4cba-91d6-bfc0de37abdf.png) | ![image](https://user-images.githubusercontent.com/71320345/206192618-c55584dc-5f2d-4293-bd1f-9e6959fafe78.png) |


