### PR TITLE
fix: File and Trash icons brightness in dark mode.

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
@@ -40,6 +40,7 @@ class TrashCell extends StatelessWidget {
         FlowyIconButton(
           width: 26,
           onPressed: onRestore,
+          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
           icon: svgWidget(
             "editor/restore",
@@ -50,6 +51,7 @@ class TrashCell extends StatelessWidget {
         FlowyIconButton(
           width: 26,
           onPressed: onDelete,
+          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
           icon: svgWidget(
             "editor/delete",

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
@@ -75,6 +75,10 @@ class SettingsFileLocationCustomzierState
                   message: LocaleKeys.settings_files_restoreLocation.tr(),
                   child: FlowyIconButton(
                     icon: const Icon(Icons.restore_outlined),
+                    hoverColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.5),
                     onPressed: () async {
                       final result = await appFlowyDocumentDirectory();
                       await _setCustomLocation(result.path);
@@ -97,6 +101,10 @@ class SettingsFileLocationCustomzierState
                   message: LocaleKeys.settings_files_customizeLocation.tr(),
                   child: FlowyIconButton(
                     icon: const Icon(Icons.folder_open_outlined),
+                    hoverColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.5),
                     onPressed: () async {
                       final result =
                           await getIt<FilePickerService>().getDirectoryPath();


### PR DESCRIPTION
Fixes: #2298

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

- The fix ensures that the icons appear more eye-pleasing and consistent with the overall dark theme.

https://user-images.githubusercontent.com/72064462/234187701-f42a4708-35be-4d66-97f0-a00e3615da6e.mov

#### PR Checklist

- [X] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [X] I've listed at least one issue that this PR fixes in the description above.
- [X] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [X] All existing tests are passing.
