### PR TITLE
fix: modify same database by duplicate view

### DIFF
--- a/frontend/.vscode/launch.json
+++ b/frontend/.vscode/launch.json
@@ -12,8 +12,8 @@
             "type": "dart",
             "preLaunchTask": "AF: Build Appflowy Core",
             "env": {
-                // "RUST_LOG": "trace",
-                "RUST_LOG": "debug"
+                "RUST_LOG": "trace",
+                // "RUST_LOG": "debug"
             },
             "cwd": "${workspaceRoot}/appflowy_flutter"
         },

--- a/frontend/rust-lib/flowy-database/src/manager.rs
+++ b/frontend/rust-lib/flowy-database/src/manager.rs
@@ -417,7 +417,6 @@ pub async fn create_new_database(
     DatabaseViewRevision::from_json(database_view_data)?
   };
 
-  tracing::trace!("Initial calendar layout setting: {:?}", layout_setting);
   database_view_rev.layout_settings = layout_setting;
   let database_view_ops = make_database_view_operations(&database_view_rev);
   let database_view_bytes = database_view_ops.json_bytes();

--- a/frontend/rust-lib/flowy-database/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database/src/services/database/database_editor.rs
@@ -888,9 +888,12 @@ impl DatabaseEditor {
     Ok(())
   }
 
-  pub async fn duplicate_database(&self, view_id: &str) -> FlowyResult<BuildDatabaseContext> {
+  pub async fn duplicate_database(&self, _view_id: &str) -> FlowyResult<BuildDatabaseContext> {
     let database_pad = self.database_pad.read().await;
-    let database_view_data = self.database_views.duplicate_database_view(view_id).await?;
+    // let database_view_data = self
+    //   .database_views
+    //   .duplicate_database_view_setting(view_id)
+    //   .await?;
     let original_blocks = database_pad.get_block_meta_revs();
     let (duplicated_fields, duplicated_blocks) = database_pad.duplicate_database_block_meta().await;
 
@@ -919,7 +922,7 @@ impl DatabaseEditor {
       block_metas: duplicated_blocks,
       blocks: blocks_meta_data,
       layout_setting: Default::default(),
-      database_view_data,
+      database_view_data: "".to_string(),
     })
   }
 

--- a/frontend/rust-lib/flowy-database/src/services/database_view/editor.rs
+++ b/frontend/rust-lib/flowy-database/src/services/database_view/editor.rs
@@ -238,7 +238,7 @@ impl DatabaseViewEditor {
     self.filter_controller.filter_row_revs(rows).await;
   }
 
-  pub async fn v_duplicate_data(&self) -> FlowyResult<String> {
+  pub async fn v_duplicate_view_setting(&self) -> FlowyResult<String> {
     let json_str = self.pad.read().await.json_str()?;
     Ok(json_str)
   }

--- a/frontend/rust-lib/flowy-database/src/services/database_view/editor_manager.rs
+++ b/frontend/rust-lib/flowy-database/src/services/database_view/editor_manager.rs
@@ -101,9 +101,9 @@ impl DatabaseViews {
     Ok(row_revs)
   }
 
-  pub async fn duplicate_database_view(&self, view_id: &str) -> FlowyResult<String> {
+  pub async fn duplicate_database_view_setting(&self, view_id: &str) -> FlowyResult<String> {
     let editor = self.get_view_editor(view_id).await?;
-    let view_data = editor.v_duplicate_data().await?;
+    let view_data = editor.v_duplicate_view_setting().await?;
     Ok(view_data)
   }
 


### PR DESCRIPTION
Duplicating view including duplicating the setting and data of the view. Currently,  only duplicate the data of the view.  Duplicating the setting of the view will be done in another PR.