### PR TITLE
fix: open-ai replace does not work in certain use-cases

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -373,12 +373,6 @@ extension TextTransaction on Transaction {
       final length = texts.length;
       var path = textNodes.first.path;
 
-      //FIND OFFSET CHARACTERS AFTER SELECTION
-      String offSetChar =
-      (document.nodeAtPath(selection.end.path) as TextNode)
-          .toPlainText()
-          .substring(selection.end.offset);
-
       for (var i = 0; i < texts.length; i++) {
         final text = texts[i];
         if (i == 0) {
@@ -408,11 +402,15 @@ extension TextTransaction on Transaction {
             path = path.next;
           } else {
             if (i == texts.length - 1) {
-              //ADD OFFSET CHARACTER TO END OF LAST TEXT-NODE TO AVOID DATA LOSS
+              final delta = Delta()
+                ..insert(text)
+                ..addAll(
+                  textNodes.last.delta.slice(selection.end.offset),
+                );
               insertNode(
                 path,
                 TextNode(
-                  delta: Delta()..insert("${text}${offSetChar}"),
+                  delta: delta,
                 ),
               );
             } else {

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -371,6 +371,14 @@ extension TextTransaction on Transaction {
 
     if (textNodes.length < texts.length) {
       final length = texts.length;
+      var path = textNodes.first.path;
+
+      //FIND OFFSET CHARACTERS AFTER SELECTION
+      String offSetChar =
+      (document.nodeAtPath(selection.end.path) as TextNode)
+          .toPlainText()
+          .substring(selection.end.offset);
+
       for (var i = 0; i < texts.length; i++) {
         final text = texts[i];
         if (i == 0) {
@@ -380,7 +388,7 @@ extension TextTransaction on Transaction {
             textNodes.first.toPlainText().length,
             text,
           );
-        } else if (i == length - 1) {
+        } else if (i == length - 1 && textNodes.length >= 2) {
           replaceText(
             textNodes.last,
             0,
@@ -396,15 +404,23 @@ extension TextTransaction on Transaction {
               text,
             );
           } else {
-            var path = textNodes.first.path;
-            var j = i - textNodes.length + length - 1;
-            while (j > 0) {
-              path = path.next;
-              j--;
+            if (i == texts.length - 1) {
+              //ADD OFFSET CHARACTER TO END OF LAST TEXT-NODE TO AVOID DATA LOSS
+              document.insert(path, [
+                TextNode(
+                  delta: Delta()..insert("${text}${offSetChar}"),
+                ),
+              ]);
+            } else {
+              document.insert(path, [
+                TextNode(
+                  delta: Delta()..insert(text),
+                ),
+              ]);
             }
-            insertNode(path, TextNode(delta: Delta()..insert(text)));
           }
         }
+        path = path.next;
       }
       afterSelection = null;
       return;

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -33,19 +33,19 @@ class Transaction {
 
   /// Inserts the [Node] at the given [Path].
   void insertNode(
-      Path path,
-      Node node, {
-        bool deepCopy = true,
-      }) {
+    Path path,
+    Node node, {
+    bool deepCopy = true,
+  }) {
     insertNodes(path, [node], deepCopy: deepCopy);
   }
 
   /// Inserts a sequence of [Node]s at the given [Path].
   void insertNodes(
-      Path path,
-      Iterable<Node> nodes, {
-        bool deepCopy = true,
-      }) {
+    Path path,
+    Iterable<Node> nodes, {
+    bool deepCopy = true,
+  }) {
     if (deepCopy) {
       add(InsertOperation(path, nodes.map((e) => e.copyWith())));
     } else {
@@ -122,7 +122,9 @@ class Transaction {
   void add(Operation op, {bool transform = true}) {
     final Operation? last = operations.isEmpty ? null : operations.last;
     if (last != null) {
-      if (op is UpdateTextOperation && last is UpdateTextOperation && op.path.equals(last.path)) {
+      if (op is UpdateTextOperation &&
+          last is UpdateTextOperation &&
+          op.path.equals(last.path)) {
         final newOp = UpdateTextOperation(
           op.path,
           last.delta.compose(op.delta),
@@ -146,11 +148,11 @@ class Transaction {
 
 extension TextTransaction on Transaction {
   void mergeText(
-      TextNode first,
-      TextNode second, {
-        int? firstOffset,
-        int secondOffset = 0,
-      }) {
+    TextNode first,
+    TextNode second, {
+    int? firstOffset,
+    int secondOffset = 0,
+  }) {
     final firstLength = first.delta.length;
     final secondLength = second.delta.length;
     firstOffset ??= firstLength;
@@ -190,14 +192,15 @@ extension TextTransaction on Transaction {
   /// Optionally, you may specify formatting attributes that are applied to the inserted string.
   /// By default, the formatting attributes before the insert position will be reused.
   void insertText(
-      TextNode textNode,
-      int index,
-      String text, {
-        Attributes? attributes,
-      }) {
+    TextNode textNode,
+    int index,
+    String text, {
+    Attributes? attributes,
+  }) {
     var newAttributes = attributes;
     if (index != 0 && attributes == null) {
-      newAttributes = textNode.delta.slice(max(index - 1, 0), index).first.attributes;
+      newAttributes =
+          textNode.delta.slice(max(index - 1, 0), index).first.attributes;
       if (newAttributes != null) {
         newAttributes = {...newAttributes}; // make a copy
       }
@@ -215,11 +218,11 @@ extension TextTransaction on Transaction {
 
   /// Assigns a formatting attributes to a range of text.
   void formatText(
-      TextNode textNode,
-      int index,
-      int length,
-      Attributes attributes,
-      ) {
+    TextNode textNode,
+    int index,
+    int length,
+    Attributes attributes,
+  ) {
     afterSelection = beforeSelection;
     updateText(
       textNode,
@@ -231,10 +234,10 @@ extension TextTransaction on Transaction {
 
   /// Deletes the text of specified length starting at index.
   void deleteText(
-      TextNode textNode,
-      int index,
-      int length,
-      ) {
+    TextNode textNode,
+    int index,
+    int length,
+  ) {
     updateText(
       textNode,
       Delta()
@@ -251,15 +254,16 @@ extension TextTransaction on Transaction {
   /// Optionally, you may specify formatting attributes that are applied to the inserted string.
   /// By default, the formatting attributes before the insert position will be reused.
   void replaceText(
-      TextNode textNode,
-      int index,
-      int length,
-      String text, {
-        Attributes? attributes,
-      }) {
+    TextNode textNode,
+    int index,
+    int length,
+    String text, {
+    Attributes? attributes,
+  }) {
     var newAttributes = attributes;
     if (index != 0 && attributes == null) {
-      newAttributes = textNode.delta.slice(max(index - 1, 0), index).first.attributes;
+      newAttributes =
+          textNode.delta.slice(max(index - 1, 0), index).first.attributes;
       if (newAttributes == null) {
         final slicedDelta = textNode.delta.slice(index, index + length);
         if (slicedDelta.isNotEmpty) {
@@ -283,10 +287,10 @@ extension TextTransaction on Transaction {
   }
 
   void replaceTexts(
-      List<TextNode> textNodes,
-      Selection selection,
-      List<String> texts,
-      ) {
+    List<TextNode> textNodes,
+    Selection selection,
+    List<String> texts,
+  ) {
     if (textNodes.isEmpty || texts.isEmpty) {
       return;
     }
@@ -384,7 +388,6 @@ extension TextTransaction on Transaction {
             textNodes.first.toPlainText().length,
             text,
           );
-          path = path.next;
         } else if (i == length - 1 && textNodes.length >= 2) {
           replaceText(
             textNodes.last,
@@ -392,7 +395,6 @@ extension TextTransaction on Transaction {
             selection.endIndex,
             text,
           );
-          path = path.next;
         } else {
           if (i < textNodes.length - 1) {
             replaceText(
@@ -401,26 +403,24 @@ extension TextTransaction on Transaction {
               textNodes[i].toPlainText().length,
               text,
             );
-            path = path.next;
           } else {
             if (i == texts.length - 1) {
               //ADD OFFSET CHARACTER TO END OF LAST TEXT-NODE TO AVOID DATA LOSS
-              insertNode(
-                path,
+              document.insert(path, [
                 TextNode(
                   delta: Delta()..insert("${text}${offSetChar}"),
                 ),
-              );
+              ]);
             } else {
-              insertNode(
-                path,
+              document.insert(path, [
                 TextNode(
                   delta: Delta()..insert(text),
                 ),
-              );
+              ]);
             }
           }
         }
+        path = path.next;
       }
       afterSelection = null;
       return;

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -388,6 +388,7 @@ extension TextTransaction on Transaction {
             textNodes.first.toPlainText().length,
             text,
           );
+          path = path.next;
         } else if (i == length - 1 && textNodes.length >= 2) {
           replaceText(
             textNodes.last,
@@ -395,6 +396,7 @@ extension TextTransaction on Transaction {
             selection.endIndex,
             text,
           );
+          path = path.next;
         } else {
           if (i < textNodes.length - 1) {
             replaceText(
@@ -403,24 +405,26 @@ extension TextTransaction on Transaction {
               textNodes[i].toPlainText().length,
               text,
             );
+            path = path.next;
           } else {
             if (i == texts.length - 1) {
               //ADD OFFSET CHARACTER TO END OF LAST TEXT-NODE TO AVOID DATA LOSS
-              document.insert(path, [
+              insertNode(
+                path,
                 TextNode(
                   delta: Delta()..insert("${text}${offSetChar}"),
                 ),
-              ]);
+              );
             } else {
-              document.insert(path, [
+              insertNode(
+                path,
                 TextNode(
                   delta: Delta()..insert(text),
                 ),
-              ]);
+              );
             }
           }
         }
-        path = path.next;
       }
       afterSelection = null;
       return;

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -33,19 +33,19 @@ class Transaction {
 
   /// Inserts the [Node] at the given [Path].
   void insertNode(
-    Path path,
-    Node node, {
-    bool deepCopy = true,
-  }) {
+      Path path,
+      Node node, {
+        bool deepCopy = true,
+      }) {
     insertNodes(path, [node], deepCopy: deepCopy);
   }
 
   /// Inserts a sequence of [Node]s at the given [Path].
   void insertNodes(
-    Path path,
-    Iterable<Node> nodes, {
-    bool deepCopy = true,
-  }) {
+      Path path,
+      Iterable<Node> nodes, {
+        bool deepCopy = true,
+      }) {
     if (deepCopy) {
       add(InsertOperation(path, nodes.map((e) => e.copyWith())));
     } else {
@@ -122,9 +122,7 @@ class Transaction {
   void add(Operation op, {bool transform = true}) {
     final Operation? last = operations.isEmpty ? null : operations.last;
     if (last != null) {
-      if (op is UpdateTextOperation &&
-          last is UpdateTextOperation &&
-          op.path.equals(last.path)) {
+      if (op is UpdateTextOperation && last is UpdateTextOperation && op.path.equals(last.path)) {
         final newOp = UpdateTextOperation(
           op.path,
           last.delta.compose(op.delta),
@@ -148,11 +146,11 @@ class Transaction {
 
 extension TextTransaction on Transaction {
   void mergeText(
-    TextNode first,
-    TextNode second, {
-    int? firstOffset,
-    int secondOffset = 0,
-  }) {
+      TextNode first,
+      TextNode second, {
+        int? firstOffset,
+        int secondOffset = 0,
+      }) {
     final firstLength = first.delta.length;
     final secondLength = second.delta.length;
     firstOffset ??= firstLength;
@@ -192,15 +190,14 @@ extension TextTransaction on Transaction {
   /// Optionally, you may specify formatting attributes that are applied to the inserted string.
   /// By default, the formatting attributes before the insert position will be reused.
   void insertText(
-    TextNode textNode,
-    int index,
-    String text, {
-    Attributes? attributes,
-  }) {
+      TextNode textNode,
+      int index,
+      String text, {
+        Attributes? attributes,
+      }) {
     var newAttributes = attributes;
     if (index != 0 && attributes == null) {
-      newAttributes =
-          textNode.delta.slice(max(index - 1, 0), index).first.attributes;
+      newAttributes = textNode.delta.slice(max(index - 1, 0), index).first.attributes;
       if (newAttributes != null) {
         newAttributes = {...newAttributes}; // make a copy
       }
@@ -218,11 +215,11 @@ extension TextTransaction on Transaction {
 
   /// Assigns a formatting attributes to a range of text.
   void formatText(
-    TextNode textNode,
-    int index,
-    int length,
-    Attributes attributes,
-  ) {
+      TextNode textNode,
+      int index,
+      int length,
+      Attributes attributes,
+      ) {
     afterSelection = beforeSelection;
     updateText(
       textNode,
@@ -234,10 +231,10 @@ extension TextTransaction on Transaction {
 
   /// Deletes the text of specified length starting at index.
   void deleteText(
-    TextNode textNode,
-    int index,
-    int length,
-  ) {
+      TextNode textNode,
+      int index,
+      int length,
+      ) {
     updateText(
       textNode,
       Delta()
@@ -254,16 +251,15 @@ extension TextTransaction on Transaction {
   /// Optionally, you may specify formatting attributes that are applied to the inserted string.
   /// By default, the formatting attributes before the insert position will be reused.
   void replaceText(
-    TextNode textNode,
-    int index,
-    int length,
-    String text, {
-    Attributes? attributes,
-  }) {
+      TextNode textNode,
+      int index,
+      int length,
+      String text, {
+        Attributes? attributes,
+      }) {
     var newAttributes = attributes;
     if (index != 0 && attributes == null) {
-      newAttributes =
-          textNode.delta.slice(max(index - 1, 0), index).first.attributes;
+      newAttributes = textNode.delta.slice(max(index - 1, 0), index).first.attributes;
       if (newAttributes == null) {
         final slicedDelta = textNode.delta.slice(index, index + length);
         if (slicedDelta.isNotEmpty) {
@@ -287,10 +283,10 @@ extension TextTransaction on Transaction {
   }
 
   void replaceTexts(
-    List<TextNode> textNodes,
-    Selection selection,
-    List<String> texts,
-  ) {
+      List<TextNode> textNodes,
+      Selection selection,
+      List<String> texts,
+      ) {
     if (textNodes.isEmpty || texts.isEmpty) {
       return;
     }
@@ -388,6 +384,7 @@ extension TextTransaction on Transaction {
             textNodes.first.toPlainText().length,
             text,
           );
+          path = path.next;
         } else if (i == length - 1 && textNodes.length >= 2) {
           replaceText(
             textNodes.last,
@@ -395,6 +392,7 @@ extension TextTransaction on Transaction {
             selection.endIndex,
             text,
           );
+          path = path.next;
         } else {
           if (i < textNodes.length - 1) {
             replaceText(
@@ -403,24 +401,26 @@ extension TextTransaction on Transaction {
               textNodes[i].toPlainText().length,
               text,
             );
+            path = path.next;
           } else {
             if (i == texts.length - 1) {
               //ADD OFFSET CHARACTER TO END OF LAST TEXT-NODE TO AVOID DATA LOSS
-              document.insert(path, [
+              insertNode(
+                path,
                 TextNode(
                   delta: Delta()..insert("${text}${offSetChar}"),
                 ),
-              ]);
+              );
             } else {
-              document.insert(path, [
+              insertNode(
+                path,
                 TextNode(
                   delta: Delta()..insert(text),
                 ),
-              ]);
+              );
             }
           }
         }
-        path = path.next;
       }
       afterSelection = null;
       return;

--- a/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/lib/src/core/transform/transaction.dart
@@ -363,6 +363,19 @@ extension TextTransaction on Transaction {
           );
         } else {
           deleteNode(textNode);
+          if (i == textNodes.length - 1) {
+            final delta = Delta()
+              ..insert(texts[0])
+              ..addAll(
+                textNodes.last.delta.slice(selection.end.offset),
+              );
+            replaceText(
+              textNode,
+              selection.start.offset,
+              texts[0].length,
+              delta.toPlainText(),
+            );
+          }
         }
       }
       afterSelection = null;

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
@@ -125,7 +125,7 @@ void main() async {
           .map((e) => editor.nodeAtPath([e])!)
           .whereType<TextNode>()
           .toList(growable: false);
-      expect(textNodes[0].toPlainText(), '0123ABC');
+      expect(textNodes[0].toPlainText(), '0123ABC456789');
     });
 
     testWidgets('test replaceTexts, textNodes.length < texts.length',

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
@@ -155,52 +155,52 @@ void main() async {
       editor.editorState.apply(transaction);
       await tester.pumpAndSettle();
 
-          expect(editor.documentLength, 4);
-          textNodes = [0, 1, 2, 3]
-              .map((e) => editor.nodeAtPath([e])!)
-              .whereType<TextNode>()
-              .toList(growable: false);
-          expect(textNodes[0].toPlainText(), '0123ABC');
-          expect(textNodes[1].toPlainText(), 'ABC');
-          expect(textNodes[2].toPlainText(), 'ABC');
-          expect(textNodes[3].toPlainText(), 'ABC456789');
-        });
+      expect(editor.documentLength, 4);
+      textNodes = [0, 1, 2, 3]
+          .map((e) => editor.nodeAtPath([e])!)
+          .whereType<TextNode>()
+          .toList(growable: false);
+      expect(textNodes[0].toPlainText(), '0123ABC');
+      expect(textNodes[1].toPlainText(), 'ABC');
+      expect(textNodes[2].toPlainText(), 'ABC');
+      expect(textNodes[3].toPlainText(), 'ABC456789');
+    });
 
     testWidgets('test replaceTexts, textNodes.length << texts.length',
-            (tester) async {
-          TestWidgetsFlutterBinding.ensureInitialized();
+        (tester) async {
+      TestWidgetsFlutterBinding.ensureInitialized();
 
-          final editor = tester.editor
-            ..insertTextNode('some text');
-          await editor.startTesting();
-          await tester.pumpAndSettle();
+      final editor = tester.editor..insertTextNode('Welcome to AppFlowy!');
+      await editor.startTesting();
+      await tester.pumpAndSettle();
 
-          expect(editor.documentLength, 1);
+      expect(editor.documentLength, 1);
 
-          final selection = Selection(
-            start: Position(path: [0], offset:0),
-            end: Position(path: [0], offset: 9),
-          );
-          final transaction = editor.editorState.transaction;
-          var textNodes = [0]
-              .map((e) => editor.nodeAtPath([e])!)
-              .whereType<TextNode>()
-              .toList(growable: false);
-          final texts = ['ABC1', 'ABC2', 'ABC3', 'ABC4','ABC5'];
-          transaction.replaceTexts(textNodes, selection, texts);
-          editor.editorState.apply(transaction);
-          await tester.pumpAndSettle();
+      // select 'to'
+      final selection = Selection(
+        start: Position(path: [0], offset: 8),
+        end: Position(path: [0], offset: 10),
+      );
+      final transaction = editor.editorState.transaction;
+      var textNodes = [0]
+          .map((e) => editor.nodeAtPath([e])!)
+          .whereType<TextNode>()
+          .toList(growable: false);
+      final texts = ['ABC1', 'ABC2', 'ABC3', 'ABC4', 'ABC5'];
+      transaction.replaceTexts(textNodes, selection, texts);
+      editor.editorState.apply(transaction);
+      await tester.pumpAndSettle();
 
-          expect(editor.documentLength, 5);
-          textNodes = [0, 1, 2, 3,4]
-              .map((e) => editor.nodeAtPath([e])!)
-              .whereType<TextNode>()
-              .toList(growable: false);
-          expect(textNodes[0].toPlainText(), 'ABC1');
-          expect(textNodes[1].toPlainText(), 'ABC2');
-          expect(textNodes[2].toPlainText(), 'ABC3');
-          expect(textNodes[3].toPlainText(), 'ABC4');
-          expect(textNodes[4].toPlainText(), 'ABC5');
-        });
+      expect(editor.documentLength, 5);
+      textNodes = [0, 1, 2, 3, 4]
+          .map((e) => editor.nodeAtPath([e])!)
+          .whereType<TextNode>()
+          .toList(growable: false);
+      expect(textNodes[0].toPlainText(), 'Welcome ABC1');
+      expect(textNodes[1].toPlainText(), 'ABC2');
+      expect(textNodes[2].toPlainText(), 'ABC3');
+      expect(textNodes[3].toPlainText(), 'ABC4');
+      expect(textNodes[4].toPlainText(), 'ABC5 AppFlowy!');
+    });
   });
 }

--- a/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_editor/test/core/transform/transaction_test.dart
@@ -155,15 +155,52 @@ void main() async {
       editor.editorState.apply(transaction);
       await tester.pumpAndSettle();
 
-      expect(editor.documentLength, 4);
-      textNodes = [0, 1, 2, 3]
-          .map((e) => editor.nodeAtPath([e])!)
-          .whereType<TextNode>()
-          .toList(growable: false);
-      expect(textNodes[0].toPlainText(), '0123ABC');
-      expect(textNodes[1].toPlainText(), 'ABC');
-      expect(textNodes[2].toPlainText(), 'ABC');
-      expect(textNodes[3].toPlainText(), 'ABC456789');
-    });
+          expect(editor.documentLength, 4);
+          textNodes = [0, 1, 2, 3]
+              .map((e) => editor.nodeAtPath([e])!)
+              .whereType<TextNode>()
+              .toList(growable: false);
+          expect(textNodes[0].toPlainText(), '0123ABC');
+          expect(textNodes[1].toPlainText(), 'ABC');
+          expect(textNodes[2].toPlainText(), 'ABC');
+          expect(textNodes[3].toPlainText(), 'ABC456789');
+        });
+
+    testWidgets('test replaceTexts, textNodes.length << texts.length',
+            (tester) async {
+          TestWidgetsFlutterBinding.ensureInitialized();
+
+          final editor = tester.editor
+            ..insertTextNode('some text');
+          await editor.startTesting();
+          await tester.pumpAndSettle();
+
+          expect(editor.documentLength, 1);
+
+          final selection = Selection(
+            start: Position(path: [0], offset:0),
+            end: Position(path: [0], offset: 9),
+          );
+          final transaction = editor.editorState.transaction;
+          var textNodes = [0]
+              .map((e) => editor.nodeAtPath([e])!)
+              .whereType<TextNode>()
+              .toList(growable: false);
+          final texts = ['ABC1', 'ABC2', 'ABC3', 'ABC4','ABC5'];
+          transaction.replaceTexts(textNodes, selection, texts);
+          editor.editorState.apply(transaction);
+          await tester.pumpAndSettle();
+
+          expect(editor.documentLength, 5);
+          textNodes = [0, 1, 2, 3,4]
+              .map((e) => editor.nodeAtPath([e])!)
+              .whereType<TextNode>()
+              .toList(growable: false);
+          expect(textNodes[0].toPlainText(), 'ABC1');
+          expect(textNodes[1].toPlainText(), 'ABC2');
+          expect(textNodes[2].toPlainText(), 'ABC3');
+          expect(textNodes[3].toPlainText(), 'ABC4');
+          expect(textNodes[4].toPlainText(), 'ABC5');
+        });
   });
 }


### PR DESCRIPTION
Replacing lesser number of available multi-line text nodes with higher number of incoming multi-line nodes lead to inconsistencies such as overwriting and unexpected line skips, this PR fixes the issue.

fixes #2092 