### PR TITLE
fix analyzer warnings

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
@@ -253,7 +253,6 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
       disabledColor: theme.shader4,
       highlightColor: theme.main1,
       indicatorColor: theme.main1,
-      toggleableActiveColor: theme.main1,
       cardColor: theme.input,
       colorScheme: ColorScheme(
         brightness: brightness,

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/image.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/image.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
-
 /// For icon that needs to change color when it is on hovered
 ///
 /// Get the hover color from ThemeData
@@ -12,16 +11,11 @@ class FlowySvg extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (size != null) {
-      return SizedBox.fromSize(
-        size: size,
-        child: SvgPicture.asset('assets/images/$name.svg',
-            color: Theme.of(context).iconTheme.color),
-      );
-    } else {
-      return SvgPicture.asset('assets/images/$name.svg',
-          color: Theme.of(context).iconTheme.color);
-    }
+    return svgWidget(
+      'assets/images/$name.svg',
+      size: size,
+      color: Theme.of(context).iconTheme.color,
+    );
   }
 }
 


### PR DESCRIPTION
Looks like there are analyzer warnings that snuck into `main` somewhere along the way. The[ integration test revert is failing CI](https://github.com/AppFlowy-IO/AppFlowy/pull/2201#pullrequestreview-1373633257) due to these errors. Submitting a separate PR instead of adding those changes to this PR.

Here are the analyzer errors:
```
Run flutter analyze
Analyzing appflowy_flutter...                                   

   info • 'toggleableActiveColor' is deprecated and shouldn't be used. No longer used by the framework, please remove any reference to it. For more information, consult the migration guide at https://flutter.dev/docs/release/breaking-changes/toggleable-active-color#migration-guide. This feature was deprecated after v3.4.0-19.0.pre • lib/workspace/application/appearance.dart:256:7 • deprecated_member_use
   info • 'color' is deprecated and shouldn't be used • packages/flowy_infra/lib/image.dart:19:13 • deprecated_member_use
   info • 'color' is deprecated and shouldn't be used • packages/flowy_infra/lib/image.dart:23:[11](https://github.com/AppFlowy-IO/AppFlowy/actions/runs/4622496646/jobs/8175251844?pr=2201#step:9:12) • deprecated_member_use
```