### PR TITLE
Refactor linux workflow & fix 1503

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,15 +78,7 @@ jobs:
           mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/usr/share/applications
           cp -r ./scripts/linux_installer ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
           cd ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
-          # Create control file
-          printf 'Package: AppFlowy
-          Version: %s
-          Depends: libkeybinder-3.0-0
-          Architecture: amd64
-          Essential: no
-          Priority: optional
-          Maintainer: AppFlowy
-          Description: An Open Source Alternative to Notion\n' "${{ github.ref_name }}" > control
+          grep -rl "\[CHANGE_THIS\]" ./control | xargs sed -i "s/\[CHANGE_THIS\]/${{ github.ref_name }}/"
           chmod 0755 {postinst,postrm}
 
       - name: Build Linux package
@@ -171,15 +163,7 @@ jobs:
           mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/usr/share/applications
           cp -r ./scripts/linux_installer ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
           cd ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
-          # Create control file
-          printf 'Package: AppFlowy
-          Version: %s
-          Depends: libkeybinder-3.0-0
-          Architecture: amd64
-          Essential: no
-          Priority: optional
-          Maintainer: AppFlowy
-          Description: An Open Source Alternative to Notion\n' "${{ github.ref_name }}" > control
+          grep -rl "\[CHANGE_THIS\]" ./control | xargs sed -i "s/\[CHANGE_THIS\]/${{ github.ref_name }}/"
           chmod 0755 {postinst,postrm}
 
       - name: Build Linux package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,13 @@ jobs:
           flutter config --enable-linux-desktop
           cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-linux-x86_64 appflowy
 
-      - name: Build Linux package
-        working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}
+      - name: Configuring Linux Package
+        working-directory: frontend
         run: |
-          mkdir -p package/opt && mv AppFlowy package/opt/
-          cd package && mkdir DEBIAN
+          mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/opt
+          mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/usr/share/applications
+          cp -r ./scripts/linux_installer ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
+          cd ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
           # Create control file
           printf 'Package: AppFlowy
           Version: %s
@@ -83,33 +85,22 @@ jobs:
           Essential: no
           Priority: optional
           Maintainer: AppFlowy
-          Description: An Open Source Alternative to Notion\n' "${{ github.ref_name }}" > DEBIAN/control
+          Description: An Open Source Alternative to Notion\n' "${{ github.ref_name }}" > control
+          chmod 0755 {postinst,postrm}
 
-          # postinst script for creating symlink
-          printf '#!/bin/bash
-          if [ -e /usr/local/bin/appflowy ]; then
-            echo "Symlink already exists, skipping."
-          else
-            echo "Creating Symlink in /usr/local/bin/appflowy"
-            ln -s /opt/AppFlowy/app_flowy /usr/local/bin/appflowy
-          fi' > DEBIAN/postinst
-          chmod 0755 DEBIAN/postinst
+      - name: Build Linux package
+        working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}
+        run: |
+          mv AppFlowy package/opt/
+          cd package
 
-          # postrm script for cleaning up residuals
-          printf '#!/bin/bash
-          if [ -e /usr/local/bin/appflowy ]; then
-            rm /usr/local/bin/appflowy
-          fi' > DEBIAN/postrm
-          chmod 0755 DEBIAN/postrm
-
-          mkdir -p usr/share/applications
           # Update Exec & icon path in desktop entry
           grep -rl "\[CHANGE_THIS\]" ./opt/AppFlowy/appflowy.desktop.temp | xargs sed -i "s/\[CHANGE_THIS\]/\/opt/"
           # Add desktop entry in package
           mv ./opt/AppFlowy/appflowy.desktop.temp ./usr/share/applications/appflowy.desktop
 
           # Build
-          cd ../ && dpkg-deb --build --root-owner-group package ${{ env.LINUX_PACKAGE_NAME }}
+          cd ../ && dpkg-deb --build --root-owner-group -Z xz package ${{ env.LINUX_PACKAGE_NAME }}
 
       - name: Upload Release Asset
         id: upload-release-asset
