### PR TITLE
fix: run integration tests on Linux

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -107,6 +107,7 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
             export DISPLAY=:99
             sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+            sudo apt-get install network-manager
             flutter test integration_test/runner.dart -d Linux --coverage --verbose
           elif [ "$RUNNER_OS" == "macOS" ]; then
             flutter test integration_test/runner.dart -d macOS --coverage --verbose

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -105,6 +105,8 @@ jobs:
         working-directory: frontend/appflowy_flutter
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
+            export DISPLAY=:99
+            sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
             flutter test integration_test/runner.dart -d Linux --coverage --verbose
           elif [ "$RUNNER_OS" == "macOS" ]; then
             flutter test integration_test/runner.dart -d macOS --coverage --verbose

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -105,11 +105,11 @@ jobs:
         working-directory: frontend/appflowy_flutter
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            flutter test integration_test/runner.dart -d Linux --coverage
+            flutter test integration_test/runner.dart -d Linux --coverage --verbose
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            flutter test integration_test/runner.dart -d macOS --coverage
+            flutter test integration_test/runner.dart -d macOS --coverage --verbose
           elif [ "$RUNNER_OS" == "Windows" ]; then
-            flutter test integration_test/runner.dart -d Windows --coverage
+            flutter test integration_test/runner.dart -d Windows --coverage --verbose
           fi
         shell: bash
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -22,7 +22,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

Integration tests fail after upgrading Flutter from `3.3.10` to `3.7.5` because Flutter dropped OpenGL support. IIUC, the CI runners don't render using metal, so until https://github.com/flutter/flutter/issues/118469 is fixed, we will need to run the integration tests on a different OS.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

fixes https://github.com/AppFlowy-IO/AppFlowy/issues/2200
---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
