### PR TITLE
Improve Editing and Navigating shortcuts with Ctrl/Meta

### DIFF
--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
@@ -340,7 +340,7 @@ ShortcutEventHandler cursorLeftWordDelete = (editorState, event) {
 
   final transaction = editorState.transaction;
   transaction.deleteText(
-      textNode, startOfWord.offset, selection.end.offset - startOfWord!.offset);
+      textNode, startOfWord.offset, selection.end.offset - startOfWord.offset);
 
   editorState.apply(transaction);
 

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
@@ -323,13 +323,15 @@ ShortcutEventHandler cursorRightWordSelect = (editorState, event) {
 };
 
 ShortcutEventHandler cursorLeftWordDelete = (editorState, event) {
-  final nodes = editorState.service.selectionService.currentSelectedNodes;
+  final textNodes = editorState.service.selectionService.currentSelectedNodes
+      .whereType<TextNode>();
   final selection = editorState.service.selectionService.currentSelection.value;
-  final textNode = nodes.whereType<TextNode>().toList(growable: false).first;
 
-  if (nodes.isEmpty || selection == null) {
+  if (textNodes.isEmpty || selection == null) {
     return KeyEventResult.ignored;
   }
+
+  final textNode = textNodes.first;
 
   final startOfWord =
       selection.end.goLeft(editorState, selectionRange: _SelectionRange.word);

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/arrow_keys_handler.dart
@@ -322,6 +322,31 @@ ShortcutEventHandler cursorRightWordSelect = (editorState, event) {
   return KeyEventResult.handled;
 };
 
+ShortcutEventHandler cursorLeftWordDelete = (editorState, event) {
+  final nodes = editorState.service.selectionService.currentSelectedNodes;
+  final selection = editorState.service.selectionService.currentSelection.value;
+  final textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+
+  if (nodes.isEmpty || selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  final startOfWord =
+      selection.end.goLeft(editorState, selectionRange: _SelectionRange.word);
+
+  if (startOfWord == null) {
+    return KeyEventResult.ignored;
+  }
+
+  final transaction = editorState.transaction;
+  transaction.deleteText(
+      textNode, startOfWord.offset, selection.end.offset - startOfWord!.offset);
+
+  editorState.apply(transaction);
+
+  return KeyEventResult.handled;
+};
+
 enum _SelectionRange {
   character,
   word,

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/backspace_handler.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/internal_key_event_handlers/backspace_handler.dart
@@ -253,8 +253,8 @@ void _deleteTextNodes(
   final last = textNodes.last;
   var content = textNodes.last.toPlainText();
   content = content.substring(selection.end.offset, content.length);
-  // Merge the fist and the last text node content,
-  //  and delete the all nodes expect for the first.
+  // Merge the first and the last text node content,
+  //  and delete all the nodes except for the first.
   transaction
     ..deleteNodes(textNodes.sublist(1))
     ..mergeText(

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -51,16 +51,16 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Cursor down select',
-    command: 'shift+alt+arrow left,meta+alt+arrow left',
-    windowsCommand: 'shift+alt+arrow left,ctrl+alt+arrow left',
-    linuxCommand: 'shift+alt+arrow left,ctrl+alt+arrow left',
+    command: 'shift+alt+arrow left',
+    windowsCommand: 'shift+alt+arrow left',
+    linuxCommand: 'shift+alt+arrow left',
     handler: cursorLeftWordSelect,
   ),
   ShortcutEvent(
     key: 'Cursor down select',
-    command: 'shift+alt+arrow right,ctrl+alt+arrow right',
-    windowsCommand: 'shift+alt+arrow right,ctrl+alt+arrow right',
-    linuxCommand: 'shift+alt+arrow right,ctrl+alt+arrow right',
+    command: 'shift+alt+arrow right',
+    windowsCommand: 'shift+alt+arrow right',
+    linuxCommand: 'shift+alt+arrow right',
     handler: cursorRightWordSelect,
   ),
   ShortcutEvent(

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -60,6 +60,13 @@ List<ShortcutEvent> builtInShortcutEvents = [
     handler: cursorRightWordSelect,
   ),
   ShortcutEvent(
+    key: 'Cursor word delete',
+    command: 'meta+backspace',
+    windowsCommand: 'ctrl+backspace',
+    linuxCommand: 'ctrl+backspace',
+    handler: cursorLeftWordDelete,
+  ),
+  ShortcutEvent(
     key: 'Cursor left select',
     command: 'shift+arrow left',
     handler: cursorLeftSelect,

--- a/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -51,12 +51,16 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Cursor down select',
-    command: 'shift+alt+arrow left',
+    command: 'shift+alt+arrow left,meta+alt+arrow left',
+    windowsCommand: 'shift+alt+arrow left,ctrl+alt+arrow left',
+    linuxCommand: 'shift+alt+arrow left,ctrl+alt+arrow left',
     handler: cursorLeftWordSelect,
   ),
   ShortcutEvent(
     key: 'Cursor down select',
-    command: 'shift+alt+arrow right',
+    command: 'shift+alt+arrow right,ctrl+alt+arrow right',
+    windowsCommand: 'shift+alt+arrow right,ctrl+alt+arrow right',
+    linuxCommand: 'shift+alt+arrow right,ctrl+alt+arrow right',
     handler: cursorRightWordSelect,
   ),
   ShortcutEvent(

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
@@ -476,10 +476,17 @@ void main() async {
     var selection = Selection.single(path: [0], startOffset: text.length);
     await editor.updateSelection(selection);
 
-    await editor.pressLogicKey(
-      LogicalKeyboardKey.backspace,
-      isControlPressed: true,
-    );
+    if (Platform.isWindows || Platform.isLinux) {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isControlPressed: true,
+      );
+    } else {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isMetaPressed: true,
+      );
+    }
 
     //fetching all the text that is still on the editor.
     var nodes =
@@ -490,10 +497,17 @@ void main() async {
     words.removeLast();
     expect(newText, words.join());
 
-    await editor.pressLogicKey(
-      LogicalKeyboardKey.backspace,
-      isControlPressed: true,
-    );
+    if (Platform.isWindows || Platform.isLinux) {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isControlPressed: true,
+      );
+    } else {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isMetaPressed: true,
+      );
+    }
 
     //fetching all the text that is still on the editor.
     nodes = editor.editorState.service.selectionService.currentSelectedNodes;
@@ -505,10 +519,17 @@ void main() async {
     expect(newText, words.join());
 
     for (var i = 0; i < words.length; i++) {
-      await editor.pressLogicKey(
-        LogicalKeyboardKey.backspace,
-        isControlPressed: true,
-      );
+      if (Platform.isWindows || Platform.isLinux) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.backspace,
+          isControlPressed: true,
+        );
+      } else {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.backspace,
+          isMetaPressed: true,
+        );
+      }
     }
 
     nodes = editor.editorState.service.selectionService.currentSelectedNodes;
@@ -527,10 +548,17 @@ void main() async {
     var selection = Selection.single(path: [0], startOffset: 0);
     await editor.updateSelection(selection);
 
-    await editor.pressLogicKey(
-      LogicalKeyboardKey.backspace,
-      isControlPressed: true,
-    );
+    if (Platform.isWindows || Platform.isLinux) {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isControlPressed: true,
+      );
+    } else {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isMetaPressed: true,
+      );
+    }
 
     //fetching all the text that is still on the editor.
     var nodes =
@@ -545,10 +573,17 @@ void main() async {
     await editor.updateSelection(selection);
     //Welcome to App|flowy 😁
 
-    await editor.pressLogicKey(
-      LogicalKeyboardKey.backspace,
-      isControlPressed: true,
-    );
+    if (Platform.isWindows || Platform.isLinux) {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isControlPressed: true,
+      );
+    } else {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isMetaPressed: true,
+      );
+    }
 
     //fetching all the text that is still on the editor.
     nodes = editor.editorState.service.selectionService.currentSelectedNodes;

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
@@ -484,7 +484,7 @@ void main() async {
     //fetching all the text that is still on the editor.
     var nodes =
         editor.editorState.service.selectionService.currentSelectedNodes;
-    var textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+    var textNode = nodes.whereType<TextNode>().first;
     var newText = textNode.toPlainText();
 
     words.removeLast();
@@ -497,7 +497,7 @@ void main() async {
 
     //fetching all the text that is still on the editor.
     nodes = editor.editorState.service.selectionService.currentSelectedNodes;
-    textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+    textNode = nodes.whereType<TextNode>().first;
 
     newText = textNode.toPlainText();
 
@@ -517,6 +517,46 @@ void main() async {
     newText = textNode.toPlainText();
 
     expect(newText, '');
+  });
+
+  testWidgets('Testing ctrl + backspace edge cases', (tester) async {
+    const text = 'Welcome to Appflowy 😁';
+    final editor = tester.editor..insertTextNode(text);
+
+    await editor.startTesting();
+    var selection = Selection.single(path: [0], startOffset: 0);
+    await editor.updateSelection(selection);
+
+    await editor.pressLogicKey(
+      LogicalKeyboardKey.backspace,
+      isControlPressed: true,
+    );
+
+    //fetching all the text that is still on the editor.
+    var nodes =
+        editor.editorState.service.selectionService.currentSelectedNodes;
+    var textNode = nodes.whereType<TextNode>().first;
+    var newText = textNode.toPlainText();
+
+    //nothing happens
+    expect(newText, text);
+
+    selection = Selection.single(path: [0], startOffset: 14);
+    await editor.updateSelection(selection);
+    //Welcome to App|flowy 😁
+
+    await editor.pressLogicKey(
+      LogicalKeyboardKey.backspace,
+      isControlPressed: true,
+    );
+
+    //fetching all the text that is still on the editor.
+    nodes = editor.editorState.service.selectionService.currentSelectedNodes;
+    textNode = nodes.whereType<TextNode>().first;
+    newText = textNode.toPlainText();
+
+    const expectedText = 'Welcome to flowy 😁';
+    expect(newText, expectedText);
   });
 }
 

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
@@ -466,6 +466,59 @@ void main() async {
       ),
     );
   });
