### PR TITLE
Fix the app's Dockerfile and comment it

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -1,63 +1,80 @@
+#================
+# BUILDER
+#================
+
 FROM archlinux/archlinux:base-devel as builder
 
-RUN pacman -Syy
+# Upgrade the system
+RUN pacman -Syyu --noconfirm
 
-RUN pacman -Syu --needed --noconfirm git xdg-user-dirs
-
-# makepkg user and workdir
+# Set up makepkg user and workdir
 ARG user=makepkg
-ENV PATH="/home/$user/.pub-cache/bin:/home/$user/.local/flutter/bin:/home/$user/.local/flutter/bin/cache/dart-sdk/bin:${PATH}"
-RUN useradd --system --create-home $user \
-  && echo "$user ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/$user
+RUN pacman -S --needed --noconfirm sudo
+RUN useradd --system --create-home $user && \
+    echo "$user ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+ENV PATH="/home/$user/.pub-cache/bin:/home/$user/flutter/bin:/home/$user/flutter/bin/cache/dart-sdk/bin:${PATH}"
 USER $user
 WORKDIR /home/$user
 
 # Install yay
-RUN git clone https://aur.archlinux.org/yay.git \
-  && cd yay \
-  && makepkg -sri --needed --noconfirm
+RUN sudo pacman -S --needed --noconfirm git
+RUN git clone --depth 1 https://aur.archlinux.org/yay.git && \
+    cd yay && \
+    makepkg -sri --needed --noconfirm
 
-RUN yay -S --noconfirm curl base-devel sqlite openssl clang cmake ninja pkg-config gtk3 unzip
+# Install Rust
+RUN yay -S --noconfirm curl base-devel openssl clang cmake ninja pkg-config xdg-user-dirs
 RUN xdg-user-dirs-update
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN source $HOME/.cargo/env && rustup toolchain install stable && rustup default stable
-RUN git clone https://github.com/flutter/flutter.git $HOME/.local/flutter
-RUN flutter channel stable
+RUN source ~/.cargo/env && \
+    rustup toolchain install stable && \
+    rustup default stable
+
+# Install Flutter
+RUN sudo pacman -S --noconfirm tar gtk3
+RUN curl -sSfL \
+      --output flutter.tar.xz \
+      https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.3.10-stable.tar.xz && \
+    tar -xf flutter.tar.xz && \
+    rm flutter.tar.xz
 RUN flutter config --enable-linux-desktop
 RUN flutter doctor
 RUN dart pub global activate protoc_plugin
-RUN sudo pacman -Syu --needed --noconfirm git xdg-user-dirs libkeybinder3
 
-RUN git clone https://github.com/AppFlowy-IO/appflowy.git && \
-cd appflowy/frontend && \
-source $HOME/.cargo/env && \
-cargo install --force cargo-make && \
-cargo install --force duckscript_cli && \
-cargo make appflowy-flutter-deps-tools && \
-cargo make -p production-linux-x86_64 appflowy-linux
+# Build the AppFlowy app
+RUN sudo pacman -S --noconfirm libkeybinder3 sqlite
+RUN git clone --depth 1 https://github.com/AppFlowy-IO/appflowy.git
+RUN cd appflowy/frontend && \
+    source ~/.cargo/env && \
+    cargo install --force cargo-make duckscript_cli && \
+    cargo make appflowy-flutter-deps-tools && \
+    cargo make -p production-linux-x86_64 appflowy-linux
 
-CMD ["/home/makepkg/appflowy/frontend/appflowy_flutter/build/linux/x64/release/bundle/appflowy_flutter"]
 
-#################
+#================
+# APP
+#================
+
 FROM archlinux/archlinux
 
-RUN pacman -Syy && \
-    pacman -Syu --needed --noconfirm xdg-user-dirs && \
+# Upgrade the system
+RUN pacman -Syyu --noconfirm
+
+# Install runtime dependencies
+RUN pacman -S --noconfirm xdg-user-dirs gtk3 libkeybinder3 && \
     pacman -Scc --noconfirm
