### PR TITLE
feat: added auto hide sidebar when resizing the app window in a desktop

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/home/home_setting_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/home/home_setting_bloc.dart
@@ -42,6 +42,19 @@ class HomeSettingBloc extends Bloc<HomeSettingEvent, HomeSettingState> {
             var isMenuCollapsed = !state.isMenuCollapsed;
             _appearanceSettingsCubit.saveIsMenuCollapsed(isMenuCollapsed);
             emit(state.copyWith(isMenuCollapsed: isMenuCollapsed));
+            if (state.isSmallScreen) {
+              emit(state.copyWith(pinSideBar: !isMenuCollapsed));
+            } else {
+              if (state.isMenuCollapsed) {
+                emit(state.copyWith(pinSideBar: !isMenuCollapsed));
+              }
+            }
+          },
+          pinSideBar: (_PinSideBar e) {
+            emit(state.copyWith(pinSideBar: e.pinSideBar));
+          },
+          isSmallScreen: (_IsSmallScreen e) {
+            emit(state.copyWith(isSmallScreen: e.isSmallScreen));
           },
           editPanelResizeStart: (_EditPanelResizeStart e) {
             emit(state.copyWith(
@@ -97,6 +110,9 @@ class HomeSettingEvent with _$HomeSettingEvent {
   const factory HomeSettingEvent.didReceiveWorkspaceSetting(
       WorkspaceSettingPB setting) = _DidReceiveWorkspaceSetting;
   const factory HomeSettingEvent.collapseMenu() = _CollapseMenu;
+  const factory HomeSettingEvent.pinSideBar(bool pinSideBar) = _PinSideBar;
+  const factory HomeSettingEvent.isSmallScreen(bool isSmallScreen) =
+      _IsSmallScreen;
   const factory HomeSettingEvent.editPanelResized(double offset) =
       _EditPanelResized;
   const factory HomeSettingEvent.editPanelResizeStart() = _EditPanelResizeStart;
@@ -110,7 +126,9 @@ class HomeSettingState with _$HomeSettingState {
     required WorkspaceSettingPB workspaceSetting,
     required bool unauthorized,
     required bool isMenuCollapsed,
+    required bool pinSideBar,
     required double resizeOffset,
+    required bool isSmallScreen,
     required double resizeStart,
     required MenuResizeType resizeType,
   }) = _HomeSettingState;
@@ -123,6 +141,8 @@ class HomeSettingState with _$HomeSettingState {
         panelContext: none(),
         workspaceSetting: workspaceSetting,
         unauthorized: false,
+        pinSideBar: false,
+        isSmallScreen: false,
         isMenuCollapsed: appearanceSettingsState.isMenuCollapsed,
         resizeOffset: appearanceSettingsState.menuOffset,
         resizeStart: 0,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
@@ -19,12 +19,12 @@ class HomeLayout {
   late double homePageROffset;
   late double menuSpacing;
   late Duration animDuration;
-
+  
   HomeLayout(BuildContext context, BoxConstraints homeScreenConstraint) {
     final homeSetting = context.read<HomeSettingBloc>().state;
 
     showEditPanel = homeSetting.panelContext.isSome();
-
+    
     menuWidth = Sizes.sideBarMed;
     if (context.widthPx >= PageBreaks.desktop) {
       menuWidth = Sizes.sideBarLg;
@@ -32,13 +32,29 @@ class HomeLayout {
 
     menuWidth += homeSetting.resizeOffset;
 
-    if (homeSetting.isMenuCollapsed) {
-      showMenu = false;
-    } else {
-      showMenu = true;
-      menuIsDrawer = context.widthPx <= PageBreaks.tabletPortrait;
-    }
+    bool isSmallScreen = false;
 
+    if (context.widthPx < PageBreaks.tabletPortrait) isSmallScreen = true;
+    context
+        .read<HomeSettingBloc>()
+        .add(HomeSettingEvent.isSmallScreen(isSmallScreen));
+
+    if (isSmallScreen) {
+      if (homeSetting.pinSideBar) {
+        showMenu = true;
+        menuIsDrawer = context.widthPx <= PageBreaks.tabletPortrait;
+      } else {
+        showMenu = false;
+      }
+    } else {
+      if (homeSetting.isMenuCollapsed && !homeSetting.pinSideBar) {
+        showMenu = false;
+      } else {
+        showMenu = true;
+        menuIsDrawer = context.widthPx <= PageBreaks.tabletPortrait;
+      }
+    } 
+       
     homePageLOffset = (showMenu && !menuIsDrawer) ? menuWidth : 0.0;
 
     menuSpacing = !showMenu && Platform.isMacOS ? 80.0 : 0.0;

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/navigation.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/navigation.dart
@@ -64,9 +64,9 @@ class FlowyNavigation extends StatelessWidget {
 
   Widget _renderCollapse(BuildContext context) {
     return BlocBuilder<HomeSettingBloc, HomeSettingState>(
-      buildWhen: (p, c) => p.isMenuCollapsed != c.isMenuCollapsed,
+      buildWhen: (p, c) => p.isMenuCollapsed != c.isMenuCollapsed || p.isSmallScreen != c.isSmallScreen,
       builder: (context, state) {
-        if (state.isMenuCollapsed) {
+        if (state.isMenuCollapsed || ((state.isSmallScreen) && !state.pinSideBar)) {
           return RotationTransition(
             turns: const AlwaysStoppedAnimation(180 / 360),
             child: Tooltip(
@@ -77,10 +77,10 @@ class FlowyNavigation extends StatelessWidget {
                 child: FlowyIconButton(
                   width: 24,
                   hoverColor: Colors.transparent,
-                  onPressed: () {
-                    context
+                  onPressed: () {                  
+                      context
                         .read<HomeSettingBloc>()
-                        .add(const HomeSettingEvent.collapseMenu());
+                        .add(const HomeSettingEvent.collapseMenu());   
                   },
                   iconPadding: const EdgeInsets.fromLTRB(2, 2, 2, 2),
                   icon: svgWidget(


### PR DESCRIPTION
This is useful for users resizing their appflowy window to a smaller screen while in use. 
It takes care of [FR] #1674

Attached is a short clip showing the feature in play

https://user-images.githubusercontent.com/25469676/229218687-1b98183b-7bd3-4715-9aa3-c3e2421499b6.mp4

