### PR TITLE
fix: auto-delete empty field in Kanban Board

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/board/presentation/board_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/board/presentation/board_page.dart
@@ -285,6 +285,8 @@ class _BoardContentState extends State<BoardContent> {
               .read<BoardBloc>()
               .add(BoardEvent.endEditingRow(groupItem.row.id));
 
+          if (fieldController.fieldInfos.isEmpty) return;
+
           /// Check if the field contains some text
           var fieldID = fieldController.fieldInfos[0].id;
           final cellCache = cellBuilder.cellCache;

--- a/frontend/appflowy_flutter/lib/plugins/database_view/board/presentation/board_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/board/presentation/board_page.dart
@@ -3,9 +3,11 @@
 import 'dart:collection';
 
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/plugins/database_view/application/cell/cell_service.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_controller.dart';
 import 'package:appflowy/plugins/database_view/application/row/row_cache.dart';
 import 'package:appflowy/plugins/database_view/application/row/row_data_controller.dart';
+import 'package:appflowy/plugins/database_view/application/row/row_service.dart';
 import 'package:appflowy/plugins/database_view/widgets/row/row_detail.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-database/field_entities.pb.dart';
@@ -282,6 +284,26 @@ class _BoardContentState extends State<BoardContent> {
           context
               .read<BoardBloc>()
               .add(BoardEvent.endEditingRow(groupItem.row.id));
+
+          /// Check if the field contains some text
+          var fieldID = fieldController.fieldInfos[0].id;
+          final cellCache = cellBuilder.cellCache;
+          var data = cellCache.get(
+            CellCacheKey(
+              fieldId: fieldID,
+              rowId: rowPB.id,
+            ),
+          );
+
+          if (data == null) return;
+
+          /// If the field is empty simply delete the row
+          if (data.toString().isEmpty) {
+            final rowService = RowBackendService(
+              viewId: viewId,
+            );
+            rowService.deleteRow(groupItem.row.id);
+          }
         },
       ),
     );


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview
Now the field in Kanban board item is automatically deleted when the user tries to save an empty field.

> Issue: #1898 

https://user-images.githubusercontent.com/37607224/230738649-95b5a008-2a46-4acc-ac1c-769a4fccf662.mp4


#### PR Checklist

- [✅] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [✅] I've listed at least one issue that this PR fixes in the description above.
- [ - ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [✅] All existing tests are passing.
