### PR TITLE
chore: changed the link of shortcuts page

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/question_bubble.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/question_bubble.dart
@@ -66,7 +66,7 @@ class BubbleActionList extends StatelessWidget {
               break;
             case BubbleAction.shortcuts:
               _launchURL(
-                  "https://github.com/AppFlowy-IO/AppFlowy-Docs/blob/main/essential-documentation/shortcuts.md");
+                  "https://appflowy.gitbook.io/docs/essential-documentation/shortcuts");
               break;
           }
         }


### PR DESCRIPTION
Solves #1977 

Now clicking on the shortcuts button points the user to [this](https://appflowy.gitbook.io/docs/essential-documentation/shortcuts).