-RUN xdg-user-dirs-update
 
-COPY --from=builder /usr/sbin/yay /usr/sbin/yay
-RUN yay -S --noconfirm gtk3 libkeybinder3
-
+# Set up appflowy user
 ARG user=appflowy
 ARG uid=1000
 ARG gid=1000
-
-RUN groupadd --gid $gid appflowy
+RUN groupadd --gid $gid $user
 RUN useradd --create-home --uid $uid --gid $gid $user
 USER $user
+
+# Set up the AppFlowy app
 WORKDIR /home/$user
+COPY --from=builder /home/makepkg/appflowy/frontend/appflowy_flutter/build/linux/x64/release/bundle .
+RUN xdg-user-dirs-update
 
-COPY --from=builder /home/makepkg/appflowy/frontend/appflowy_flutter/build/linux/x64/release/bundle/ .
-
-CMD ["./appflowy_flutter"]
+CMD ["./AppFlowy"]

--- a/frontend/scripts/docker-buildfiles/docker-compose.yml
+++ b/frontend/scripts/docker-buildfiles/docker-compose.yml
@@ -1,5 +1,11 @@
 version: "3"
 
+# NOTE: Docker should be allowed to connect to the X server in your host prior
+# to running `docker compose up`. Run `xhost local:docker` in the host to allow
+# for those connections, otherwise the following error will occur:
+#         Gtk-WARNING **: cannot open display: :0
+# See https://stackoverflow.com/a/34586732/8401696 for more context.
+
 services:
   app:
     build: .
@@ -7,17 +13,18 @@ services:
     stdin_open: true
     # tty: true
     devices:
-      - "/dev/dri:/dev/dri" # fixes MESA-LOADER error
+      - /dev/dri:/dev/dri # fixes MESA-LOADER error
     environment:
-      - DISPLAY=${DISPLAY}
+      - DISPLAY=$DISPLAY
       - NO_AT_BRIDGE=1 # fixes dbind-WARNING
     volumes:
       - $HOME/.Xauthority:/root/.Xauthority:rw
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /dev/dri:/dev/dri
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
-      - appflowy-data:/home/makepkg
+      - builder-data:/home/makepkg
+      - /etc/pacman.d/mirrorlist:/etc/pacman.d/mirrorlist
     network_mode: host
 
 volumes:
-  appflowy-data:
+  builder-data: # Used to cache build artifacts and thus speed up image rebuilds


### PR DESCRIPTION
# Description

While trying to run the app through Docker (following https://appflowy.gitbook.io/docs/essential-documentation/install-appflowy/installation-methods/installing-with-docker) I ran into the following issues:

- Some mirrors were unavailable or timing out for me, e.g.
  `failed retrieving file 'libtiff-4.5.0-3-x86_64.pkg.tar.zst.sig' from geo.mirror.pkgbuild.com : Operation too slow. Less than 1 bytes/sec transferred the last 10 seconds`.

  Solved by mounting my own `/etc/pacman.d/mirrorlist` into the container.

- [The app is only compatible with Flutter 3.3.10](https://github.com/AppFlowy-IO/AppFlowy/issues/1741), but the Flutter version is not pinned in the Docker image.

  Solved by downloading the precise version according to https://docs.flutter.dev/get-started/install/linux#install-flutter-manually.

- I needed to run `xhost local:docker` in my host prior to starting the app, otherwise an error will occur

  Solved by running the aforementioned command and adding a note about it.

- The entrypoint `["./appflowy_flutter"]` apparently is incorrect

  Solved by figuring out where the executable is located within the generated bundle with `find . -executable -type f`

While going through those issues and solving them, I tinkered with the image and added some comments along the way.

# Trying it out

```console
$ cd frontend/scripts/docker-buildfiles
$ docker-compose rm -fvs
$ docker image rm --force appflowy/appflowy:latest
$ docker-compose up
```