### PR TITLE
test: grid switch from multi select to text test

### DIFF
--- a/frontend/rust-lib/flowy-grid/tests/grid/field_test/test.rs
+++ b/frontend/rust-lib/flowy-grid/tests/grid/field_test/test.rs
@@ -202,7 +202,32 @@ async fn grid_switch_from_checkbox_to_select_option_test() {
 // input:
 //      option1, option2 -> "option1.name, option2.name"
 #[tokio::test]
-async fn grid_switch_from_multi_select_to_text_test() {}
+async fn grid_switch_from_multi_select_to_text_test() {
+    let mut test = GridFieldTest::new().await;
+    let field_rev = test.get_first_field_rev(FieldType::MultiSelect).clone();
+
+    let mut multi_select_type_option = test.get_multi_select_type_option(&field_rev.id);
+
+    let script_switchfield = vec![SwitchToField {
+        field_id: field_rev.id.clone(),
+        new_field_type: FieldType::RichText,
+    }];
+
+    test.run_scripts(script_switchfield).await;
+
+    let script_assertfield = vec![AssertCellContent {
+        field_id: field_rev.id.clone(),
+        row_index: 0,
+        from_field_type: FieldType::MultiSelect,
+        expected_content: format!(
+            "{},{}",
+            multi_select_type_option.get_mut(0).unwrap().id.to_string(),
+            multi_select_type_option.get_mut(1).unwrap().id.to_string()
+        ),
+    }];
+
+    test.run_scripts(script_assertfield).await;
+}
 
 // Test when switching the current field from Checkbox to Text test
 // input:


### PR DESCRIPTION
@appflowy could you please help me review this unit test,
somehow, the ".name" method doesn't return the name of options in multi selection type. So i use the ".id" method, then the test case was passed.