### PR TITLE
revert: "Fix: #2028 auto enter edit mode for text field."

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/header/field_editor.dart
@@ -147,8 +147,6 @@ class _FieldNameTextFieldState extends State<_FieldNameTextField> {
     widget.popoverMutex.listenOnPopoverChanged(() {
       if (focusNode.hasFocus) {
         focusNode.unfocus();
-      } else {
-        focusNode.requestFocus();
       }
     });
 


### PR DESCRIPTION
The original commit has some visible regressions. See the video below:

https://user-images.githubusercontent.com/71320345/233851095-733b3c3a-621c-437b-aa9c-58fd41cf3b56.mp4

- when switching from one popover to another, notice that the text field is stealing focus
- the select option editor popover isn't opening at all