### PR TITLE
Catch platform errors

### DIFF
--- a/frontend/app_flowy/lib/main.dart
+++ b/frontend/app_flowy/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:appflowy_backend/log.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 
@@ -18,6 +20,13 @@ class FlowyApp implements EntryPoint {
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Handle platform errors not caught by Flutter.
+  // Reduces the likelihood of the app crashing, and logs the error.
+  PlatformDispatcher.instance.onError = (error, stack) {
+    Log.error('Uncaught platform error', error, stack);
+    return true;
+  };
 
   await EasyLocalization.ensureInitialized();
   await hotKeyManager.unregisterAll();

--- a/frontend/app_flowy/packages/appflowy_backend/lib/log.dart
+++ b/frontend/app_flowy/packages/appflowy_backend/lib/log.dart
@@ -24,43 +24,43 @@ class Log {
     );
   }
 
-  static void info(dynamic msg) {
+  static void info(dynamic msg, [dynamic error, StackTrace? stackTrace]) {
     if (isReleaseVersion()) {
       log(0, toNativeUtf8(msg));
     } else {
-      Log.shared._logger.i(msg);
+      Log.shared._logger.i(msg, error, stackTrace);
     }
   }
 
-  static void debug(dynamic msg) {
+  static void debug(dynamic msg, [dynamic error, StackTrace? stackTrace]) {
     if (isReleaseVersion()) {
       log(1, toNativeUtf8(msg));
     } else {
-      Log.shared._logger.d(msg);
+      Log.shared._logger.d(msg, error, stackTrace);
     }
   }
 
-  static void warn(dynamic msg) {
+  static void warn(dynamic msg, [dynamic error, StackTrace? stackTrace]) {
     if (isReleaseVersion()) {
       log(3, toNativeUtf8(msg));
     } else {
-      Log.shared._logger.w(msg);
+      Log.shared._logger.w(msg, error, stackTrace);
     }
   }
 
-  static void trace(dynamic msg) {
+  static void trace(dynamic msg, [dynamic error, StackTrace? stackTrace]) {
     if (isReleaseVersion()) {
       log(2, toNativeUtf8(msg));
     } else {
-      Log.shared._logger.v(msg);
+      Log.shared._logger.v(msg, error, stackTrace);
     }
   }
 
-  static void error(dynamic msg) {
+  static void error(dynamic msg, [dynamic error, StackTrace? stackTrace]) {
     if (isReleaseVersion()) {
       log(4, toNativeUtf8(msg));
     } else {
-      Log.shared._logger.e(msg);
+      Log.shared._logger.e(msg, error, stackTrace);
     }
   }
 }


### PR DESCRIPTION
Adds handling for platform errors that are not caught by the
Flutter framework. Doing so will log the error properly and
prevent the app from crashing.