### PR TITLE
fix: support for arrow key and tab selection in referenced board/grid

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/base/link_to_page_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/base/link_to_page_widget.dart
@@ -7,6 +7,7 @@ import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra_ui/style_widget/button.dart';
 import 'package:flowy_infra_ui/style_widget/text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'insert_page_command.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -92,85 +93,163 @@ class LinkToPageMenu extends StatefulWidget {
 }
 
 class _LinkToPageMenuState extends State<LinkToPageMenu> {
+  final _focusNode = FocusNode(debugLabel: 'reference_list_widget');
   EditorStyle get style => widget.editorState.editorStyle;
+  int _selectedIndex = 0;
+  List<dartz.Tuple2<AppPB, List<ViewPB>>> _availableLayout = [];
+  final Map<int, dartz.Tuple2<AppPB, ViewPB>> _items = {};
+  bool _isLoading = true;
+
+  Future<void> fetchItems() async {
+    final items = await AppBackendService().fetchViews(widget.layoutType);
+
+    setState(() {
+      _availableLayout = items;
+      _isLoading = false;
+    });
+
+    int index = 0;
+    for (final app in _availableLayout) {
+      for (final view in app.value2) {
+        _items.putIfAbsent(index, () => dartz.Tuple2(app.value1, view));
+      }
+
+      index += 1;
+    }
+  }
+
+  @override
+  void initState() {
+    fetchItems();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+    });
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.transparent,
-      width: 300,
+    return Focus(
+      focusNode: _focusNode,
+      onKey: _onKey,
       child: Container(
-        padding: const EdgeInsets.fromLTRB(10, 6, 10, 6),
-        decoration: BoxDecoration(
-          color: style.selectionMenuBackgroundColor,
-          boxShadow: [
-            BoxShadow(
-              blurRadius: 5,
-              spreadRadius: 1,
-              color: Colors.black.withOpacity(0.1),
-            ),
-          ],
-          borderRadius: BorderRadius.circular(6.0),
+        color: Colors.transparent,
+        width: 300,
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(10, 6, 10, 6),
+          decoration: BoxDecoration(
+            color: style.selectionMenuBackgroundColor,
+            boxShadow: [
+              BoxShadow(
+                blurRadius: 5,
+                spreadRadius: 1,
+                color: Colors.black.withOpacity(0.1),
+              ),
+            ],
+            borderRadius: BorderRadius.circular(6.0),
+          ),
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(),
+                )
+              : _buildListWidget(context, _selectedIndex, _availableLayout),
         ),
-        child: _buildListWidget(context),
       ),
     );
   }
 
