### PR TITLE
fix: #1290 [Bug] 300ms delay on buttons in titlebar

### DIFF
--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/button.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/style_widget/button.dart
@@ -2,6 +2,7 @@ import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra/size.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flowy_infra_ui/style_widget/text.dart';
+import 'package:flowy_infra_ui/widget/ignore_parent_gesture.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
 import 'package:flutter/material.dart';
 import 'package:textstyle_extensions/textstyle_extensions.dart';
@@ -176,7 +177,12 @@ class FlowyTextButton extends StatelessWidget {
       highlightColor: Colors.transparent,
       elevation: 0,
       constraints: constraints,
-      onPressed: onPressed,
+      onPressed: () {},
+      child: child,
+    );
+
+    child = IgnoreParentGestureWidget(
+      onPress: onPressed,
       child: child,
     );
 

--- a/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/ignore_parent_gesture.dart
+++ b/frontend/app_flowy/packages/flowy_infra_ui/lib/widget/ignore_parent_gesture.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class IgnoreParentGestureWidget extends StatelessWidget {
+  const IgnoreParentGestureWidget({
+    Key? key,
+    required this.child,
+    this.onPress,
+  }) : super(key: key);
+
+  final Widget child;
+  final VoidCallback? onPress;
+
+  @override
+  Widget build(BuildContext context) {
+    // https://docs.flutter.dev/development/ui/advanced/gestures#gesture-disambiguation
+    // https://github.com/AppFlowy-IO/AppFlowy/issues/1290
+    return Listener(
+      onPointerDown: (event) {
+        onPress?.call();
+      },
+      onPointerSignal: (event) {},
+      onPointerMove: (event) {},
+      onPointerUp: (event) {},
+      onPointerHover: (event) {},
+      onPointerPanZoomStart: (event) {},
+      onPointerPanZoomUpdate: (event) {},
+      onPointerPanZoomEnd: (event) {},
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
Just a workaround to prevent the `MoveWindowDetector` from accepting the events.

Reference
* https://docs.flutter.dev/development/ui/advanced/gestures#gesture-disambiguation
* https://github.com/flutter/flutter/issues/67255