### PR TITLE
fix: double asterisk to bold fixes #2080

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -309,7 +309,7 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Double asterisk to bold',
-    command: 'shift+asterisk',
+    character: '*',
     handler: doubleAsteriskToBoldHandler,
   ),
   ShortcutEvent(

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/service/shortcut_event/built_in_shortcut_events.dart
@@ -309,7 +309,7 @@ List<ShortcutEvent> builtInShortcutEvents = [
   ),
   ShortcutEvent(
     key: 'Double asterisk to bold',
-    command: 'shift+digit 8',
+    command: 'shift+asterisk',
     handler: doubleAsteriskToBoldHandler,
   ),
   ShortcutEvent(


### PR DESCRIPTION
Now, when you type text between two asterisks (e.g., \*bold text\*), it will appear in bold in the editor.


https://user-images.githubusercontent.com/98649066/227230689-0a7b00d6-4f99-4bf2-a4a8-911fd0e49e3e.mp4




Please note that I tested this feature on Windows, but I haven't had the chance to test it on MacOS yet. Therefore, I kindly ask all MacOS users to test this feature and report any issues they encounter.

Fixes #2080 