### PR TITLE
[FR] Shortcut for toggling checkbox 

### DIFF
--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
@@ -1,22 +1,49 @@
 import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event_handler.dart';
 import 'package:appflowy_editor/src/core/document/attributes.dart';
 import 'package:appflowy_editor/src/core/document/node.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 
 ShortcutEventHandler toggleCheckbox = (editorState, event) {
   final selection = editorState.service.selectionService.currentSelection.value;
   final nodes = editorState.service.selectionService.currentSelectedNodes;
-  final textNodes = nodes.whereType<TextNode>().toList(growable: false);
-  if (selection == null || textNodes.isEmpty) {
+  final checkboxTextNodes = nodes
+      .where(
+        (element) =>
+            element is TextNode &&
+            element.subtype == BuiltInAttributeKey.checkbox,
+      )
+      .toList(growable: false);
+
+  if (selection == null || checkboxTextNodes.isEmpty) {
     return KeyEventResult.ignored;
   }
-  for (Node node in textNodes) {
-    if (node.attributes.containsKey('checkbox') &&
-        node.attributes.containsValue('checkbox')) {
-      bool currentStatus = !(node.attributes['checkbox']);
-      Attributes checkboxAttribute = {'checkbox': currentStatus};
-      node.updateAttributes(checkboxAttribute);
+
+  //If any one of the checkboxes is unchecked then make all checkboxes checked
+
+  bool isAllCheckboxesChecked = true;
+  final transaction = editorState.transaction;
+  for (final node in checkboxTextNodes) {
+    if (node.attributes[BuiltInAttributeKey.checkbox] == false) {
+      isAllCheckboxesChecked = false;
+      transaction.updateNode(node, {
+        BuiltInAttributeKey.checkbox:
+            !node.attributes[BuiltInAttributeKey.checkbox]
+      });
     }
   }
+  editorState.apply(transaction);
+
+  //if all the checkboxes are checked, then make all of the checkboxes unchecked
+  final transaction2 = editorState.transaction;
+  if (isAllCheckboxesChecked) {
+    for (final node in checkboxTextNodes) {
+      transaction2.updateNode(node, {
+        BuiltInAttributeKey.checkbox:
+            !node.attributes[BuiltInAttributeKey.checkbox]
+      });
+    }
+  }
+  editorState.apply(transaction2);
   return KeyEventResult.handled;
 };

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
@@ -1,0 +1,22 @@
+import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event_handler.dart';
+import 'package:appflowy_editor/src/core/document/attributes.dart';
+import 'package:appflowy_editor/src/core/document/node.dart';
+import 'package:flutter/material.dart';
+
+ShortcutEventHandler toggleCheckbox = (editorState, event) {
+  final selection = editorState.service.selectionService.currentSelection.value;
+  final nodes = editorState.service.selectionService.currentSelectedNodes;
+  final textNodes = nodes.whereType<TextNode>().toList(growable: false);
+  if (selection == null || textNodes.isEmpty) {
+    return KeyEventResult.ignored;
+  }
+  for (Node node in textNodes) {
+    if (node.attributes.containsKey('checkbox') &&
+        node.attributes.containsValue('checkbox')) {
+      bool currentStatus = !(node.attributes['checkbox']);
+      Attributes checkboxAttribute = {'checkbox': currentStatus};
+      node.updateAttributes(checkboxAttribute);
+    }
+  }
+  return KeyEventResult.handled;
+};

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
@@ -1,6 +1,3 @@
-import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event_handler.dart';
-import 'package:appflowy_editor/src/core/document/attributes.dart';
-import 'package:appflowy_editor/src/core/document/node.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/checkbox_event_handler.dart
@@ -16,31 +16,23 @@ ShortcutEventHandler toggleCheckbox = (editorState, event) {
     return KeyEventResult.ignored;
   }
 
-  //If any one of the checkboxes is unchecked then make all checkboxes checked
-
-  bool isAllCheckboxesChecked = true;
+  bool isAllCheckboxesChecked = checkboxTextNodes
+      .every((node) => node.attributes[BuiltInAttributeKey.checkbox] == true);
   final transaction = editorState.transaction;
-  for (final node in checkboxTextNodes) {
-    if (node.attributes[BuiltInAttributeKey.checkbox] == false) {
-      isAllCheckboxesChecked = false;
-      transaction.updateNode(node, {
-        BuiltInAttributeKey.checkbox:
-            !node.attributes[BuiltInAttributeKey.checkbox]
-      });
-    }
-  }
-  editorState.apply(transaction);
+  transaction.afterSelection = selection;
 
-  //if all the checkboxes are checked, then make all of the checkboxes unchecked
-  final transaction2 = editorState.transaction;
   if (isAllCheckboxesChecked) {
+    //if all the checkboxes are checked, then make all of the checkboxes unchecked
     for (final node in checkboxTextNodes) {
-      transaction2.updateNode(node, {
-        BuiltInAttributeKey.checkbox:
-            !node.attributes[BuiltInAttributeKey.checkbox]
-      });
+      transaction.updateNode(node, {BuiltInAttributeKey.checkbox: false});
+    }
+  } else {
+    //If any one of the checkboxes is unchecked then make all checkboxes checked
+    for (final node in checkboxTextNodes) {
+      transaction.updateNode(node, {BuiltInAttributeKey.checkbox: true});
     }
   }
-  editorState.apply(transaction2);
+
+  editorState.apply(transaction);
   return KeyEventResult.handled;
 };

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
@@ -89,21 +89,3 @@ ShortcutEventHandler formatEmbedCodeEventHandler = (editorState, event) {
   formatEmbedCode(editorState);
   return KeyEventResult.ignored;
 };
-
-ShortcutEventHandler toggleCheckbox = (editorState, event) {
-  final selection = editorState.service.selectionService.currentSelection.value;
-  final nodes = editorState.service.selectionService.currentSelectedNodes;
-  final textNodes = nodes.whereType<TextNode>().toList(growable: false);
-  if (selection == null || textNodes.isEmpty) {
-    return KeyEventResult.ignored;
-  }
-  for (Node node in textNodes) {
-    // debugPrint("Nodes attribute : ${node.attributes}");
-    if (node.attributes.containsKey('checkbox')) {
-      bool currentStatus = !(node.attributes['checkbox']);
-      Attributes checkboxAttribute = {'checkbox': currentStatus};
-      node.updateAttributes(checkboxAttribute);
-    }
-  }
-  return KeyEventResult.handled;
-};

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
@@ -2,6 +2,8 @@ import 'package:appflowy_editor/src/service/default_text_operations/format_rich_
 import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event_handler.dart';
 import 'package:flutter/material.dart';
 
+import 'dart:convert';
+import 'package:appflowy_editor/src/core/document/attributes.dart';
 import 'package:appflowy_editor/src/core/document/node.dart';
 
 ShortcutEventHandler formatBoldEventHandler = (editorState, event) {
@@ -86,4 +88,22 @@ ShortcutEventHandler formatEmbedCodeEventHandler = (editorState, event) {
   }
   formatEmbedCode(editorState);
   return KeyEventResult.ignored;
+};
+
+ShortcutEventHandler toggleCheckbox = (editorState, event) {
+  final selection = editorState.service.selectionService.currentSelection.value;
+  final nodes = editorState.service.selectionService.currentSelectedNodes;
+  final textNodes = nodes.whereType<TextNode>().toList(growable: false);
+  if (selection == null || textNodes.isEmpty) {
+    return KeyEventResult.ignored;
+  }
+  for (Node node in textNodes) {
+    // debugPrint("Nodes attribute : ${node.attributes}");
+    if (node.attributes.containsKey('checkbox')) {
+      bool currentStatus = !(node.attributes['checkbox']);
+      Attributes checkboxAttribute = {'checkbox': currentStatus};
+      node.updateAttributes(checkboxAttribute);
+    }
+  }
+  return KeyEventResult.handled;
 };

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/format_style_handler.dart
@@ -2,8 +2,6 @@ import 'package:appflowy_editor/src/service/default_text_operations/format_rich_
 import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event_handler.dart';
 import 'package:flutter/material.dart';
 
-import 'dart:convert';
-import 'package:appflowy_editor/src/core/document/attributes.dart';
 import 'package:appflowy_editor/src/core/document/node.dart';
 
 ShortcutEventHandler formatBoldEventHandler = (editorState, event) {

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -160,6 +160,13 @@ List<ShortcutEvent> builtInShortcutEvents = [
     handler: formatUnderlineEventHandler,
   ),
   ShortcutEvent(
+    key: 'Checkbox Toggle',
+    command: 'meta+q',
+    windowsCommand: 'ctrl+q',
+    linuxCommand: 'ctrl+q',
+    handler: toggleCheckbox,
+  ),
+  ShortcutEvent(
     key: 'Format strikethrough',
     command: 'meta+shift+s',
     windowsCommand: 'ctrl+shift+s',

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -162,9 +162,9 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Toggle Checkbox',
-    command: 'meta+q',
-    windowsCommand: 'ctrl+q',
-    linuxCommand: 'ctrl+q',
+    command: 'meta+enter',
+    windowsCommand: 'ctrl+enter',
+    linuxCommand: 'ctrl+enter',
     handler: toggleCheckbox,
   ),
   ShortcutEvent(

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -14,6 +14,7 @@ import 'package:appflowy_editor/src/service/internal_key_event_handlers/format_s
 import 'package:appflowy_editor/src/service/internal_key_event_handlers/space_on_web_handler.dart';
 import 'package:appflowy_editor/src/service/internal_key_event_handlers/tab_handler.dart';
 import 'package:appflowy_editor/src/service/internal_key_event_handlers/whitespace_handler.dart';
+import 'package:appflowy_editor/src/service/internal_key_event_handlers/checkbox_event_handler.dart';
 import 'package:appflowy_editor/src/service/shortcut_event/shortcut_event.dart';
 import 'package:flutter/foundation.dart';
 
@@ -160,7 +161,7 @@ List<ShortcutEvent> builtInShortcutEvents = [
     handler: formatUnderlineEventHandler,
   ),
   ShortcutEvent(
-    key: 'Checkbox Toggle',
+    key: 'Toggle Checkbox',
     command: 'meta+q',
     windowsCommand: 'ctrl+q',
     linuxCommand: 'ctrl+q',

--- a/frontend/app_flowy/packages/appflowy_editor/test/infra/test_raw_key_event.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/infra/test_raw_key_event.dart
@@ -136,6 +136,9 @@ extension on LogicalKeyboardKey {
     if (this == LogicalKeyboardKey.keyH) {
       return PhysicalKeyboardKey.keyH;
     }
+    if (this == LogicalKeyboardKey.keyQ) {
+      return PhysicalKeyboardKey.keyQ;
+    }
     if (this == LogicalKeyboardKey.keyZ) {
       return PhysicalKeyboardKey.keyZ;
     }

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
@@ -13,7 +13,7 @@ void main() async {
   });
 
   group('checkbox_event_handler_test.dart', () {
-    testWidgets('toggle checkbox with shortcut ctrl+q', (tester) async {
+    testWidgets('toggle checkbox with shortcut ctrl+enter', (tester) async {
       const text = 'Checkbox1';
       final editor = tester.editor
         ..insertTextNode(
@@ -33,45 +33,209 @@ void main() async {
 
       final checkboxNode = editor.nodeAtPath([0]) as TextNode;
       expect(checkboxNode.subtype, BuiltInAttributeKey.checkbox);
-      expect(checkboxNode.attributes.check, false);
+      expect(checkboxNode.attributes[BuiltInAttributeKey.checkbox], false);
 
       for (final event in builtInShortcutEvents) {
         if (event.key == 'Toggle Checkbox') {
           event.updateCommand(
-            windowsCommand: 'ctrl+q',
-            linuxCommand: 'ctrl+q',
-            macOSCommand: 'meta+q',
+            windowsCommand: 'ctrl+enter',
+            linuxCommand: 'ctrl+enter',
+            macOSCommand: 'meta+enter',
           );
         }
       }
 
       if (Platform.isWindows || Platform.isLinux) {
         await editor.pressLogicKey(
-          LogicalKeyboardKey.keyQ,
+          LogicalKeyboardKey.enter,
           isControlPressed: true,
         );
       } else {
         await editor.pressLogicKey(
-          LogicalKeyboardKey.keyQ,
+          LogicalKeyboardKey.enter,
           isMetaPressed: true,
         );
       }
 
-      expect(checkboxNode.attributes.check, true);
+      expect(checkboxNode.attributes[BuiltInAttributeKey.checkbox], true);
+
+      await editor.updateSelection(
+        Selection.single(path: [0], startOffset: text.length),
+      );
 
       if (Platform.isWindows || Platform.isLinux) {
         await editor.pressLogicKey(
-          LogicalKeyboardKey.keyQ,
+          LogicalKeyboardKey.enter,
           isControlPressed: true,
         );
       } else {
         await editor.pressLogicKey(
-          LogicalKeyboardKey.keyQ,
+          LogicalKeyboardKey.enter,
           isMetaPressed: true,
         );
       }
 
-      expect(checkboxNode.attributes.check, false);
+      expect(checkboxNode.attributes[BuiltInAttributeKey.checkbox], false);
+    });
+
+    testWidgets(
+        'test if all checkboxes get unchecked after toggling them, if all of them were already checked',
+        (tester) async {
+      const text = 'Checkbox';
+      final editor = tester.editor
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: true,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        )
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: true,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        )
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: true,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        );
+
+      await editor.startTesting();
+      await editor.updateSelection(
+        Selection.single(path: [0], startOffset: text.length),
+      );
+
+      final nodes =
+          editor.editorState.service.selectionService.currentSelectedNodes;
+      final checkboxTextNodes = nodes
+          .where(
+            (element) =>
+                element is TextNode &&
+                element.subtype == BuiltInAttributeKey.checkbox,
+          )
+          .toList(growable: false);
+
+      for (final node in checkboxTextNodes) {
+        expect(node.attributes[BuiltInAttributeKey.checkbox], true);
+      }
+
+      for (final event in builtInShortcutEvents) {
+        if (event.key == 'Toggle Checkbox') {
+          event.updateCommand(
+            windowsCommand: 'ctrl+enter',
+            linuxCommand: 'ctrl+enter',
+            macOSCommand: 'meta+enter',
+          );
+        }
+      }
+
+      if (Platform.isWindows || Platform.isLinux) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.enter,
+          isControlPressed: true,
+        );
+      } else {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.enter,
+          isMetaPressed: true,
+        );
+      }
+
+      for (final node in checkboxTextNodes) {
+        expect(node.attributes[BuiltInAttributeKey.checkbox], false);
+      }
+    });
+
+    testWidgets(
+        'test if all checkboxes get checked after toggling them, if any one of them were already checked',
+        (tester) async {
+      const text = 'Checkbox';
+      final editor = tester.editor
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: false,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        )
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: true,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        )
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: false,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        );
+
+      await editor.startTesting();
+      await editor.updateSelection(
+        Selection.single(path: [0], startOffset: text.length),
+      );
+
+      final nodes =
+          editor.editorState.service.selectionService.currentSelectedNodes;
+      final checkboxTextNodes = nodes
+          .where(
+            (element) =>
+                element is TextNode &&
+                element.subtype == BuiltInAttributeKey.checkbox,
+          )
+          .toList(growable: false);
+
+      for (final event in builtInShortcutEvents) {
+        if (event.key == 'Toggle Checkbox') {
+          event.updateCommand(
+            windowsCommand: 'ctrl+enter',
+            linuxCommand: 'ctrl+enter',
+            macOSCommand: 'meta+enter',
+          );
+        }
+      }
+
+      if (Platform.isWindows || Platform.isLinux) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.enter,
+          isControlPressed: true,
+        );
+      } else {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.enter,
+          isMetaPressed: true,
+        );
+      }
+
+      for (final node in checkboxTextNodes) {
+        expect(node.attributes[BuiltInAttributeKey.checkbox], true);
+      }
     });
   });
 }

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor/src/service/shortcut_event/built_in_shortcut_events.dart';
-import 'package:appflowy_editor/src/extensions/text_node_extensions.dart';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../infra/test_editor.dart';

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/checkbox_event_handler_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor/src/service/shortcut_event/built_in_shortcut_events.dart';
+import 'package:appflowy_editor/src/extensions/text_node_extensions.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../infra/test_editor.dart';
+
+void main() async {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  group('checkbox_event_handler_test.dart', () {
+    testWidgets('toggle checkbox with shortcut ctrl+q', (tester) async {
+      const text = 'Checkbox1';
+      final editor = tester.editor
+        ..insertTextNode(
+          '',
+          attributes: {
+            BuiltInAttributeKey.subtype: BuiltInAttributeKey.checkbox,
+            BuiltInAttributeKey.checkbox: false,
+          },
+          delta: Delta(
+            operations: [TextInsert(text)],
+          ),
+        );
+      await editor.startTesting();
+      await editor.updateSelection(
+        Selection.single(path: [0], startOffset: text.length),
+      );
+
+      final checkboxNode = editor.nodeAtPath([0]) as TextNode;
+      expect(checkboxNode.subtype, BuiltInAttributeKey.checkbox);
+      expect(checkboxNode.attributes.check, false);
+
+      for (final event in builtInShortcutEvents) {
+        if (event.key == 'Toggle Checkbox') {
+          event.updateCommand(
+            windowsCommand: 'ctrl+q',
+            linuxCommand: 'ctrl+q',
+            macOSCommand: 'meta+q',
+          );
+        }
+      }
+
+      if (Platform.isWindows || Platform.isLinux) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.keyQ,
+          isControlPressed: true,
+        );
+      } else {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.keyQ,
+          isMetaPressed: true,
+        );
+      }
+
+      expect(checkboxNode.attributes.check, true);
+
+      if (Platform.isWindows || Platform.isLinux) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.keyQ,
+          isControlPressed: true,
+        );
+      } else {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.keyQ,
+          isMetaPressed: true,
+        );
+      }
+
+      expect(checkboxNode.attributes.check, false);
+    });
+  });
+}


### PR DESCRIPTION
Solves #1762

Users can now use the key combination: **Ctrl+Enter** on Windows and Linux to quickly on/off a checkbox in AppFlowy. Mac Users have to press **Meta+Enter** in order to achieve the same.

This also works with multiple checkboxes. Thus as a user, you can select multiple todos and then press Ctrl+Enter to toggle them.