### PR TITLE
fix: seperating env for mac test depending upon archs

### DIFF
--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -205,11 +205,16 @@ script = [
 ]
 script_runner = "@duckscript"
 
-[env.test-macos]
+[env.test-macos-x86_64]
 TEST_CRATE_TYPE = "cdylib"
 TEST_LIB_EXT = "dylib"
 # For the moment, the DynamicLibrary only supports open x86_64 architectures binary.
 TEST_COMPILE_TARGET = "x86_64-apple-darwin"
+
+[env.test-macos-arm64]
+TEST_CRATE_TYPE = "cdylib"
+TEST_LIB_EXT = "dylib"
+TEST_COMPILE_TARGET = "aarch64-apple-darwin"
 
 [env.test-linux]
 TEST_CRATE_TYPE = "cdylib"

--- a/frontend/scripts/makefile/tests.toml
+++ b/frontend/scripts/makefile/tests.toml
@@ -1,7 +1,7 @@
 
 [tasks.dart_unit_test]
 script = '''
-cargo make --profile test-macos run_dart_unit_test
+cargo make --profile test-macos-$(uname -m) run_dart_unit_test
 '''
 script_runner = "@shell"
 


### PR DESCRIPTION
TEST_COMIPLE_TARGET variable was being set to `x86_64-apple-darwin` for macos irrespective of the architecture, resulting in error when trying to run tests on mac m1. Now TEST_COMPILE_TARGET is being set according to the architecture. 

<img width="621" alt="Screenshot 2023-04-15 at 6 53 10 PM" src="https://user-images.githubusercontent.com/79906086/232227947-e6d171f2-3552-40f8-ae89-e8da5f1ad957.png">


fixes https://github.com/AppFlowy-IO/AppFlowy/issues/2264

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

