### PR TITLE
[WIP]Feat(appflowy_flutter): dark mode/theme improvement(side bar theme improvement)

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/trash/menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/menu.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy/startup/plugin/plugin.dart';
 import 'package:appflowy/startup/startup.dart';
+import 'package:appflowy/workspace/application/sidebar_theme_extension.dart';
 import 'package:appflowy/workspace/presentation/home/home_stack.dart';
 import 'package:appflowy/workspace/presentation/home/menu/menu.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -43,6 +44,8 @@ class MenuTrash extends StatelessWidget {
   }
 
   Widget _render(BuildContext context) {
+    final sideBarStyle =
+        Theme.of(context).extension<AFSideBarThemeExtension>()!;
     return Row(
       children: [
         SizedBox(
@@ -50,11 +53,14 @@ class MenuTrash extends StatelessWidget {
           height: 16,
           child: svgWidget(
             "home/trash",
-            color: Theme.of(context).colorScheme.onSurface,
+            color: sideBarStyle.iconColor,
           ),
         ),
         const HSpace(6),
-        FlowyText.medium(LocaleKeys.trash_text.tr()),
+        FlowyText.medium(
+          LocaleKeys.trash_text.tr(),
+          color: sideBarStyle.subTitleTextColor,
+        ),
       ],
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:appflowy/user/application/user_settings_service.dart';
+import 'package:appflowy/workspace/application/sidebar_theme_extension.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_setting.pb.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -265,7 +266,7 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
         surfaceVariant: theme.bg1,
         shadow: theme.shadow,
       ),
-      extensions: [
+      extensions: <ThemeExtension<dynamic>>[
         AFThemeExtension(
           warning: theme.yellow,
           success: theme.green,
@@ -297,7 +298,10 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
             fontWeight: FontWeight.w400,
             fontColor: theme.shader3,
           ),
-        )
+        ),
+        brightness == Brightness.light
+            ? AFSideBarThemeExtension.light
+            : AFSideBarThemeExtension.dark,
       ],
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/application/sidebar_theme_extension.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/sidebar_theme_extension.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+class AFSideBarThemeExtension extends ThemeExtension<AFSideBarThemeExtension> {
+  const AFSideBarThemeExtension({
+    required this.backgroundColor,
+    required this.borderColor,
+    required this.iconColor,
+    required this.titleTextStyle,
+    required this.subTitleTextStyle,
+    required this.subTitleTextColor,
+    required this.hoverBgColor,
+    required this.hoverTextColor,
+    required this.tooltipBgColor,
+    required this.tooltipTextStyle,
+  });
+
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final Color? iconColor;
+  final TextStyle? titleTextStyle;
+  final TextStyle? subTitleTextStyle;
+  final Color? subTitleTextColor;
+  final Color? hoverBgColor;
+  final Color? hoverTextColor;
+  final Color? tooltipBgColor;
+  final TextStyle? tooltipTextStyle;
+
+  @override
+  ThemeExtension<AFSideBarThemeExtension> copyWith({
+    Color? backgroundColor,
+    Color? borderColor,
+    Color? iconColor,
+    TextStyle? titleTextStyle,
+    TextStyle? subTitleTextStyle,
+    Color? subTitleTextColor,
+    Color? hoverBgColor,
+    Color? hoverTextColor,
+    Color? tooltipBgColor,
+    TextStyle? tooltipTextStyle,
+  }) {
+    return AFSideBarThemeExtension(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      borderColor: borderColor ?? this.borderColor,
+      iconColor: iconColor ?? this.iconColor,
+      titleTextStyle: titleTextStyle ?? this.titleTextStyle,
+      subTitleTextStyle: subTitleTextStyle ?? this.subTitleTextStyle,
+      subTitleTextColor: subTitleTextColor ?? this.subTitleTextColor,
+      hoverBgColor: hoverBgColor ?? this.hoverBgColor,
+      hoverTextColor: hoverTextColor ?? this.hoverTextColor,
+      tooltipBgColor: tooltipBgColor ?? this.tooltipBgColor,
+      tooltipTextStyle: tooltipTextStyle ?? this.tooltipTextStyle,
+    );
+  }
+
+  @override
+  ThemeExtension<AFSideBarThemeExtension> lerp(
+      ThemeExtension<AFSideBarThemeExtension>? other, double t) {
+    if (other is! AFSideBarThemeExtension) {
+      return this;
+    }
+    return AFSideBarThemeExtension(
+      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t),
+      borderColor: Color.lerp(borderColor, other.borderColor, t),
+      iconColor: Color.lerp(iconColor, other.iconColor, t),
+      titleTextStyle: TextStyle.lerp(titleTextStyle, other.titleTextStyle, t),
+      subTitleTextStyle:
+          TextStyle.lerp(subTitleTextStyle, other.subTitleTextStyle, t),
+      subTitleTextColor:
+          Color.lerp(subTitleTextColor, other.subTitleTextColor, t),
+      hoverBgColor: Color.lerp(hoverBgColor, other.hoverBgColor, t),
+      hoverTextColor: Color.lerp(hoverTextColor, other.hoverTextColor, t),
+      tooltipBgColor: Color.lerp(tooltipBgColor, other.tooltipBgColor, t),
+      tooltipTextStyle:
+          TextStyle.lerp(tooltipTextStyle, other.tooltipTextStyle, t),
+    );
+  }
+
+  static const light = AFSideBarThemeExtension(
+    backgroundColor: Color(0xFFF7F8FC),
+    borderColor: Color(0xFFF2F2F2),
+    iconColor: Color(0xFF333333),
+    titleTextStyle: TextStyle(
+      fontWeight: FontWeight.w500,
+      color: Color(0xFF333333),
+      fontSize: 12,
+    ),
+    subTitleTextStyle: TextStyle(
+      fontWeight: FontWeight.w400,
+      fontSize: 12,
+    ),
+    subTitleTextColor: Color(0xFF333333),
+    hoverBgColor: Color(0xFFE0F8FF),
+    hoverTextColor: Color(0xFF333333),
+    tooltipBgColor: Color(0xFFE0F8FF),
+    tooltipTextStyle: TextStyle(
+      fontWeight: FontWeight.w500,
+      color: Color(0xFF333333),
+      fontSize: 12,
+    ),
+  );
+
+  static const dark = AFSideBarThemeExtension(
+    backgroundColor: Color(0xFF232B38),
+    borderColor: Color(0xFFF2F2F2),
+    iconColor: Color(0xFFBBC3CD),
+    titleTextStyle: TextStyle(
+      fontWeight: FontWeight.w500,
+      color: Colors.white,
+      fontSize: 12,
+    ),
+    subTitleTextStyle: TextStyle(
+      fontWeight: FontWeight.w500,
+      fontSize: 12,
+    ),
+    subTitleTextColor: Color(0xFFBBC3CD),
+    hoverBgColor: Color(0xFF363D49),
+    hoverTextColor: Color(0xFF131720),
+    tooltipBgColor: Color(0xFF00BCF0),
+    tooltipTextStyle: TextStyle(
+      fontWeight: FontWeight.w500,
+      color: Color(0xFF131720),
+      fontSize: 12,
+    ),
+  );
+}


### PR DESCRIPTION
This PR is the part of Dark mode improvement #1671 
3/14 update:
I plan to
1. Create `AFSideBarThemeExtension` to handler all the cosmetic attribute within the side bar area(the right section of the app). It has two modes to apply depends current user theme mode. 

<p float="left">
<img width="193" alt="image" src="https://user-images.githubusercontent.com/14248245/224850241-8749e91b-e002-4af9-9286-abdf2c377d78.png">

<img width="198" alt="image" src="https://user-images.githubusercontent.com/14248245/224850172-0ad784fc-97e8-4474-8cd8-7ce81f7b75ab.png">
</p>

2. Use the theme extension data in all widgets'  cosmetic attributes
<img width="542" alt="image" src="https://user-images.githubusercontent.com/14248245/224851315-76da4f62-2818-4d85-99b5-64866a166368.png">

3. (TODO) To use the colors in `FlowyColorScheme` in the `AFSideBarThemeExtension`. In this way, all the colors will come form its own theme under current light/dark mode. 
4. (TODO) Organize all the theme extension in different parts of the app.

