### PR TITLE
fix: error happens when parsing readme content

### DIFF
--- a/frontend/rust-lib/flowy-document/src/editor/mod.rs
+++ b/frontend/rust-lib/flowy-document/src/editor/mod.rs
@@ -9,8 +9,8 @@ pub use document_serde::*;
 pub use editor::*;
 
 #[inline]
+// Return the read me document content
 pub fn initial_read_me() -> String {
   let document_content = include_str!("READ_ME.json");
-  let transaction = make_transaction_from_document_content(document_content).unwrap();
-  transaction.to_json().unwrap()
+  return document_content.to_string();
 }


### PR DESCRIPTION
<img width="376" alt="Screenshot 2023-02-20 at 17 48 04" src="https://user-images.githubusercontent.com/11863087/220070869-3e0b99f8-02ed-4d80-815d-27f216929e0f.png">