-  Widget _buildListWidget(BuildContext context) {
-    return FutureBuilder<List<dartz.Tuple2<AppPB, List<ViewPB>>>>(
-      builder: (context, snapshot) {
-        if (snapshot.hasData &&
-            snapshot.connectionState == ConnectionState.done) {
-          final apps = snapshot.data;
-          final children = <Widget>[
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: FlowyText.regular(
-                widget.hintText,
-                fontSize: 10,
-                color: Colors.grey,
+  KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
+    if (event is! RawKeyDownEvent || _isLoading || _availableLayout.isEmpty) {
+      return KeyEventResult.ignored;
+    }
+
+    final acceptedKeys = [
+      LogicalKeyboardKey.arrowUp,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.tab,
+      LogicalKeyboardKey.enter
+    ];
+
+    if (!acceptedKeys.contains(event.logicalKey)) {
+      return KeyEventResult.handled;
+    }
+
+    var newSelectedIndex = _selectedIndex;
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+        newSelectedIndex != _availableLayout.length - 1) {
+      newSelectedIndex += 1;
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
+        newSelectedIndex != 0) {
+      newSelectedIndex -= 1;
+    } else if (event.logicalKey == LogicalKeyboardKey.tab) {
+      newSelectedIndex += 1;
+      newSelectedIndex %= _availableLayout.length;
+    } else if (event.logicalKey == LogicalKeyboardKey.enter) {
+      widget.onSelected(
+          _items[_selectedIndex]!.value1, _items[_selectedIndex]!.value2);
+    }
+
+    setState(() {
+      _selectedIndex = newSelectedIndex;
+    });
+
+    return KeyEventResult.handled;
+  }
+
+  Widget _buildListWidget(BuildContext context, int selectedIndex,
+      List<dartz.Tuple2<AppPB, List<ViewPB>>> items) {
+    int index = 0;
+    return Builder(builder: (context) {
+      final apps = items;
+      final children = <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: FlowyText.regular(
+            widget.hintText,
+            fontSize: 10,
+            color: Colors.grey,
+          ),
+        ),
+      ];
+      if (apps.isNotEmpty) {
+        for (final app in apps) {
+          if (app.value2.isNotEmpty) {
+            children.add(
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: FlowyText.regular(
+                  app.value1.name,
+                ),
               ),
-            ),
-          ];
-          if (apps != null && apps.isNotEmpty) {
-            for (final app in apps) {
-              if (app.value2.isNotEmpty) {
-                children.add(
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: FlowyText.regular(
-                      app.value1.name,
-                    ),
+            );
+            for (final value in app.value2) {
+              children.add(
+                FlowyButton(
+                  isSelected: index == selectedIndex,
+                  leftIcon: svgWidget(
+                    _iconName(value),
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
-                );
-                for (final value in app.value2) {
-                  children.add(
-                    FlowyButton(
-                      leftIcon: svgWidget(
-                        _iconName(value),
-                        color: Theme.of(context).colorScheme.onSurface,
-                      ),
-                      text: FlowyText.regular(value.name),
-                      onTap: () => widget.onSelected(app.value1, value),
-                    ),
-                  );
-                }
-              }
+                  text: FlowyText.regular(value.name),
+                  onTap: () => widget.onSelected(app.value1, value),
+                ),
+              );
+              index += 1;
             }
           }
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: children,
-          );
-        } else {
-          return const Center(
-            child: CircularProgressIndicator(),
-          );
         }
-      },
-      future: AppBackendService().fetchViews(widget.layoutType),
-    );
+      }
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      );
+    });
   }
 
   String _iconName(ViewPB viewPB) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/base/link_to_page_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/base/link_to_page_widget.dart
@@ -96,6 +96,7 @@ class _LinkToPageMenuState extends State<LinkToPageMenu> {
   final _focusNode = FocusNode(debugLabel: 'reference_list_widget');
   EditorStyle get style => widget.editorState.editorStyle;
   int _selectedIndex = 0;
+  int _totalItems = 0;
   List<dartz.Tuple2<AppPB, List<ViewPB>>> _availableLayout = [];
   final Map<int, dartz.Tuple2<AppPB, ViewPB>> _items = {};
   bool _isLoading = true;
@@ -112,10 +113,13 @@ class _LinkToPageMenuState extends State<LinkToPageMenu> {
     for (final app in _availableLayout) {
       for (final view in app.value2) {
         _items.putIfAbsent(index, () => dartz.Tuple2(app.value1, view));
+        index += 1;
       }
-
-      index += 1;
     }
+
+    setState(() {
+      _totalItems = index;
+    });
   }
 
   @override
@@ -182,14 +186,14 @@ class _LinkToPageMenuState extends State<LinkToPageMenu> {
 
     var newSelectedIndex = _selectedIndex;
     if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
-        newSelectedIndex != _availableLayout.length - 1) {
+        newSelectedIndex != _totalItems - 1) {
       newSelectedIndex += 1;
     } else if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
         newSelectedIndex != 0) {
       newSelectedIndex -= 1;
     } else if (event.logicalKey == LogicalKeyboardKey.tab) {
       newSelectedIndex += 1;
-      newSelectedIndex %= _availableLayout.length;
+      newSelectedIndex %= _totalItems;
     } else if (event.logicalKey == LogicalKeyboardKey.enter) {
       widget.onSelected(
           _items[_selectedIndex]!.value1, _items[_selectedIndex]!.value2);


### PR DESCRIPTION
I have now added the feature to navigate the reference board/grid menu using arrow keys and tab, and finally select the desired grid/board using enter key.

The following video depicts the required behaviour:

https://user-images.githubusercontent.com/79906086/229272873-4ad8f2df-b392-4df0-ad50-91d1cd9e2292.mov


P.S. Since the list of grids/boards is a list of lists, I have used map to map indices to the required object.

fixes #2032 