### PR TITLE
fix: homeMenuResizer position when menu is drawer.

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_screen.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_screen.dart
@@ -244,7 +244,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 animate: true)
             .animate(layout.animDuration, Curves.easeOut),
         homeMenuResizer
-            .positioned(left: layout.homePageLOffset - 5)
+            .positioned(left: layout.menuWidth - 5)
             .animate(layout.animDuration, Curves.easeOut),
       ],
     );


### PR DESCRIPTION
When menuIsDrawer = true, homeMenuResizer is still positioned at homeStack left. 
In this case, homeMenuResizer will located at homeMenu left, so we must drag home menu left area to resize home menu.
So I create this PR to fix this case.