@@ -123,6 +114,87 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Release Asset Install Package
+        id: upload-release-asset-install-package
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.LINUX_APP_RELEASE_PATH }}/${{ env.LINUX_PACKAGE_NAME }}
+          asset_name: ${{ env.LINUX_PACKAGE_NAME }}
+          asset_content_type: application/octet-stream
+
+  build-linux-x86-alt:
+    runs-on: ubuntu-18.04
+    needs: create-release
+    env:
+      LINUX_APP_RELEASE_PATH: frontend/app_flowy/product/${{ github.ref_name }}/linux/Release
+      LINUX_PACKAGE_NAME: AppFlowy_${{ github.ref_name }}_linux-amd64-alt.deb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup environment - Rust and Cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 'stable-2022-04-07'
+
+      - name: Setup environment - Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.0.5'
+
+      - name: Pre build
+        working-directory: frontend
+        run: |
+          sudo wget -qO /etc/apt/trusted.gpg.d/dart_linux_signing_key.asc https://dl-ssl.google.com/linux/linux_signing_key.pub
+          sudo apt-get update
+          sudo apt-get install -y build-essential libsqlite3-dev libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev
+          sudo apt-get install keybinder-3.0
+          source $HOME/.cargo/env
+          cargo install --force cargo-make
+          cargo install --force duckscript_cli
+          cargo make appflowy-deps-tools
+
+      - name: Build Linux app
+        working-directory: frontend
+        run: |
+          flutter config --enable-linux-desktop
+          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-linux-x86_64 appflowy
+
+      - name: Configuring Linux Package
+        working-directory: frontend
+        run: |
+          mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/opt
+          mkdir -p ../${{ env.LINUX_APP_RELEASE_PATH }}/package/usr/share/applications
+          cp -r ./scripts/linux_installer ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
+          cd ../${{ env.LINUX_APP_RELEASE_PATH }}/package/DEBIAN
+          # Create control file
+          printf 'Package: AppFlowy
+          Version: %s
+          Architecture: amd64
+          Essential: no
+          Priority: optional
+          Maintainer: AppFlowy
+          Description: An Open Source Alternative to Notion\n' "${{ github.ref_name }}" > control
+          chmod 0755 {postinst,postrm}
+
+      - name: Build Linux package
+        working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}
+        run: |
+          mv AppFlowy package/opt/
+          cd package
+
+          # Update Exec & icon path in desktop entry
+          grep -rl "\[CHANGE_THIS\]" ./opt/AppFlowy/appflowy.desktop.temp | xargs sed -i "s/\[CHANGE_THIS\]/\/opt/"
+          # Add desktop entry in package
+          mv ./opt/AppFlowy/appflowy.desktop.temp ./usr/share/applications/appflowy.desktop
+
+          # Build
+          cd ../ && dpkg-deb --build --root-owner-group -Z xz package ${{ env.LINUX_PACKAGE_NAME }}
+
+      - name: Upload Alternative Release Asset Install Package
         id: upload-release-asset-install-package
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
           # Create control file
           printf 'Package: AppFlowy
           Version: %s
+          Depends: libkeybinder-3.0-0
           Architecture: amd64
           Essential: no
           Priority: optional
@@ -173,6 +174,7 @@ jobs:
           # Create control file
           printf 'Package: AppFlowy
           Version: %s
+          Depends: libkeybinder-3.0-0
           Architecture: amd64
           Essential: no
           Priority: optional

--- a/frontend/scripts/linux_installer/control
+++ b/frontend/scripts/linux_installer/control
@@ -1,0 +1,8 @@
+Package: AppFlowy
+Version: [CHANGE_THIS]
+Depends: libkeybinder-3.0-0
+Architecture: amd64
+Essential: no
+Priority: optional
+Maintainer: AppFlowy
+Description: An Open Source Alternative to Notion

--- a/frontend/scripts/linux_installer/postinst
+++ b/frontend/scripts/linux_installer/postinst
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ -e /usr/local/bin/appflowy ]; then
+echo "Symlink already exists, skipping."
+else
+echo "Creating Symlink in /usr/local/bin/appflowy"
+ln -s /opt/AppFlowy/app_flowy /usr/local/bin/appflowy
+fi

--- a/frontend/scripts/linux_installer/postrm
+++ b/frontend/scripts/linux_installer/postrm
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [ -e /usr/local/bin/appflowy ]; then
+rm /usr/local/bin/appflowy
+fi


### PR DESCRIPTION
Following PR aims to fix #1503 by refactoring the linux build workflow in CI to be less verbose by moving ``postrm`` and ``postinst`` package scripts from CI workflow to ``scripts/linux_installer`` as all of the other OSes installer assets and scripts live there.

It also includes an additional workflow named ``build-linux-x86-alt`` with ``ubuntu-18.04`` runner image to build an alternate deb package. The following workflow should only be used temporarily as a workaround to support older debian based distributions where ``GLIBC < 2.34``, see #1503.
