### PR TITLE
feat: allow timezone aware date cells

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
@@ -29,8 +29,8 @@ class TextCellDataPersistence implements CellDataPersistence<String> {
 @freezed
 class DateCellData with _$DateCellData {
   const factory DateCellData({
-    required DateTime date,
-    String? time,
+    required DateTime? dateTime,
+    required String? time,
     required bool includeTime,
   }) = _DateCellData;
 }
@@ -45,14 +45,16 @@ class DateCellDataPersistence implements CellDataPersistence<DateCellData> {
   Future<Option<FlowyError>> save(DateCellData data) {
     var payload = DateChangesetPB.create()..cellPath = _makeCellPath(cellId);
 
-    final date = (data.date.millisecondsSinceEpoch ~/ 1000).toString();
-    payload.date = date;
-    payload.isUtc = data.date.isUtc;
-    payload.includeTime = data.includeTime;
+    if (data.dateTime != null) {
+      final date = (data.dateTime!.millisecondsSinceEpoch ~/ 1000).toString();
+      payload.date = date;
+    }
 
     if (data.time != null) {
       payload.time = data.time!;
     }
+
+    payload.includeTime = data.includeTime;
 
     return DatabaseEventUpdateDateCell(payload).send().then((result) {
       return result.fold(

--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/database_controller.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/database_controller.dart
@@ -338,7 +338,7 @@ class RowDataBuilder {
 
   void insertDate(FieldInfo fieldInfo, DateTime date) {
     assert(fieldInfo.fieldType == FieldType.DateTime);
-    final timestamp = (date.millisecondsSinceEpoch ~/ 1000);
+    final timestamp = date.millisecondsSinceEpoch ~/ 1000;
     _cellDataByFieldId[fieldInfo.field.id] = timestamp.toString();
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -290,10 +290,7 @@ Option<DateCellData> calDataFromCellData(DateCellDataPB? cellData) {
   Option<DateCellData> dateData = none();
   if (cellData != null) {
     final timestamp = cellData.timestamp * 1000;
-    final date = DateTime.fromMillisecondsSinceEpoch(
-      timestamp.toInt(),
-      isUtc: true,
-    );
+    final date = DateTime.fromMillisecondsSinceEpoch(timestamp.toInt());
     dateData = Some(
       DateCellData(
         date: date,

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -264,6 +264,8 @@ String _timeHintText(DateTypeOptionPB typeOption) {
 }
 
 DateCellData _dateDataFromCellData(DateCellDataPB? cellData) {
+  // a null DateCellDataPB may be returned, indicating that all the fields are
+  // at their default values: empty strings and false booleans
   if (cellData == null) {
     return const DateCellData(dateTime: null, time: null, includeTime: false);
   }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -36,7 +36,7 @@ class DateCellCalendarBloc
             emit(
               state.copyWith(
                 dateTime: dateData.dateTime,
-                time: dateData.time ?? "",
+                time: dateData.time,
                 includeTime: dateData.includeTime,
               ),
             );
@@ -76,20 +76,16 @@ class DateCellCalendarBloc
     String? time,
     bool? includeTime,
   }) async {
-    if (date == state.dateTime &&
-        time == state.time &&
-        includeTime == state.includeTime) {
-      return;
-    }
+    String? newTime = time ?? state.time;
 
     DateTime? newDate = date;
-    if (time != null && time.isNotEmpty && state.dateTime == null) {
-      newDate = DateTime.now();
+    if (time != null && time.isNotEmpty) {
+      newDate = state.dateTime ?? DateTime.now();
     }
 
     final DateCellData newDateData = DateCellData(
       dateTime: newDate,
-      time: time,
+      time: newTime,
       includeTime: includeTime ?? state.includeTime,
     );
 

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cell_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cell_bloc.dart
@@ -79,7 +79,11 @@ class DateCellState with _$DateCellState {
 String _dateStrFromCellData(DateCellDataPB? cellData) {
   String dateStr = "";
   if (cellData != null) {
-    dateStr = "${cellData.date} ${cellData.time}";
+    if (cellData.includeTime) {
+      dateStr = "${cellData.date} ${cellData.time}";
+    } else {
+      dateStr = cellData.date;
+    }
   }
   return dateStr;
 }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -11,7 +11,6 @@ import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra/size.dart';
 import 'package:flowy_infra/time/duration.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
-import 'package:flowy_infra_ui/widget/rounded_input_field.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-error/errors.pbserver.dart';
 import 'package:appflowy_backend/protobuf/flowy-database/date_type_option.pb.dart';
@@ -90,39 +89,35 @@ class _CellCalendarWidget extends StatefulWidget {
 
 class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
   late PopoverMutex popoverMutex;
-  late DateCellCalendarBloc bloc;
 
   @override
   void initState() {
     popoverMutex = PopoverMutex();
 
-    bloc = DateCellCalendarBloc(
-      dateTypeOptionPB: widget.dateTypeOptionPB,
-      cellData: widget.cellContext.getCellData(),
-      cellController: widget.cellContext,
-    )..add(const DateCellCalendarEvent.initial());
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: bloc,
+    return BlocProvider(
+      create: (context) => DateCellCalendarBloc(
+        dateTypeOptionPB: widget.dateTypeOptionPB,
+        cellData: widget.cellContext.getCellData(),
+        cellController: widget.cellContext,
+      )..add(const DateCellCalendarEvent.initial()),
       child: BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
-        buildWhen: (p, c) => p != c,
         builder: (context, state) {
           List<Widget> children = [
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12.0),
               child: _buildCalendar(context),
             ),
-            if (state.includeTime) ...[
-              const VSpace(12.0),
-              _TimeTextField(
-                bloc: context.read<DateCellCalendarBloc>(),
-                popoverMutex: popoverMutex,
-              ),
-            ],
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: state.includeTime
+                  ? _TimeTextField(popoverMutex: popoverMutex)
+                  : const SizedBox(),
+            ),
             const TypeOptionSeparator(spacing: 12.0),
             const _IncludeTimeButton(),
             const TypeOptionSeparator(spacing: 12.0),
@@ -143,7 +138,6 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
 
   @override
   void dispose() {
-    bloc.close();
     popoverMutex.dispose();
     super.dispose();
   }
@@ -271,11 +265,9 @@ class _IncludeTimeButton extends StatelessWidget {
 }
 
 class _TimeTextField extends StatefulWidget {
-  final DateCellCalendarBloc bloc;
   final PopoverMutex popoverMutex;
 
   const _TimeTextField({
-    required this.bloc,
     required this.popoverMutex,
     Key? key,
   }) : super(key: key);
@@ -286,18 +278,10 @@ class _TimeTextField extends StatefulWidget {
 
 class _TimeTextFieldState extends State<_TimeTextField> {
   late final FocusNode _focusNode;
-  late final TextEditingController _controller;
 
   @override
   void initState() {
     _focusNode = FocusNode();
-    _controller = TextEditingController(text: widget.bloc.state.time);
-
-    // _focusNode.addListener(() {
-    //   if (mounted) {
-    //     widget.bloc.add(DateCellCalendarEvent.setTime(_controller.text));
-    //   }
-    // });
 
     _focusNode.addListener(() {
       if (_focusNode.hasFocus) {
@@ -316,36 +300,30 @@ class _TimeTextFieldState extends State<_TimeTextField> {
 
   @override
   Widget build(BuildContext context) {
-    _controller.text = widget.bloc.state.time ?? "";
-    _controller.selection =
-        TextSelection.collapsed(offset: _controller.text.length);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12.0),
-      child: Padding(
-        padding: GridSize.typeOptionContentInsets,
-        child: RoundedInputField(
-          height: GridSize.popoverItemHeight,
-          focusNode: _focusNode,
-          autoFocus: true,
-          hintText: widget.bloc.state.timeHintText,
-          controller: _controller,
-          style: Theme.of(context).textTheme.bodyMedium!,
-          normalBorderColor: Theme.of(context).colorScheme.outline,
-          errorBorderColor: Theme.of(context).colorScheme.error,
-          focusBorderColor: Theme.of(context).colorScheme.primary,
-          cursorColor: Theme.of(context).colorScheme.primary,
-          errorText: widget.bloc.state.timeFormatError ?? "",
-          onEditingComplete: (value) =>
-              widget.bloc.add(DateCellCalendarEvent.setTime(value)),
-        ),
-      ),
+    return BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
+      builder: (context, state) {
+        return Column(
+          children: [
+            const VSpace(12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12.0),
+              child: FlowyTextField(
+                text: state.time ?? "",
+                focusNode: _focusNode,
+                submitOnLeave: true,
+                hintText: state.timeHintText,
+                errorText: state.timeFormatError,
+                onSubmitted: (timeString) {
+                  context
+                      .read<DateCellCalendarBloc>()
+                      .add(DateCellCalendarEvent.setTime(timeString));
+                },
+              ),
+            ),
+          ],
+        );
+      },
     );
-  }
-
-  @override
-  void dispose() {
-    _focusNode.dispose();
-    super.dispose();
   }
 }
 

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -210,7 +210,8 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
           selectedDayPredicate: (day) => isSameDay(state.dateTime, day),
           onDaySelected: (selectedDay, focusedDay) {
             context.read<DateCellCalendarBloc>().add(
-                DateCellCalendarEvent.selectDay(selectedDay.toLocal().date));
+                  DateCellCalendarEvent.selectDay(selectedDay.toLocal().date),
+                );
           },
           onFormatChanged: (format) {
             context

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -110,14 +110,12 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
       child: BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
         buildWhen: (p, c) => p != c,
         builder: (context, state) {
-          bool includeTime = state.dateCellData
-              .fold(() => false, (dateData) => dateData.includeTime);
           List<Widget> children = [
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12.0),
               child: _buildCalendar(context),
             ),
-            if (includeTime) ...[
+            if (state.includeTime) ...[
               const VSpace(12.0),
               _TimeTextField(
                 bloc: context.read<DateCellCalendarBloc>(),
@@ -208,12 +206,7 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
             outsideTextStyle:
                 textStyle.textColor(Theme.of(context).disabledColor),
           ),
-          selectedDayPredicate: (day) {
-            return state.dateCellData.fold(
-              () => false,
-              (dateData) => isSameDay(dateData.date, day),
-            );
-          },
+          selectedDayPredicate: (day) => isSameDay(state.dateTime, day),
           onDaySelected: (selectedDay, focusedDay) {
             context
                 .read<DateCellCalendarBloc>()
@@ -241,10 +234,7 @@ class _IncludeTimeButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocSelector<DateCellCalendarBloc, DateCellCalendarState, bool>(
-      selector: (state) => state.dateCellData.fold(
-        () => false,
-        (dateData) => dateData.includeTime,
-      ),
+      selector: (state) => state.includeTime,
       builder: (context, includeTime) {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12.0),
@@ -302,11 +292,11 @@ class _TimeTextFieldState extends State<_TimeTextField> {
     _focusNode = FocusNode();
     _controller = TextEditingController(text: widget.bloc.state.time);
 
-    _focusNode.addListener(() {
-      if (mounted) {
-        widget.bloc.add(DateCellCalendarEvent.setTime(_controller.text));
-      }
-    });
+    // _focusNode.addListener(() {
+    //   if (mounted) {
+    //     widget.bloc.add(DateCellCalendarEvent.setTime(_controller.text));
+    //   }
+    // });
 
     _focusNode.addListener(() {
       if (_focusNode.hasFocus) {
@@ -343,8 +333,7 @@ class _TimeTextFieldState extends State<_TimeTextField> {
           errorBorderColor: Theme.of(context).colorScheme.error,
           focusBorderColor: Theme.of(context).colorScheme.primary,
           cursorColor: Theme.of(context).colorScheme.primary,
-          errorText: widget.bloc.state.timeFormatError
-              .fold(() => "", (error) => error),
+          errorText: widget.bloc.state.timeFormatError ?? "",
           onEditingComplete: (value) =>
               widget.bloc.add(DateCellCalendarEvent.setTime(value)),
         ),

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -9,6 +9,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra/size.dart';
+import 'package:flowy_infra/time/duration.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/rounded_input_field.dart';
 import 'package:appflowy_backend/log.dart';
@@ -208,9 +209,8 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
           ),
           selectedDayPredicate: (day) => isSameDay(state.dateTime, day),
           onDaySelected: (selectedDay, focusedDay) {
-            context
-                .read<DateCellCalendarBloc>()
-                .add(DateCellCalendarEvent.selectDay(selectedDay));
+            context.read<DateCellCalendarBloc>().add(
+                DateCellCalendarEvent.selectDay(selectedDay.toLocal().date));
           },
           onFormatChanged: (format) {
             context

--- a/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
@@ -64,7 +64,6 @@ class TrashCell extends StatelessWidget {
     final outputFormat = DateFormat('MM/dd/yyyy hh:mm a');
     final date = DateTime.fromMillisecondsSinceEpoch(
       inputTimestamps.toInt() * 1000,
-      isUtc: true,
     );
     final outputDate = outputFormat.format(date);
     return outputDate;

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -427,7 +427,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
- "chrono-tz-build",
+ "chrono-tz-build 0.0.3",
+ "phf 0.11.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
+dependencies = [
+ "chrono",
+ "chrono-tz-build 0.1.0",
  "phf 0.11.1",
 ]
 
@@ -436,6 +447,17 @@ name = "chrono-tz-build"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.1",
+ "phf_codegen",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
 dependencies = [
  "parse-zoneinfo",
  "phf 0.11.1",
@@ -1140,6 +1162,7 @@ dependencies = [
  "atomic_refcell",
  "bytes",
  "chrono",
+ "chrono-tz 0.8.1",
  "crossbeam-utils",
  "dashmap",
  "database-model",
@@ -3607,7 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df578c295f9ec044ff1c829daf31bb7581d5b3c2a7a3d87419afe1f2531438c"
 dependencies = [
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.6.3",
  "globwalk",
  "humansize",
  "lazy_static",

--- a/frontend/rust-lib/flowy-database/Cargo.toml
+++ b/frontend/rust-lib/flowy-database/Cargo.toml
@@ -47,6 +47,7 @@ atomic_refcell = "0.1.9"
 crossbeam-utils = "0.8.15"
 async-stream = "0.3.4"
 parking_lot = "0.12.1"
+chrono-tz = "0.8.1"
 
 [dev-dependencies]
 flowy-test = { path = "../flowy-test" }

--- a/frontend/rust-lib/flowy-database/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database/src/event_handler.rs
@@ -519,6 +519,7 @@ pub(crate) async fn update_date_cell_handler(
     time: data.time,
     include_time: data.include_time,
     is_utc: data.is_utc,
+    timezone_id: data.timezone_id,
   };
 
   let editor = manager.get_database_editor(&cell_path.view_id).await?;

--- a/frontend/rust-lib/flowy-database/src/services/cell/cell_operation.rs
+++ b/frontend/rust-lib/flowy-database/src/services/cell/cell_operation.rs
@@ -254,6 +254,7 @@ pub fn insert_date_cell(timestamp: i64, field_rev: &FieldRevision) -> CellRevisi
     time: None,
     include_time: Some(false),
     is_utc: true,
+    timezone_id: None,
   })
   .unwrap();
   let data = apply_cell_data_changeset(cell_data, None, field_rev, None).unwrap();

--- a/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_tests.rs
+++ b/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_tests.rs
@@ -265,6 +265,7 @@ mod tests {
       time: include_time_str,
       is_utc: false,
       include_time: Some(include_time),
+      timezone_id: None,
     };
     let (cell_str, _) = type_option.apply_changeset(changeset, None).unwrap();
 

--- a/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_tests.rs
+++ b/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
   use crate::entities::FieldType;
-  use crate::services::cell::{CellDataChangeset, CellDataDecoder};
+  use crate::services::cell::{CellDataChangeset, CellDataDecoder, TypeCellData};
 
   use crate::services::field::{
     DateCellChangeset, DateFormat, DateTypeOptionPB, FieldBuilder, TimeFormat, TypeOptionCellData,
@@ -21,51 +21,76 @@ mod tests {
         DateFormat::Friendly => {
           assert_date(
             &type_option,
-            1647251762,
-            None,
-            "Mar 14,2022",
-            false,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1647251762".to_owned()),
+              time: None,
+              include_time: None,
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "Mar 14,2022".to_owned(),
           );
         },
         DateFormat::US => {
           assert_date(
             &type_option,
-            1647251762,
-            None,
-            "2022/03/14",
-            false,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1647251762".to_owned()),
+              time: None,
+              include_time: None,
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "2022/03/14".to_owned(),
           );
         },
         DateFormat::ISO => {
           assert_date(
             &type_option,
-            1647251762,
-            None,
-            "2022-03-14",
-            false,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1647251762".to_owned()),
+              time: None,
+              include_time: None,
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "2022-03-14".to_owned(),
           );
         },
         DateFormat::Local => {
           assert_date(
             &type_option,
-            1647251762,
-            None,
-            "03/14/2022",
-            false,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1647251762".to_owned()),
+              time: None,
+              include_time: None,
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "03/14/2022".to_owned(),
           );
         },
         DateFormat::DayMonthYear => {
           assert_date(
             &type_option,
-            1647251762,
-            None,
-            "14/03/2022",
-            false,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1647251762".to_owned()),
+              time: None,
+              include_time: None,
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "14/03/2022".to_owned(),
           );
         },
       }
@@ -84,53 +109,83 @@ mod tests {
         TimeFormat::TwentyFourHour => {
           assert_date(
             &type_option,
-            1653609600,
+            &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: None,
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: Some("Etc/UTC".to_owned()),
+            },
             None,
-            "May 27,2022 00:00",
-            true,
-            &field_rev,
+            "May 27,2022 00:00".to_owned(),
           );
           assert_date(
             &type_option,
-            1653609600,
-            Some("9:00".to_owned()),
-            "May 27,2022 09:00",
-            true,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: Some("9:00".to_owned()),
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: Some("Etc/UTC".to_owned()),
+            },
+            None,
+            "May 27,2022 09:00".to_owned(),
           );
           assert_date(
             &type_option,
-            1653609600,
-            Some("23:00".to_owned()),
-            "May 27,2022 23:00",
-            true,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: Some("23:00".to_owned()),
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: Some("Etc/UTC".to_owned()),
+            },
+            None,
+            "May 27,2022 23:00".to_owned(),
           );
         },
         TimeFormat::TwelveHour => {
           assert_date(
             &type_option,
-            1653609600,
+            &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: None,
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: Some("Etc/UTC".to_owned()),
+            },
             None,
-            "May 27,2022 12:00 AM",
-            true,
-            &field_rev,
+            "May 27,2022 12:00 AM".to_owned(),
           );
           assert_date(
             &type_option,
-            1653609600,
-            Some("9:00 AM".to_owned()),
-            "May 27,2022 09:00 AM",
-            true,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: Some("9:00 AM".to_owned()),
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: None,
+            },
+            None,
+            "May 27,2022 09:00 AM".to_owned(),
           );
           assert_date(
             &type_option,
-            1653609600,
-            Some("11:23 pm".to_owned()),
-            "May 27,2022 11:23 PM",
-            true,
             &field_rev,
+            DateCellChangeset {
+              date: Some("1653609600".to_owned()),
+              time: Some("11:23 pm".to_owned()),
+              include_time: Some(true),
+              is_utc: false,
+              timezone_id: Some("Etc/UTC".to_owned()),
+            },
+            None,
+            "May 27,2022 11:23 PM".to_owned(),
           );
         },
       }
@@ -142,7 +197,19 @@ mod tests {
     let type_option = DateTypeOptionPB::default();
     let field_type = FieldType::DateTime;
     let field_rev = FieldBuilder::from_field_type(&field_type).build();
-    assert_date(&type_option, "abc", None, "", false, &field_rev);
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("abc".to_owned()),
+        time: None,
+        include_time: None,
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "".to_owned(),
+    );
   }
 
   #[test]
@@ -153,26 +220,37 @@ mod tests {
 
     assert_date(
       &type_option,
-      1653609600,
-      Some("1:".to_owned()),
-      "May 27,2022 01:00",
-      true,
       &field_rev,
+      DateCellChangeset {
+        date: Some("1653609600".to_owned()),
+        time: Some("1:".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "May 27,2022 01:00".to_owned(),
     );
   }
 
   #[test]
+  #[should_panic]
   fn date_type_option_empty_include_time_str_test() {
     let type_option = DateTypeOptionPB::new();
     let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
 
     assert_date(
       &type_option,
-      1653609600,
-      Some("".to_owned()),
-      "May 27,2022 00:00",
-      true,
       &field_rev,
+      DateCellChangeset {
+        date: Some("1653609600".to_owned()),
+        time: Some("".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "May 27,2022 01:00".to_owned(),
     );
   }
 
@@ -183,11 +261,16 @@ mod tests {
     let field_rev = FieldBuilder::from_field_type(&field_type).build();
     assert_date(
       &type_option,
-      1653609600,
-      Some("00:00".to_owned()),
-      "May 27,2022 00:00",
-      true,
       &field_rev,
+      DateCellChangeset {
+        date: Some("1653609600".to_owned()),
+        time: Some("00:00".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "May 27,2022 00:00".to_owned(),
     );
   }
 
@@ -197,14 +280,18 @@ mod tests {
   fn date_type_option_twelve_hours_include_time_str_in_twenty_four_hours_format() {
     let type_option = DateTypeOptionPB::new();
     let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
-
     assert_date(
       &type_option,
-      1653609600,
-      Some("1:00 am".to_owned()),
-      "May 27,2022 01:00 AM",
-      true,
       &field_rev,
+      DateCellChangeset {
+        date: Some("1653609600".to_owned()),
+        time: Some("1:00 am".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "May 27,2022 01:00 AM".to_owned(),
     );
   }
 
@@ -215,14 +302,18 @@ mod tests {
     let mut type_option = DateTypeOptionPB::new();
     type_option.time_format = TimeFormat::TwelveHour;
     let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
-
     assert_date(
       &type_option,
-      1653609600,
-      Some("20:00".to_owned()),
-      "May 27,2022 08:00 PM",
-      true,
       &field_rev,
+      DateCellChangeset {
+        date: Some("1653609600".to_owned()),
+        time: Some("20:00".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+      None,
+      "May 27,2022 08:00 PM".to_owned(),
     );
   }
 
@@ -252,26 +343,180 @@ mod tests {
     assert_eq!(china_local_time, "03/14/2022 05:56 PM");
   }
 
-  fn assert_date<T: ToString>(
+  /// The time component shouldn't remain the same since the timestamp is
+  /// completely overwritten. To achieve the desired result, also pass in the
+  /// time string along with the new timestamp.
+  #[test]
+  #[should_panic]
+  fn update_date_keep_time() {
+    let type_option = DateTypeOptionPB::new();
+    let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
+
+    let old_cell_data = initialize_date_cell(
+      &type_option,
+      DateCellChangeset {
+        date: Some("1700006400".to_owned()),
+        time: Some("08:00".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Etc/UTC".to_owned()),
+      },
+    );
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("1701302400".to_owned()),
+        time: None,
+        include_time: None,
+        is_utc: false,
+        timezone_id: None,
+      },
+      Some(old_cell_data),
+      "Nov 30,2023 08:00".to_owned(),
+    );
+  }
+
+  #[test]
+  fn update_time_keep_date() {
+    let type_option = DateTypeOptionPB::new();
+    let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
+
+    let old_cell_data = initialize_date_cell(
+      &type_option,
+      DateCellChangeset {
+        date: Some("1700006400".to_owned()),
+        time: Some("08:00".to_owned()),
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: None,
+      },
+    );
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: None,
+        time: Some("14:00".to_owned()),
+        include_time: None,
+        is_utc: false,
+        timezone_id: None,
+      },
+      Some(old_cell_data),
+      "Nov 15,2023 14:00".to_owned(),
+    );
+  }
+
+  #[test]
+  fn timezone_no_daylight_saving_time() {
+    let type_option = DateTypeOptionPB::new();
+    let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
+
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("1672963200".to_owned()),
+        time: None,
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Asia/Tokyo".to_owned()),
+      },
+      None,
+      "Jan 06,2023 09:00".to_owned(),
+    );
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("1685404800".to_owned()),
+        time: None,
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Asia/Tokyo".to_owned()),
+      },
+      None,
+      "May 30,2023 09:00".to_owned(),
+    );
+  }
+
+  #[test]
+  fn timezone_with_daylight_saving_time() {
+    let type_option = DateTypeOptionPB::new();
+    let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
+
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("1672963200".to_owned()),
+        time: None,
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Europe/Paris".to_owned()),
+      },
+      None,
+      "Jan 06,2023 01:00".to_owned(),
+    );
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: Some("1685404800".to_owned()),
+        time: None,
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Europe/Paris".to_owned()),
+      },
+      None,
+      "May 30,2023 02:00".to_owned(),
+    );
+  }
+
+  #[test]
+  fn change_timezone() {
+    let type_option = DateTypeOptionPB::new();
+    let field_rev = FieldBuilder::from_field_type(&FieldType::DateTime).build();
+
+    let old_cell_data = initialize_date_cell(
+      &type_option,
+      DateCellChangeset {
+        date: Some("1672963200".to_owned()),
+        time: None,
+        include_time: Some(true),
+        is_utc: false,
+        timezone_id: Some("Asia/China".to_owned()),
+      },
+    );
+    assert_date(
+      &type_option,
+      &field_rev,
+      DateCellChangeset {
+        date: None,
+        time: None,
+        include_time: None,
+        is_utc: false,
+        timezone_id: Some("America/Los_Angeles".to_owned()),
+      },
+      Some(old_cell_data),
+      "Jan 05,2023 16:00".to_owned(),
+    );
+  }
+
+  fn assert_date(
     type_option: &DateTypeOptionPB,
-    timestamp: T,
-    include_time_str: Option<String>,
-    expected_str: &str,
-    include_time: bool,
     field_rev: &FieldRevision,
+    changeset: DateCellChangeset,
+    old_cell_data: Option<TypeCellData>,
+    expected_str: String,
   ) {
-    let changeset = DateCellChangeset {
-      date: Some(timestamp.to_string()),
-      time: include_time_str,
-      is_utc: false,
-      include_time: Some(include_time),
-      timezone_id: None,
-    };
-    let (cell_str, _) = type_option.apply_changeset(changeset, None).unwrap();
+    let (cell_str, cell_data) = type_option
+      .apply_changeset(changeset, old_cell_data)
+      .unwrap();
 
     assert_eq!(
-      decode_cell_data(cell_str, type_option, include_time, field_rev),
-      expected_str.to_owned(),
+      decode_cell_data(cell_str, type_option, cell_data.include_time, field_rev),
+      expected_str,
     );
   }
 
@@ -292,5 +537,13 @@ mod tests {
     } else {
       decoded_data.date
     }
+  }
+
+  fn initialize_date_cell(
+    type_option: &DateTypeOptionPB,
+    changeset: DateCellChangeset,
+  ) -> TypeCellData {
+    let (cell_str, _) = type_option.apply_changeset(changeset, None).unwrap();
+    TypeCellData::new(cell_str, FieldType::DateTime)
   }
 }

--- a/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database/src/services/field/type_options/date_type_option/date_type_option_entities.rs
@@ -25,6 +25,9 @@ pub struct DateCellDataPB {
 
   #[pb(index = 4)]
   pub include_time: bool,
+
+  #[pb(index = 5)]
+  pub timezone_id: String,
 }
 
 #[derive(Clone, Debug, Default, ProtoBuf)]
@@ -43,6 +46,9 @@ pub struct DateChangesetPB {
 
   #[pb(index = 5)]
   pub is_utc: bool,
+
+  #[pb(index = 6, one_of)]
+  pub timezone_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -51,6 +57,7 @@ pub struct DateCellChangeset {
   pub time: Option<String>,
   pub include_time: Option<bool>,
   pub is_utc: bool,
+  pub timezone_id: Option<String>,
 }
 
 impl DateCellChangeset {
@@ -85,6 +92,7 @@ impl ToCellChangesetString for DateCellChangeset {
 pub struct DateCellData {
   pub timestamp: Option<i64>,
   pub include_time: bool,
+  pub timezone_id: String,
 }
 
 impl<'de> serde::Deserialize<'de> for DateCellData {
@@ -110,6 +118,7 @@ impl<'de> serde::Deserialize<'de> for DateCellData {
         Ok(DateCellData {
           timestamp: Some(value),
           include_time: false,
+          timezone_id: "".to_owned(),
         })
       }
 
@@ -126,6 +135,7 @@ impl<'de> serde::Deserialize<'de> for DateCellData {
       {
         let mut timestamp: Option<i64> = None;
         let mut include_time: Option<bool> = None;
+        let mut timezone_id: Option<String> = None;
 
         while let Some(key) = map.next_key()? {
           match key {
@@ -135,15 +145,20 @@ impl<'de> serde::Deserialize<'de> for DateCellData {
             "include_time" => {
               include_time = map.next_value()?;
             },
+            "timezone_id" => {
+              timezone_id = map.next_value()?;
+            },
             _ => {},
           }
         }
 
-        let include_time = include_time.unwrap_or(false);
+        let include_time = include_time.unwrap_or_default();
+        let timezone_id = timezone_id.unwrap_or_default();
 
         Ok(DateCellData {
           timestamp,
           include_time,
+          timezone_id,
         })
       }
     }

--- a/frontend/rust-lib/flowy-database/src/services/field/type_options/text_type_option/text_tests.rs
+++ b/frontend/rust-lib/flowy-database/src/services/field/type_options/text_type_option/text_tests.rs
@@ -26,6 +26,7 @@ mod tests {
     let data = DateCellData {
       timestamp: Some(1647251762),
       include_time: true,
+      timezone_id: "".to_owned(),
     };
 
     assert_eq!(

--- a/frontend/rust-lib/flowy-database/tests/database/block_test/util.rs
+++ b/frontend/rust-lib/flowy-database/tests/database/block_test/util.rs
@@ -44,6 +44,7 @@ impl DatabaseRowTestBuilder {
       time: None,
       is_utc: true,
       include_time: Some(false),
+      timezone_id: None,
     })
     .unwrap();
     let date_field = self.field_rev_with_type(&FieldType::DateTime);

--- a/frontend/rust-lib/flowy-database/tests/database/field_test/util.rs
+++ b/frontend/rust-lib/flowy-database/tests/database/field_test/util.rs
@@ -65,6 +65,7 @@ pub fn make_date_cell_string(s: &str) -> String {
     time: None,
     is_utc: true,
     include_time: Some(false),
+    timezone_id: None,
   })
   .unwrap()
 }


### PR DESCRIPTION
This PR partly addresses #2336 by implementing the backend and data storage for timezones with accompanying tests. The frontend isn't implemented yet (see the above issue). It also reorganize some of the code in the frontend, particularly the date calendar bloc.

resolves #2066
resolves #2238 

To Do:

- [x] fix bug: toggling include time on an empty date cell automatically enters the current date time
- [x] fix bug: turning off include time on an empty date cell doesn't work
- [x] fix date tests
- [x] add more date tests for timezone-aware data:
    - [x] regular timezones
    - [x] timezones that have daylight saving time (variable offsets)