### PR TITLE
CleanUp: removed unused PhantomSnapshotPersistence-import

### DIFF
--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -14,10 +14,7 @@ use crate::{
 use bytes::Bytes;
 use flowy_document::editor::initial_read_me;
 use flowy_error::FlowyError;
-use flowy_revision::{
-    PhantomSnapshotPersistence, RevisionManager, RevisionPersistence, RevisionPersistenceConfiguration,
-    RevisionWebSocket,
-};
+use flowy_revision::{RevisionManager, RevisionPersistence, RevisionPersistenceConfiguration, RevisionWebSocket};
 use folder_rev_model::user_default;
 use lazy_static::lazy_static;
 use lib_infra::future::FutureResult;


### PR DESCRIPTION
As written in title. It just removes `use PhantomSnapshotPersistence` as it is not used (anymore).
