### PR TITLE
chore: pass hover events through the popover mask

### DIFF
--- a/frontend/app_flowy/packages/appflowy_popover/lib/src/mask.dart
+++ b/frontend/app_flowy/packages/appflowy_popover/lib/src/mask.dart
@@ -107,10 +107,11 @@ class _PopoverMaskState extends State<PopoverMask> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: widget.onTap,
-      child: Container(
-        decoration: widget.decoration,
+    return MouseRegion(
+      opaque: false,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: Container(decoration: widget.decoration),
       ),
     );
   }


### PR DESCRIPTION
Title says all. Currently blocked since most other input events are also passed in addition to hover (drag, right click, double click, etc.) And whether this is a behavior we'd like to see is also debatable.