### PR TITLE
feat: on enter exit editing property field #1295

### DIFF
--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
@@ -6,7 +6,7 @@ import 'package:dartz/dartz.dart' show none;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/style_widget/button.dart';
 import 'package:flowy_infra_ui/style_widget/text.dart';
-import 'package:flowy_infra_ui/widget/rounded_input_field.dart';
+import 'package:flowy_infra_ui/style_widget/text_field.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:flutter/material.dart';
@@ -178,11 +178,9 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
         builder: (context, state) {
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12.0),
-            child: RoundedInputField(
-              height: 36,
+            child: FlowyTextField(
               focusNode: focusNode,
-              onFieldSubmitted: (String _) => PopoverContainer.of(context).close(),
-              style: Theme.of(context).textTheme.bodyMedium,
+              onSubmitted: (String _) => PopoverContainer.of(context).close(),
               controller: controller,
               errorText: context.read<FieldEditorBloc>().state.errorText,
               onChanged: (newName) {

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
@@ -181,6 +181,7 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
             child: RoundedInputField(
               height: 36,
               focusNode: focusNode,
+              onFieldSubmitted: (String _) => PopoverContainer.of(context).close(),
               style: Theme.of(context).textTheme.bodyMedium,
               controller: controller,
               errorText: context.read<FieldEditorBloc>().state.errorText,

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
@@ -170,7 +170,8 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
               focusNode: focusNode,
               onSubmitted: (String _) => PopoverContainer.of(context).close(),
               text: context.read<FieldEditorBloc>().state.name,
-              errorText: context.read<FieldEditorBloc>().state.errorText,
+              errorText: context.read<FieldEditorBloc>().state.errorText.isEmpty ?
+                null : context.read<FieldEditorBloc>().state.errorText,
               onChanged: (newName) {
                 context
                     .read<FieldEditorBloc>()

--- a/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/app_flowy/lib/plugins/grid/presentation/widgets/header/field_editor.dart
@@ -135,11 +135,9 @@ class _FieldNameTextField extends StatefulWidget {
 
 class _FieldNameTextFieldState extends State<_FieldNameTextField> {
   FocusNode focusNode = FocusNode();
-  late TextEditingController controller;
 
   @override
   void initState() {
-    controller = TextEditingController();
     focusNode.addListener(() {
       if (focusNode.hasFocus) {
         widget.popoverMutex.close();
@@ -157,21 +155,11 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocListener(
-      listeners: [
-        BlocListener<FieldEditorBloc, FieldEditorState>(
-          listenWhen: (p, c) => p.field == none(),
-          listener: (context, state) {
-            focusNode.requestFocus();
-          },
-        ),
-        BlocListener<FieldEditorBloc, FieldEditorState>(
-          listenWhen: (p, c) => controller.text != c.name,
-          listener: (context, state) {
-            controller.text = state.name;
-          },
-        ),
-      ],
+    return BlocListener<FieldEditorBloc, FieldEditorState>(
+      listenWhen: (p, c) => p.field == none(),
+      listener: (context, state) {
+        focusNode.requestFocus();
+      },
       child: BlocBuilder<FieldEditorBloc, FieldEditorState>(
         buildWhen: (previous, current) =>
             previous.errorText != current.errorText,
@@ -181,7 +169,7 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
             child: FlowyTextField(
               focusNode: focusNode,
               onSubmitted: (String _) => PopoverContainer.of(context).close(),
-              controller: controller,
+              text: context.read<FieldEditorBloc>().state.name,
               errorText: context.read<FieldEditorBloc>().state.errorText,
               onChanged: (newName) {
                 context

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -19,6 +19,7 @@ class FlowyTextField extends StatefulWidget {
   final bool autoClearWhenDone;
   final bool submitOnLeave;
   final Duration? debounceDuration;
+  final String errorText;
 
   const FlowyTextField({
     this.hintText = "",
@@ -34,6 +35,7 @@ class FlowyTextField extends StatefulWidget {
     this.autoClearWhenDone = false,
     this.submitOnLeave = false,
     this.debounceDuration,
+    this.errorText = "",
     Key? key,
   }) : super(key: key);
 
@@ -117,6 +119,7 @@ class FlowyTextFieldState extends State<FlowyTextField> {
         ),
         isDense: true,
         hintText: widget.hintText,
+        errorText: widget.errorText.isNotEmpty ? widget.errorText : null,
         hintStyle: Theme.of(context)
             .textTheme
             .bodySmall!
@@ -126,6 +129,13 @@ class FlowyTextFieldState extends State<FlowyTextField> {
         focusedBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: Theme.of(context).colorScheme.primary,
+            width: 1.0,
+          ),
+          borderRadius: Corners.s8Border,
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: Theme.of(context).colorScheme.error,
             width: 1.0,
           ),
           borderRadius: Corners.s8Border,

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -131,14 +131,21 @@ class FlowyTextFieldState extends State<FlowyTextField> {
             color: Theme.of(context).colorScheme.primary,
             width: 1.0,
           ),
-          borderRadius: Corners.s8Border,
+          borderRadius: Corners.s10Border,
+        ),
+        errorBorder: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: Theme.of(context).colorScheme.error,
+            width: 1.0,
+          ),
+          borderRadius: Corners.s10Border,
         ),
         focusedErrorBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: Theme.of(context).colorScheme.error,
             width: 1.0,
           ),
-          borderRadius: Corners.s8Border,
+          borderRadius: Corners.s10Border,
         ),
       ),
     );

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -19,7 +19,7 @@ class FlowyTextField extends StatefulWidget {
   final bool autoClearWhenDone;
   final bool submitOnLeave;
   final Duration? debounceDuration;
-  final String errorText;
+  final String? errorText;
 
   const FlowyTextField({
     this.hintText = "",
@@ -35,7 +35,7 @@ class FlowyTextField extends StatefulWidget {
     this.autoClearWhenDone = false,
     this.submitOnLeave = false,
     this.debounceDuration,
-    this.errorText = "",
+    this.errorText,
     Key? key,
   }) : super(key: key);
 
@@ -119,7 +119,7 @@ class FlowyTextFieldState extends State<FlowyTextField> {
         ),
         isDense: true,
         hintText: widget.hintText,
-        errorText: widget.errorText.isNotEmpty ? widget.errorText : null,
+        errorText: widget.errorText,
         hintStyle: Theme.of(context)
             .textTheme
             .bodySmall!

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/rounded_input_field.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/rounded_input_field.dart
@@ -27,6 +27,7 @@ class RoundedInputField extends StatefulWidget {
   final TextEditingController? controller;
   final bool autoFocus;
   final int? maxLength;
+  final Function(String)? onFieldSubmitted;
 
   const RoundedInputField({
     Key? key,
@@ -51,6 +52,7 @@ class RoundedInputField extends StatefulWidget {
     this.controller,
     this.autoFocus = false,
     this.maxLength,
+    this.onFieldSubmitted,
   }) : super(key: key);
 
   @override
@@ -106,6 +108,7 @@ class _RoundedInputFieldState extends State<RoundedInputField> {
           maxLength: widget.maxLength,
           maxLengthEnforcement:
               MaxLengthEnforcement.truncateAfterCompositionEnds,
+          onFieldSubmitted: widget.onFieldSubmitted,
           onChanged: (value) {
             inputText = value;
             if (widget.onChanged != null) {


### PR DESCRIPTION
Introduces `onFieldSubmitted` on `RoundedInputField` type that will get used as `TextFormField` property.

Closes #1295.