+
+  testWidgets('Presses ctrl + backspace to delete a word', (tester) async {
+    List<String> words = ["Welcome", " ", "to", " ", "Appflowy", " ", "😁"];
+    final text = words.join();
+    final editor = tester.editor..insertTextNode(text);
+
+    await editor.startTesting();
+    var selection = Selection.single(path: [0], startOffset: text.length);
+    await editor.updateSelection(selection);
+
+    await editor.pressLogicKey(
+      LogicalKeyboardKey.backspace,
+      isControlPressed: true,
+    );
+
+    //fetching all the text that is still on the editor.
+    var nodes =
+        editor.editorState.service.selectionService.currentSelectedNodes;
+    var textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+    var newText = textNode.toPlainText();
+
+    words.removeLast();
+    expect(newText, words.join());
+
+    await editor.pressLogicKey(
+      LogicalKeyboardKey.backspace,
+      isControlPressed: true,
+    );
+
+    //fetching all the text that is still on the editor.
+    nodes = editor.editorState.service.selectionService.currentSelectedNodes;
+    textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+
+    newText = textNode.toPlainText();
+
+    words.removeLast();
+    expect(newText, words.join());
+
+    for (var i = 0; i < words.length; i++) {
+      await editor.pressLogicKey(
+        LogicalKeyboardKey.backspace,
+        isControlPressed: true,
+      );
+    }
+
+    nodes = editor.editorState.service.selectionService.currentSelectedNodes;
+    textNode = nodes.whereType<TextNode>().toList(growable: false).first;
+
+    newText = textNode.toPlainText();
+
+    print(newText);
+    expect(newText, '');
+  });
 }
 
 Future<void> _testPressArrowKeyInNotCollapsedSelection(

--- a/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
+++ b/frontend/app_flowy/packages/appflowy_editor/test/service/internal_key_event_handlers/arrow_keys_handler_test.dart
@@ -516,7 +516,6 @@ void main() async {
 
     newText = textNode.toPlainText();
 
-    print(newText);
     expect(newText, '');
   });
 }


### PR DESCRIPTION
Solves #75 #1825 

Adds the following functionalities:

- [x] Ctrl + Backspace to delete a word.
- [x] Ctrl + Alt + Arrow Key Left to select the left word (left to the cursor).
- [x] Ctrl + Alt + Arrow Key Right to select the right word (right to the cursor).