### PR TITLE
Fix: referenced board and grid keywords

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/board/board_menu_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/board/board_menu_item.dart
@@ -18,7 +18,7 @@ SelectionMenuItem boardMenuItem = SelectionMenuItem(
     );
   },
   // TODO(a-wallen): Translate keywords
-  keywords: ['referenced board', 'referenced kanban'],
+  keywords: ['referenced', 'board', 'kanban'],
   handler: (editorState, menuService, context) {
     showLinkToPageMenu(
       editorState,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/grid/grid_menu_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/grid/grid_menu_item.dart
@@ -17,7 +17,7 @@ SelectionMenuItem gridMenuItem = SelectionMenuItem(
           : editorState.editorStyle.selectionMenuItemIconColor,
     );
   },
-  keywords: ['referenced grid'],
+  keywords: ['referenced', 'grid'],
   handler: (editorState, menuService, context) {
     showLinkToPageMenu(
       editorState,


### PR DESCRIPTION
Fixed the issue with Referenced Board/Referenced Grid not appearing when using the slash menu command "/referenced". The keywords for these items have been rewritten and now they can be inserted using either the slash menu `/referenced`, `/board`, `/grid`, or `/kanban` command.

fixes https://github.com/AppFlowy-IO/AppFlowy/issues/2139