### PR TITLE
feat: handling same as Notion when user fills in the mixing of number and text

### DIFF
--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/number_type_option/number_type_option.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/number_type_option/number_type_option.rs
@@ -11,6 +11,7 @@ use fancy_regex::Regex;
 use flowy_derive::ProtoBuf;
 use flowy_error::FlowyResult;
 use grid_rev_model::{FieldRevision, TypeOptionDataDeserializer, TypeOptionDataSerializer};
+use lazy_static::lazy_static;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -99,8 +100,7 @@ impl NumberTypeOptionPB {
     pub(crate) fn format_cell_data(&self, s: &str) -> FlowyResult<NumberCellData> {
         match self.format {
             NumberFormat::Num => {
-                let re = Regex::new(r"[^\d\.]").unwrap();
-                let strnum = re.replace_all(s, "");
+                let strnum = NUM_REGEX.replace_all(s, "");
                 match Decimal::from_str(&strnum) {
                     Ok(value, ..) => Ok(NumberCellData::from_decimal(value)),
                     Err(_) => Ok(NumberCellData::new()),
@@ -209,4 +209,8 @@ impl std::default::Default for NumberTypeOptionPB {
             name: "Number".to_string(),
         }
     }
+}
+
+lazy_static! {
+    static ref NUM_REGEX: Regex = Regex::new(r"[^\d\.]").unwrap();
 }

--- a/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
@@ -510,6 +510,7 @@ impl GridRevisionEditor {
                 // Update the changeset.data property with the return value.
                 let type_cell_data =
                     apply_cell_data_changeset(cell_changeset, cell_rev, field_rev, Some(self.cell_data_cache.clone()))?;
+                tracing::trace!("xxxxxxxxxxxx:: {}", type_cell_data);
                 let cell_changeset = CellChangesetPB {
                     grid_id: self.grid_id.clone(),
                     row_id: row_id.to_owned(),

--- a/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/grid_editor.rs
@@ -510,7 +510,6 @@ impl GridRevisionEditor {
                 // Update the changeset.data property with the return value.
                 let type_cell_data =
                     apply_cell_data_changeset(cell_changeset, cell_rev, field_rev, Some(self.cell_data_cache.clone()))?;
-                tracing::trace!("xxxxxxxxxxxx:: {}", type_cell_data);
                 let cell_changeset = CellChangesetPB {
                     grid_id: self.grid_id.clone(),
                     row_id: row_id.to_owned(),


### PR DESCRIPTION
@appflowy could you please help me review this change
i tried to modify the code to achieve the same behaviours like Notion app for Number type.

the only problem is when i fill in the text under Number type, the backend in Rust processes as an empty string which is correct, But the frontend still display the string on the cell instead of empty the cell.