### PR TITLE
fix: Replace `Shortcuts` icon in the help menu option to fix misalignment 

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/question_bubble.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/question_bubble.dart
@@ -203,7 +203,7 @@ extension QuestionBubbleExtension on BubbleAction {
       case BubbleAction.debug:
         return '🐛';
       case BubbleAction.shortcuts:
-        return '⌨️';
+        return '📋';
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/AppFlowy-IO/AppFlowy/issues/2062

### Issue Description
The shortcut option in the help menu is misaligned. This is due to the emoji being smaller in size compared to other emojis.

### Reproduction Step
Click on the `?` icon on the bottom right section of the app.

> Screenshot
<img width="261" alt="issue" src="https://user-images.githubusercontent.com/13991373/227417737-1409232d-a992-4b3c-8d10-ff45a5e505c6.png">

### Fix Description
Replaced current emoji with clipboard emoji which is more appropriate in size as suggested [here](https://github.com/AppFlowy-IO/AppFlowy/issues/2062#issuecomment-1480461543)

> Screenshot

![image](https://user-images.githubusercontent.com/13991373/227417999-877a9498-530f-4eec-aee2-4500c9906c77.png)


---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.

