### PR TITLE
fix: scrolling selection-menu when it goes out of bound, fixes #2019

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/render/selection_menu/selection_menu_service.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/render/selection_menu/selection_menu_service.dart
@@ -88,28 +88,29 @@ class SelectionMenu implements SelectionMenuService {
 
     _selectionMenuEntry = OverlayEntry(builder: (context) {
       return Positioned(
-          top: showBelow ? _offset.dy : null,
-          bottom: showBelow ? null : _offset.dy,
-          left: offset.dx,
-          right: 0,
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: SelectionMenuWidget(
-              items: [
-                ..._defaultSelectionMenuItems,
-                ...editorState.selectionMenuItems,
-              ],
-              maxItemInRow: 5,
-              editorState: editorState,
-              menuService: this,
-              onExit: () {
-                dismiss();
-              },
-              onSelectionUpdate: () {
-                _selectionUpdateByInner = true;
-              },
-            ),
-          ));
+        top: showBelow ? _offset.dy : null,
+        bottom: showBelow ? null : _offset.dy,
+        left: offset.dx,
+        right: 0,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: SelectionMenuWidget(
+            items: [
+              ..._defaultSelectionMenuItems,
+              ...editorState.selectionMenuItems,
+            ],
+            maxItemInRow: 5,
+            editorState: editorState,
+            menuService: this,
+            onExit: () {
+              dismiss();
+            },
+            onSelectionUpdate: () {
+              _selectionUpdateByInner = true;
+            },
+          ),
+        ),
+      );
     });
 
     Overlay.of(context)?.insert(_selectionMenuEntry!);

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/render/selection_menu/selection_menu_service.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/render/selection_menu/selection_menu_service.dart
@@ -88,25 +88,28 @@ class SelectionMenu implements SelectionMenuService {
 
     _selectionMenuEntry = OverlayEntry(builder: (context) {
       return Positioned(
-        top: showBelow ? _offset.dy : null,
-        bottom: showBelow ? null : _offset.dy,
-        left: offset.dx,
-        child: SelectionMenuWidget(
-          items: [
-            ..._defaultSelectionMenuItems,
-            ...editorState.selectionMenuItems,
-          ],
-          maxItemInRow: 5,
-          editorState: editorState,
-          menuService: this,
-          onExit: () {
-            dismiss();
-          },
-          onSelectionUpdate: () {
-            _selectionUpdateByInner = true;
-          },
-        ),
-      );
+          top: showBelow ? _offset.dy : null,
+          bottom: showBelow ? null : _offset.dy,
+          left: offset.dx,
+          right: 0,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SelectionMenuWidget(
+              items: [
+                ..._defaultSelectionMenuItems,
+                ...editorState.selectionMenuItems,
+              ],
+              maxItemInRow: 5,
+              editorState: editorState,
+              menuService: this,
+              onExit: () {
+                dismiss();
+              },
+              onSelectionUpdate: () {
+                _selectionUpdateByInner = true;
+              },
+            ),
+          ));
     });
 
     Overlay.of(context)?.insert(_selectionMenuEntry!);


### PR DESCRIPTION
On small window sizes, the width of the slash menu becomes greater and the menu overflows the right boundary. The user was hence not able to access all the menu items.

This PR fixes this issue. Now Selection menu scrolls in case of overflow, otherwise it behaves as it used to originally.

The following video illustrates the change I have made :

https://user-images.githubusercontent.com/79906086/226300367-5ff771d5-fa8b-4474-b022-916beaa30b73.mov

fixes #2019 
