### PR TITLE
fix: command of double tilde to strikethrough

### DIFF
--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -282,7 +282,7 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Double tilde to strikethrough',
-    command: 'shift+tilde',
+    command: 'tilde,shift+tilde',
     handler: doubleTildeToStrikethrough,
   ),
   ShortcutEvent(


### PR DESCRIPTION
The `ShortcutEvent` did not fire on my keyboard layout (de-at)