### PR TITLE
feat(appflowy_editor):  double asterisk to bold text and remove slash after clicking selection menu item  

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -309,6 +309,11 @@ List<ShortcutEvent> builtInShortcutEvents = [
     command: 'shift+underscore',
     handler: underscoreToItalicHandler,
   ),
+  ShortcutEvent(
+    key: 'Double asterisk to bold',
+    command: 'shift+digit 8',
+    handler: doubleAsteriskToBoldHanlder,
+  ),
   // https://github.com/flutter/flutter/issues/104944
   // Workaround: Using space editing on the web platform often results in errors,
   //  so adding a shortcut event to handle the space input instead of using the

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/infra/test_raw_key_event.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/infra/test_raw_key_event.dart
@@ -145,6 +145,9 @@ extension on LogicalKeyboardKey {
     if (this == LogicalKeyboardKey.tilde) {
       return PhysicalKeyboardKey.backquote;
     }
+    if (this == LogicalKeyboardKey.digit8) {
+      return PhysicalKeyboardKey.digit8;
+    }
     throw UnimplementedError();
   }
 }

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/render/selection_menu/selection_menu_widget_test.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/render/selection_menu/selection_menu_widget_test.dart
@@ -18,13 +18,28 @@ void main() async {
     //
     // Use const value temporarily instead.
     const i = 7;
-    testWidgets('Selects number.$i item in selection menu', (tester) async {
+    testWidgets('Selects number.$i item in selection menu with keyboard',
+        (tester) async {
       final editor = await _prepare(tester);
       for (var j = 0; j < i; j++) {
         await editor.pressLogicKey(LogicalKeyboardKey.arrowDown);
       }
 
       await editor.pressLogicKey(LogicalKeyboardKey.enter);
+      expect(
+        find.byType(SelectionMenuWidget, skipOffstage: false),
+        findsNothing,
+      );
+      if (defaultSelectionMenuItems[i].name != 'Image') {
+        await _testDefaultSelectionMenuItems(i, editor);
+      }
+    });
+
+    testWidgets('Selects number.$i item in selection menu with clicking',
+        (tester) async {
+      final editor = await _prepare(tester);
+      await tester.tap(find.byType(SelectionMenuItemWidget).at(i));
+      await tester.pumpAndSettle();
       expect(
         find.byType(SelectionMenuWidget, skipOffstage: false),
         findsNothing,
@@ -135,19 +150,27 @@ Future<void> _testDefaultSelectionMenuItems(
     int index, EditorWidgetTester editor) async {
   expect(editor.documentLength, 4);
   expect(editor.documentSelection, Selection.single(path: [2], startOffset: 0));
+  expect((editor.nodeAtPath([0]) as TextNode).toPlainText(),
+      'Welcome to Appflowy 😁');
+  expect((editor.nodeAtPath([1]) as TextNode).toPlainText(),
+      'Welcome to Appflowy 😁');
   final node = editor.nodeAtPath([2]);
   final item = defaultSelectionMenuItems[index];
   if (item.name == 'Text') {
     expect(node?.subtype == null, true);
+    expect(node?.toString(), null);
   } else if (item.name == 'Heading 1') {
     expect(node?.subtype, BuiltInAttributeKey.heading);
     expect(node?.attributes.heading, BuiltInAttributeKey.h1);
+    expect(node?.toString(), null);
   } else if (item.name == 'Heading 2') {
     expect(node?.subtype, BuiltInAttributeKey.heading);
     expect(node?.attributes.heading, BuiltInAttributeKey.h2);
+    expect(node?.toString(), null);
   } else if (item.name == 'Heading 3') {
     expect(node?.subtype, BuiltInAttributeKey.heading);
     expect(node?.attributes.heading, BuiltInAttributeKey.h3);
+    expect(node?.toString(), null);
   } else if (item.name == 'Bulleted list') {
     expect(node?.subtype, BuiltInAttributeKey.bulletedList);
   } else if (item.name == 'Checkbox') {

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/service/internal_key_event_handlers/markdown_syntax_to_styled_text_test.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/service/internal_key_event_handlers/markdown_syntax_to_styled_text_test.dart
@@ -257,4 +257,98 @@ void main() async {
       });
     });
   });
+
+  group('convert double asterisk to bold', () {
+    Future<void> insertAsterisk(
+      EditorWidgetTester editor, {
+      int repeat = 1,
+    }) async {
+      for (var i = 0; i < repeat; i++) {
+        await editor.pressLogicKey(
+          LogicalKeyboardKey.digit8,
+          isShiftPressed: true,
+        );
+      }
+    }
+
+    testWidgets('**AppFlowy** to bold AppFlowy', ((widgetTester) async {
+      const text = '**AppFlowy*';
+      final editor = widgetTester.editor..insertTextNode('');
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+      final textNode = editor.nodeAtPath([0]) as TextNode;
+      for (var i = 0; i < text.length; i++) {
+        await editor.insertText(textNode, text[i], i);
+      }
+
+      await insertAsterisk(editor);
+
+      final allBold = textNode.allSatisfyBoldInSelection(Selection.single(
+          path: [0], startOffset: 0, endOffset: textNode.toPlainText().length));
+
+      expect(allBold, true);
+      expect(textNode.toPlainText(), 'AppFlowy');
+    }));
+
+    testWidgets('App**Flowy** to bold AppFlowy', ((widgetTester) async {
+      const text = 'App**Flowy*';
+      final editor = widgetTester.editor..insertTextNode('');
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+      final textNode = editor.nodeAtPath([0]) as TextNode;
+      for (var i = 0; i < text.length; i++) {
+        await editor.insertText(textNode, text[i], i);
+      }
+
+      await insertAsterisk(editor);
+
+      final allBold = textNode.allSatisfyBoldInSelection(Selection.single(
+          path: [0], startOffset: 3, endOffset: textNode.toPlainText().length));
+
+      expect(allBold, true);
+      expect(textNode.toPlainText(), 'AppFlowy');
+    }));
+
+    testWidgets('***AppFlowy** to bold *AppFlowy', ((widgetTester) async {
+      const text = '***AppFlowy*';
+      final editor = widgetTester.editor..insertTextNode('');
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+      final textNode = editor.nodeAtPath([0]) as TextNode;
+      for (var i = 0; i < text.length; i++) {
+        await editor.insertText(textNode, text[i], i);
+      }
+
+      await insertAsterisk(editor);
+
+      final allBold = textNode.allSatisfyBoldInSelection(Selection.single(
+          path: [0], startOffset: 1, endOffset: textNode.toPlainText().length));
+
+      expect(allBold, true);
+      expect(textNode.toPlainText(), '*AppFlowy');
+    }));
+
+    testWidgets('**** nothing changes', ((widgetTester) async {
+      const text = '***';
+      final editor = widgetTester.editor..insertTextNode('');
+
+      await editor.startTesting();
+      await editor.updateSelection(Selection.single(path: [0], startOffset: 0));
+      final textNode = editor.nodeAtPath([0]) as TextNode;
+      for (var i = 0; i < text.length; i++) {
+        await editor.insertText(textNode, text[i], i);
+      }
+
+      await insertAsterisk(editor);
+
+      final allBold = textNode.allSatisfyBoldInSelection(Selection.single(
+          path: [0], startOffset: 0, endOffset: textNode.toPlainText().length));
+
+      expect(allBold, false);
+      expect(textNode.toPlainText(), text);
+    }));
+  });
 }


### PR DESCRIPTION
Add the following two features which were removed due to license reason
1. double asterisk to bold text
2. remove the slash '/'  after clicking the selection menu item  

Related to #1900 
Resolves #1881 

