### PR TITLE
fix: update the cell content if input is not valid data

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/date_cal_bloc.dart
@@ -102,7 +102,7 @@ class DateCalBloc extends Bloc<DateCalEvent, DateCalState> {
       }
     }
 
-    cellController.saveCellData(newCalData, resultCallback: (result) {
+    cellController.saveCellData(newCalData, onFinish: (result) {
       result.fold(
         () => updateCalData(Some(newCalData), none()),
         (err) {

--- a/frontend/app_flowy/lib/plugins/grid/application/cell/number_cell_bloc.dart
+++ b/frontend/app_flowy/lib/plugins/grid/application/cell/number_cell_bloc.dart
@@ -1,8 +1,7 @@
-import 'package:flowy_sdk/protobuf/flowy-error/errors.pb.dart';
+import 'package:flowy_sdk/log.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'dart:async';
-import 'package:dartz/dartz.dart';
 import 'cell_service/cell_service.dart';
 
 part 'number_cell_bloc.freezed.dart';
@@ -20,20 +19,19 @@ class NumberCellBloc extends Bloc<NumberCellEvent, NumberCellState> {
           initial: () {
             _startListening();
           },
-          didReceiveCellUpdate: (content) {
-            emit(state.copyWith(content: content));
+          didReceiveCellUpdate: (cellContent) {
+            emit(state.copyWith(cellContent: cellContent ?? ""));
           },
           updateCell: (text) {
-            cellController.saveCellData(text, resultCallback: (result) {
-              result.fold(
-                () => null,
-                (err) {
-                  if (!isClosed) {
-                    add(NumberCellEvent.didReceiveCellUpdate(right(err)));
-                  }
-                },
-              );
-            });
+            if (state.cellContent != text) {
+              emit(state.copyWith(cellContent: text));
+              cellController.saveCellData(text, onFinish: (result) {
+                result.fold(
+                  () {},
+                  (err) => Log.error(err),
+                );
+              });
+            }
           },
         );
       },
@@ -51,13 +49,22 @@ class NumberCellBloc extends Bloc<NumberCellEvent, NumberCellState> {
   }
 
   void _startListening() {
-    _onCellChangedFn = cellController.startListening(
-      onCellChanged: ((cellContent) {
-        if (!isClosed) {
-          add(NumberCellEvent.didReceiveCellUpdate(left(cellContent ?? "")));
-        }
-      }),
-    );
+    _onCellChangedFn =
+        cellController.startListening(onCellChanged: ((cellContent) {
+      if (!isClosed) {
+        add(NumberCellEvent.didReceiveCellUpdate(cellContent));
+      }
+    }), listenWhenOnCellChanged: (oldValue, newValue) {
+      // If the new value is not the same as the content, which means the
+      // backend formatted the content that user enter. For example:
+      //
+      // state.cellContent: "abc"
+      // oldValue: ""
+      // newValue: ""
+      // The oldValue is the same as newValue. So the [onCellChanged] won't
+      // get called. So just return true to refresh the cell content
+      return true;
+    });
   }
 }
 
@@ -65,20 +72,19 @@ class NumberCellBloc extends Bloc<NumberCellEvent, NumberCellState> {
 class NumberCellEvent with _$NumberCellEvent {
   const factory NumberCellEvent.initial() = _Initial;
   const factory NumberCellEvent.updateCell(String text) = _UpdateCell;
-  const factory NumberCellEvent.didReceiveCellUpdate(
-      Either<String, FlowyError> cellContent) = _DidReceiveCellUpdate;
+  const factory NumberCellEvent.didReceiveCellUpdate(String? cellContent) =
+      _DidReceiveCellUpdate;
 }
 
 @freezed
 class NumberCellState with _$NumberCellState {
   const factory NumberCellState({
-    required Either<String, FlowyError> content,
+    required String cellContent,
   }) = _NumberCellState;
 
   factory NumberCellState.initial(GridCellController context) {
-    final cellContent = context.getCellData() ?? "";
     return NumberCellState(
-      content: left(cellContent),
+      cellContent: context.getCellData() ?? "",
     );
   }
 }

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/number_cell.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/cell/number_cell.dart
@@ -29,8 +29,7 @@ class _NumberCellState extends GridFocusNodeCellState<GridNumberCell> {
     final cellController = widget.cellControllerBuilder.build();
     _cellBloc = getIt<NumberCellBloc>(param1: cellController)
       ..add(const NumberCellEvent.initial());
-    _controller =
-        TextEditingController(text: contentFromState(_cellBloc.state));
+    _controller = TextEditingController(text: _cellBloc.state.cellContent);
     super.initState();
   }
 
@@ -41,9 +40,8 @@ class _NumberCellState extends GridFocusNodeCellState<GridNumberCell> {
       child: MultiBlocListener(
         listeners: [
           BlocListener<NumberCellBloc, NumberCellState>(
-            listenWhen: (p, c) => p.content != c.content,
-            listener: (context, state) =>
-                _controller.text = contentFromState(state),
+            listenWhen: (p, c) => p.cellContent != c.cellContent,
+            listener: (context, state) => _controller.text = state.cellContent,
           ),
         ],
         child: Padding(
@@ -80,20 +78,16 @@ class _NumberCellState extends GridFocusNodeCellState<GridNumberCell> {
       _delayOperation?.cancel();
       _delayOperation = Timer(const Duration(milliseconds: 30), () {
         if (_cellBloc.isClosed == false &&
-            _controller.text != contentFromState(_cellBloc.state)) {
+            _controller.text != _cellBloc.state.cellContent) {
           _cellBloc.add(NumberCellEvent.updateCell(_controller.text));
         }
       });
     }
   }
 
-  String contentFromState(NumberCellState state) {
-    return state.content.fold((l) => l, (r) => "");
-  }
-
   @override
   String? onCopy() {
-    return _cellBloc.state.content.fold((content) => content, (r) => null);
+    return _cellBloc.state.cellContent;
   }
 
   @override

--- a/frontend/rust-lib/flowy-grid/src/services/field/type_options/number_type_option/number_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-grid/src/services/field/type_options/number_type_option/number_type_option_entities.rs
@@ -2,7 +2,7 @@ use crate::services::cell::{CellBytesCustomParser, CellProtobufBlobParser, Decod
 use crate::services::field::number_currency::Currency;
 use crate::services::field::{strip_currency_symbol, NumberFormat, STRIP_SYMBOL};
 use bytes::Bytes;
-use flowy_error::{FlowyError, FlowyResult};
+use flowy_error::FlowyResult;
 use rust_decimal::Decimal;
 use rusty_money::Money;
 use std::str::FromStr;
@@ -40,7 +40,8 @@ impl NumberCellData {
                     if num_str.chars().all(char::is_numeric) {
                         Self::from_format_str(&num_str, sign_positive, format)
                     } else {
-                        Err(FlowyError::invalid_data().context("Should only contain numbers"))
+                        // returns empty string if it can be formatted
+                        Ok(Self::default())
                     }
                 }
             },

--- a/frontend/rust-lib/flowy-user/src/services/database.rs
+++ b/frontend/rust-lib/flowy-user/src/services/database.rs
@@ -18,7 +18,6 @@ impl UserDB {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     fn open_user_db_if_need(&self, user_id: &str) -> Result<Arc<ConnectionPool>, FlowyError> {
         if user_id.is_empty() {
             return Err(ErrorCode::UserIdIsEmpty.into());


### PR DESCRIPTION
If the initial input content is: "", then after entering an invalid number string, the cell content will be empty. The cellDataNofitier doesn't notify the listener because the new value is the same as the old one. aka, "", the empty string.

Add `listenWhenOnCellChanged` callback to let the caller design how to handle the value change notification.