### PR TITLE
fix(appflowy_flutter): fix double click title issue #1324

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/left_bar_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/left_bar_item.dart
@@ -55,18 +55,26 @@ class _ViewLeftBarItemState extends State<ViewLeftBarItem> {
 
     return IntrinsicWidth(
       key: ValueKey(_controller.text),
-      child: TextField(
-        controller: _controller,
-        focusNode: _focusNode,
-        scrollPadding: EdgeInsets.zero,
-        decoration: const InputDecoration(
-          contentPadding: EdgeInsets.symmetric(vertical: 4.0),
-          border: InputBorder.none,
-          isDense: true,
+      child: GestureDetector(
+        onDoubleTap: () {
+          _controller.selection = TextSelection(
+            baseOffset: 0,
+            extentOffset: _controller.text.length,
+          );
+        },
+        child: TextField(
+          controller: _controller,
+          focusNode: _focusNode,
+          scrollPadding: EdgeInsets.zero,
+          decoration: const InputDecoration(
+            contentPadding: EdgeInsets.symmetric(vertical: 4.0),
+            border: InputBorder.none,
+            isDense: true,
+          ),
+          style: Theme.of(context).textTheme.bodyMedium,
+          // cursorColor: widget.cursorColor,
+          // obscureText: widget.enableObscure,
         ),
-        style: Theme.of(context).textTheme.bodyMedium,
-        // cursorColor: widget.cursorColor,
-        // obscureText: widget.enableObscure,
       ),
     );
   }


### PR DESCRIPTION
Double-click the title to select all the text on it.
Fix #1324 
