### PR TITLE
fix: sort hint text typo

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/sort/create_sort_list.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/sort/create_sort_list.dart
@@ -122,7 +122,7 @@ class _FilterTextFieldDelegate extends SliverPersistentHeaderDelegate {
         color: Theme.of(context).colorScheme.background,
         height: fixHeight,
         child: FlowyTextField(
-          hintText: LocaleKeys.grid_settings_filterBy.tr(),
+          hintText: LocaleKeys.grid_settings_sortBy.tr(),
           onChanged: (text) {
             context
                 .read<CreateSortBloc>()


### PR DESCRIPTION
### Description:

This pull request fixes the bug reported in issue #2044 where the hint text under the sort feature was misplaced. The expected behavior was to display "Sort by" in the hint text, but instead, it was displaying "Filter by".

### Type of change:

I fixed the bug by simply correcting the code, replacing "filterBy" with "sortBy" which references the correct hint text.
fixes #2044 
