### PR TITLE
Fix: Null check error in FlowyHoverContainer

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_accessory.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_accessory.dart
@@ -123,7 +123,6 @@ class _AccessoryHoverState extends State<AccessoryHover> {
   @override
   Widget build(BuildContext context) {
     List<Widget> children = [
-      const _Background(),
       Padding(padding: widget.contentPadding, child: widget.child),
     ];
 
@@ -169,28 +168,6 @@ class AccessoryHoverState extends ChangeNotifier {
   }
 
   bool get onHover => _onHover;
-}
-
-class _Background extends StatelessWidget {
-  const _Background({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Consumer<AccessoryHoverState>(
-      builder: (context, state, child) {
-        if (state.onHover) {
-          return FlowyHoverContainer(
-            style: HoverStyle(
-              borderRadius: Corners.s6Border,
-              hoverColor: AFThemeExtension.of(context).lightGreyHover,
-            ),
-          );
-        } else {
-          return const SizedBox();
-        }
-      },
-    );
-  }
 }
 
 class CellAccessoryContainer extends StatelessWidget {

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_accessory.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_accessory.dart
@@ -3,7 +3,6 @@ import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flowy_infra/size.dart';
 import 'package:styled_widget/styled_widget.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:easy_localization/easy_localization.dart';

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
@@ -115,11 +115,11 @@ class HoverStyle {
 
 class FlowyHoverContainer extends StatelessWidget {
   final HoverStyle style;
-  final Widget? child;
+  final Widget child;
 
   const FlowyHoverContainer({
     Key? key,
-    this.child,
+    required this.child,
     required this.style,
   }) : super(key: key);
 
@@ -151,7 +151,7 @@ class FlowyHoverContainer extends StatelessWidget {
               .iconTheme
               .copyWith(color: Theme.of(context).colorScheme.onSurface),
         ),
-        child: child ?? const SizedBox.shrink(),
+        child: child,
       ),
     );
   }

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
@@ -151,7 +151,7 @@ class FlowyHoverContainer extends StatelessWidget {
               .iconTheme
               .copyWith(color: Theme.of(context).colorScheme.onSurface),
         ),
-        child: child!,
+        child: child ?? const SizedBox.shrink(),
       ),
     );
   }


### PR DESCRIPTION
I added a `SizedBox.shrink()` when there is no child in the `FlowyHoverContainer` in order to prevent the null check error happen again. Meanwhile, I delete the `_background` widget since it doesn't show any UI effect anyway. 

Fixes #2147 

https://user-images.githubusercontent.com/14248245/228919011-4dea812b-4356-4d75-b573-cb9ca5d04d12.mov

