### PR TITLE
ci: dont run flutter ci on commits that only change tauri sources

### DIFF
--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -7,6 +7,7 @@ on:
       - "release/*"
     paths:
       - "frontend/**"
+      - "!frontend/appflowy_tauri/**"
 
   pull_request:
     branches:
@@ -14,6 +15,7 @@ on:
       - "release/*"
     paths:
       - "frontend/**"
+      - "!frontend/appflowy_tauri/**"
 
 env:
   FLUTTER_VERSION: "3.7.5"


### PR DESCRIPTION
<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->
fixes https://github.com/AppFlowy-IO/AppFlowy/issues/2073

---

Changing ```frontend/appflowy_tauri/src-tauri/src/main.rs``` before these changes caused the following workflows to be triggered:

![image](https://user-images.githubusercontent.com/25817019/233853448-f5fa72be-768b-41c3-82d7-d1f7a0ad4bf4.png)

After these changes:

![image](https://user-images.githubusercontent.com/25817019/233853697-5f4e7a1a-ba4d-4b16-94e9-aa5b97af655a.png)


<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
