### PR TITLE
feat: change the UI of language selector

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
@@ -264,7 +264,17 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
         contentTextStyle: TextStyle(color: colorScheme.onSurface),
       ),
       scrollbarTheme: ScrollbarThemeData(
-        thumbColor: MaterialStateProperty.all(theme.shader3),
+        thumbColor: MaterialStateProperty.resolveWith((states) {
+          const Set<MaterialState> interactiveStates = <MaterialState>{
+            MaterialState.pressed,
+            MaterialState.hovered,
+            MaterialState.dragged,
+          };
+          if (states.any(interactiveStates.contains)) {
+            return theme.shader7;
+          }
+          return theme.shader5;
+        }),
         thickness: MaterialStateProperty.resolveWith((states) {
           const Set<MaterialState> interactiveStates = <MaterialState>{
             MaterialState.pressed,
@@ -272,7 +282,7 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
             MaterialState.dragged,
           };
           if (states.any(interactiveStates.contains)) {
-            return 5.0;
+            return 4;
           }
           return 3.0;
         }),

--- a/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance.dart
@@ -242,6 +242,12 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
       shadow: theme.shadow,
     );
 
+    const Set<MaterialState> scrollbarInteractiveStates = <MaterialState>{
+      MaterialState.pressed,
+      MaterialState.hovered,
+      MaterialState.dragged,
+    };
+
     return ThemeData(
       brightness: brightness,
       textTheme: _getTextTheme(fontFamily: fontFamily, fontColor: theme.text),
@@ -265,23 +271,13 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
       ),
       scrollbarTheme: ScrollbarThemeData(
         thumbColor: MaterialStateProperty.resolveWith((states) {
-          const Set<MaterialState> interactiveStates = <MaterialState>{
-            MaterialState.pressed,
-            MaterialState.hovered,
-            MaterialState.dragged,
-          };
-          if (states.any(interactiveStates.contains)) {
+          if (states.any(scrollbarInteractiveStates.contains)) {
             return theme.shader7;
           }
           return theme.shader5;
         }),
         thickness: MaterialStateProperty.resolveWith((states) {
-          const Set<MaterialState> interactiveStates = <MaterialState>{
-            MaterialState.pressed,
-            MaterialState.hovered,
-            MaterialState.dragged,
-          };
-          if (states.any(interactiveStates.contains)) {
+          if (states.any(scrollbarInteractiveStates.contains)) {
             return 4;
           }
           return 3.0;

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -77,7 +77,7 @@ class ThemeSetting extends StatelessWidget {
       child: FlowyButton(
         text: FlowyText.medium(theme),
         rightIcon: currentTheme == theme
-            ? svgWidget("grid/checkmark")
+            ? const FlowySvg(name: 'grid/checkmark')
             : const SizedBox(),
         onTap: () {
           if (currentTheme != theme) {
@@ -134,7 +134,7 @@ class ThemeModeSetting extends StatelessWidget {
       child: FlowyButton(
         text: FlowyText.medium(_themeModeLabelText(themeMode)),
         rightIcon: currentThemeMode == themeMode
-            ? svgWidget("grid/checkmark")
+            ? const FlowySvg(name: 'grid/checkmark')
             : const SizedBox(),
         onTap: () {
           if (currentThemeMode != themeMode) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -78,7 +78,7 @@ class ThemeSetting extends StatelessWidget {
         text: FlowyText.medium(theme),
         rightIcon: currentTheme == theme
             ? const FlowySvg(name: 'grid/checkmark')
-            : const SizedBox(),
+            : null,
         onTap: () {
           if (currentTheme != theme) {
             context.read<AppearanceSettingsCubit>().setTheme(theme);
@@ -135,7 +135,7 @@ class ThemeModeSetting extends StatelessWidget {
         text: FlowyText.medium(_themeModeLabelText(themeMode)),
         rightIcon: currentThemeMode == themeMode
             ? const FlowySvg(name: 'grid/checkmark')
-            : const SizedBox(),
+            : null,
         onTap: () {
           if (currentThemeMode != themeMode) {
             context.read<AppearanceSettingsCubit>().setThemeMode(themeMode);

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -15,18 +15,14 @@ class SettingsLanguageView extends StatelessWidget {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: BlocBuilder<AppearanceSettingsCubit, AppearanceSettingsState>(
-        builder: (context, state) => Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        builder: (context, state) => Row(
           children: [
-            Row(
-              children: [
-                Expanded(
-                  child:
-                      FlowyText.medium(LocaleKeys.settings_menu_language.tr()),
-                ),
-                LanguageSelector(currentLocale: state.locale),
-              ],
+            Expanded(
+              child: FlowyText.medium(
+                LocaleKeys.settings_menu_language.tr(),
+              ),
             ),
+            LanguageSelector(currentLocale: state.locale),
           ],
         ),
       ),
@@ -54,17 +50,36 @@ class LanguageSelector extends StatelessWidget {
       popupBuilder: (BuildContext context) {
         final allLocales = EasyLocalization.of(context)!.supportedLocales;
 
-        return ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 400),
-          child: ListView.builder(
-            itemBuilder: (context, index) {
-              final locale = allLocales[index];
-              return LanguageItem(locale: locale, currentLocale: currentLocale);
-            },
-            itemCount: allLocales.length,
-          ),
+        return LanguageItemsListView(
+          allLocales: allLocales,
+          currentLocale: currentLocale,
         );
       },
+    );
+  }
+}
+
+class LanguageItemsListView extends StatelessWidget {
+  const LanguageItemsListView({
+    super.key,
+    required this.allLocales,
+    required this.currentLocale,
+  });
+
+  final List<Locale> allLocales;
+  final Locale currentLocale;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 400),
+      child: ListView.builder(
+        itemBuilder: (context, index) {
+          final locale = allLocales[index];
+          return LanguageItem(locale: locale, currentLocale: currentLocale);
+        },
+        itemCount: allLocales.length,
+      ),
     );
   }
 }
@@ -88,7 +103,7 @@ class LanguageItem extends StatelessWidget {
         ),
         rightIcon: currentLocale == locale
             ? const FlowySvg(name: 'grid/checkmark')
-            : const SizedBox(),
+            : null,
         onTap: () {
           if (currentLocale != locale) {
             context.read<AppearanceSettingsCubit>().setLocale(context, locale);

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -52,32 +52,16 @@ class LanguageSelector extends StatelessWidget {
         onPressed: () {},
       ),
       popupBuilder: (BuildContext context) {
+        final allLocales = EasyLocalization.of(context)!.supportedLocales;
+
         return ConstrainedBox(
           constraints: const BoxConstraints(maxHeight: 400),
           child: ListView.builder(
             itemBuilder: (context, index) {
-              final locale =
-                  EasyLocalization.of(context)!.supportedLocales[index];
-              return SizedBox(
-                height: 32,
-                child: FlowyButton(
-                  text: FlowyText.medium(
-                    languageFromLocale(locale),
-                  ),
-                  rightIcon: currentLocale == locale
-                      ? const FlowySvg(name: 'grid/checkmark')
-                      : const SizedBox(),
-                  onTap: () {
-                    if (currentLocale != locale) {
-                      context
-                          .read<AppearanceSettingsCubit>()
-                          .setLocale(context, locale);
-                    }
-                  },
-                ),
-              );
+              final locale = allLocales[index];
+              return LanguageItem(locale: locale, currentLocale: currentLocale);
             },
-            itemCount: EasyLocalization.of(context)!.supportedLocales.length,
+            itemCount: allLocales.length,
           ),
         );
       },
@@ -103,7 +87,7 @@ class LanguageItem extends StatelessWidget {
           languageFromLocale(locale),
         ),
         rightIcon: currentLocale == locale
-            ? svgWidget("grid/checkmark")
+            ? const FlowySvg(name: 'grid/checkmark')
             : const SizedBox(),
         onTap: () {
           if (currentLocale != locale) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -1,7 +1,9 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/application/appearance.dart';
+import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flowy_infra_ui/style_widget/text.dart';
+import 'package:flowy_infra/image.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flowy_infra/language.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,85 +14,102 @@ class SettingsLanguageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              FlowyText.medium(LocaleKeys.settings_menu_language.tr()),
-              const LanguageSelectorDropdown(),
-            ],
-          ),
-        ],
+      child: BlocBuilder<AppearanceSettingsCubit, AppearanceSettingsState>(
+        builder: (context, state) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child:
+                      FlowyText.medium(LocaleKeys.settings_menu_language.tr()),
+                ),
+                LanguageSelector(currentLocale: state.locale),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
-class LanguageSelectorDropdown extends StatefulWidget {
-  const LanguageSelectorDropdown({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  State<LanguageSelectorDropdown> createState() =>
-      _LanguageSelectorDropdownState();
-}
-
-class _LanguageSelectorDropdownState extends State<LanguageSelectorDropdown> {
-  Color currHoverColor = Colors.white.withOpacity(0.0);
-  void hoverExitLanguage() {
-    setState(() {
-      currHoverColor = Colors.white.withOpacity(0.0);
-    });
-  }
-
-  void hoverEnterLanguage() {
-    setState(() {
-      currHoverColor = Theme.of(context).colorScheme.secondaryContainer;
-    });
-  }
+class LanguageSelector extends StatelessWidget {
+  final Locale currentLocale;
+  const LanguageSelector({
+    super.key,
+    required this.currentLocale,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      onEnter: (_) => hoverEnterLanguage(),
-      onExit: (_) => hoverExitLanguage(),
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 8),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-          color: currHoverColor,
-        ),
-        child: DropdownButtonHideUnderline(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 6),
-            child: DropdownButton<Locale>(
-              value: context.locale,
-              dropdownColor: Theme.of(context).cardColor,
-              onChanged: (locale) {
-                context
-                    .read<AppearanceSettingsCubit>()
-                    .setLocale(context, locale!);
-              },
-              autofocus: true,
-              borderRadius: BorderRadius.circular(8),
-              items:
-                  EasyLocalization.of(context)!.supportedLocales.map((locale) {
-                return DropdownMenuItem<Locale>(
-                  value: locale,
-                  child: Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: FlowyText.medium(
-                      languageFromLocale(locale),
-                      color: Theme.of(context).colorScheme.tertiary,
-                    ),
+    return AppFlowyPopover(
+      direction: PopoverDirection.bottomWithRightAligned,
+      child: FlowyTextButton(
+        languageFromLocale(currentLocale),
+        fontColor: Theme.of(context).colorScheme.onBackground,
+        fillColor: Colors.transparent,
+        onPressed: () {},
+      ),
+      popupBuilder: (BuildContext context) {
+        return ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 400),
+          child: ListView.builder(
+            itemBuilder: (context, index) {
+              final locale =
+                  EasyLocalization.of(context)!.supportedLocales[index];
+              return SizedBox(
+                height: 32,
+                child: FlowyButton(
+                  text: FlowyText.medium(
+                    languageFromLocale(locale),
                   ),
-                );
-              }).toList(),
-            ),
+                  rightIcon: currentLocale == locale
+                      ? const FlowySvg(name: 'grid/checkmark')
+                      : const SizedBox(),
+                  onTap: () {
+                    if (currentLocale != locale) {
+                      context
+                          .read<AppearanceSettingsCubit>()
+                          .setLocale(context, locale);
+                    }
+                  },
+                ),
+              );
+            },
+            itemCount: EasyLocalization.of(context)!.supportedLocales.length,
           ),
+        );
+      },
+    );
+  }
+}
+
+class LanguageItem extends StatelessWidget {
+  final Locale locale;
+  final Locale currentLocale;
+  const LanguageItem({
+    super.key,
+    required this.locale,
+    required this.currentLocale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 32,
+      child: FlowyButton(
+        text: FlowyText.medium(
+          languageFromLocale(locale),
         ),
+        rightIcon: currentLocale == locale
+            ? svgWidget("grid/checkmark")
+            : const SizedBox(),
+        onTap: () {
+          if (currentLocale != locale) {
+            context.read<AppearanceSettingsCubit>().setLocale(context, locale);
+          }
+        },
       ),
     );
   }


### PR DESCRIPTION
This PR is to change the current language picker UI along with fix #2291.
### Feature Preview
https://user-images.githubusercontent.com/14248245/233741806-04d02ea7-a4f3-43c5-a489-5709e66315a2.mov


Initially, I attempted to change the text color when it is hovered, but I realized that it was difficult to achieve due to the limitations of the DropdownButton. I considered importing a dropdownbutton related package(just for changing the text color?) or creating a customized DropdownButton(time-consuming). Instead, I think the best approach at the moment is to use the same popup-style widget in the theme setting, which would maintain consistency throughout the application setting page too.



#### PR Checklist

- [X] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [X] I've listed at least one issue that this PR fixes in the description above.
- [X] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [X] All existing tests are passing.
