### PR TITLE
fix: fix icon hover color in dark mode

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/trash/src/sizes.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/src/sizes.dart
@@ -4,10 +4,14 @@ class TrashSizes {
   static double get fileNameWidth => 320 * scale;
   static double get lashModifyWidth => 230 * scale;
   static double get createTimeWidth => 230 * scale;
-  static double get padding => 100 * scale;
+  // padding between createTime and action icon
+  static double get padding => 40 * scale;
+  static double get actionIconWidth => 40 * scale;
   static double get totalWidth =>
       TrashSizes.fileNameWidth +
       TrashSizes.lashModifyWidth +
       TrashSizes.createTimeWidth +
-      TrashSizes.padding;
+      TrashSizes.padding +
+      // restore and delete icon
+      2 * TrashSizes.actionIconWidth;
 }

--- a/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
@@ -1,7 +1,5 @@
 import 'package:flowy_infra/image.dart';
-import 'package:flowy_infra_ui/style_widget/icon_button.dart';
-import 'package:flowy_infra_ui/style_widget/text.dart';
-import 'package:flowy_infra_ui/widget/spacing.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/trash.pb.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -38,25 +36,19 @@ class TrashCell extends StatelessWidget {
         ),
         const Spacer(),
         FlowyIconButton(
-          width: 26,
+          iconColorOnHover: Theme.of(context).colorScheme.onSurface,
+          width: TrashSizes.actionIconWidth,
           onPressed: onRestore,
-          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
-          icon: svgWidget(
-            "editor/restore",
-            color: Theme.of(context).iconTheme.color,
-          ),
+          icon: const FlowySvg(name: 'editor/restore'),
         ),
         const HSpace(20),
         FlowyIconButton(
-          width: 26,
+          iconColorOnHover: Theme.of(context).colorScheme.onSurface,
+          width: TrashSizes.actionIconWidth,
           onPressed: onDelete,
-          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
-          icon: svgWidget(
-            "editor/delete",
-            color: Theme.of(context).iconTheme.color,
-          ),
+          icon: const FlowySvg(name: 'editor/delete'),
         ),
       ],
     );

--- a/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/src/trash_cell.dart
@@ -40,6 +40,7 @@ class TrashCell extends StatelessWidget {
         FlowyIconButton(
           width: 26,
           onPressed: onRestore,
+          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
           icon: svgWidget(
             "editor/restore",
@@ -50,6 +51,7 @@ class TrashCell extends StatelessWidget {
         FlowyIconButton(
           width: 26,
           onPressed: onDelete,
+          hoverColor: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
           iconPadding: const EdgeInsets.all(5),
           icon: svgWidget(
             "editor/delete",

--- a/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
@@ -96,10 +96,7 @@ class _TrashPageState extends State<TrashPage> {
           IntrinsicWidth(
             child: FlowyButton(
               text: FlowyText.medium(LocaleKeys.trash_restoreAll.tr()),
-              leftIcon: svgWidget(
-                'editor/restore',
-                color: Theme.of(context).iconTheme.color,
-              ),
+              leftIcon: const FlowySvg(name: 'editor/restore'),
               onTap: () => context.read<TrashBloc>().add(
                     const TrashEvent.restoreAll(),
                   ),
@@ -109,10 +106,7 @@ class _TrashPageState extends State<TrashPage> {
           IntrinsicWidth(
             child: FlowyButton(
               text: FlowyText.medium(LocaleKeys.trash_deleteAll.tr()),
-              leftIcon: svgWidget(
-                'editor/delete',
-                color: Theme.of(context).iconTheme.color,
-              ),
+              leftIcon: const FlowySvg(name: 'editor/delete'),
               onTap: () =>
                   context.read<TrashBloc>().add(const TrashEvent.deleteAll()),
             ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
@@ -74,11 +74,11 @@ class SettingsFileLocationCustomzierState
                 Tooltip(
                   message: LocaleKeys.settings_files_restoreLocation.tr(),
                   child: FlowyIconButton(
+                    height: 40,
+                    width: 40,
                     icon: const Icon(Icons.restore_outlined),
-                    hoverColor: Theme.of(context)
-                        .colorScheme
-                        .secondary
-                        .withOpacity(0.5),
+                    hoverColor:
+                        Theme.of(context).colorScheme.secondaryContainer,
                     onPressed: () async {
                       final result = await appFlowyDocumentDirectory();
                       await _setCustomLocation(result.path);
@@ -100,11 +100,11 @@ class SettingsFileLocationCustomzierState
                 Tooltip(
                   message: LocaleKeys.settings_files_customizeLocation.tr(),
                   child: FlowyIconButton(
+                    height: 40,
+                    width: 40,
                     icon: const Icon(Icons.folder_open_outlined),
-                    hoverColor: Theme.of(context)
-                        .colorScheme
-                        .secondary
-                        .withOpacity(0.5),
+                    hoverColor:
+                        Theme.of(context).colorScheme.secondaryContainer,
                     onPressed: () async {
                       final result =
                           await getIt<FilePickerService>().getDirectoryPath();

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_file_customize_location_view.dart
@@ -75,6 +75,10 @@ class SettingsFileLocationCustomzierState
                   message: LocaleKeys.settings_files_restoreLocation.tr(),
                   child: FlowyIconButton(
                     icon: const Icon(Icons.restore_outlined),
+                    hoverColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.5),
                     onPressed: () async {
                       final result = await appFlowyDocumentDirectory();
                       await _setCustomLocation(result.path);
@@ -97,6 +101,10 @@ class SettingsFileLocationCustomzierState
                   message: LocaleKeys.settings_files_customizeLocation.tr(),
                   child: FlowyIconButton(
                     icon: const Icon(Icons.folder_open_outlined),
+                    hoverColor: Theme.of(context)
+                        .colorScheme
+                        .secondary
+                        .withOpacity(0.5),
                     onPressed: () async {
                       final result =
                           await getIt<FilePickerService>().getDirectoryPath();

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/hover.dart
@@ -99,6 +99,7 @@ class HoverStyle {
   final Color borderColor;
   final double borderWidth;
   final Color? hoverColor;
+  final Color? foregroundColorOnHover;
   final BorderRadius borderRadius;
   final EdgeInsets contentMargin;
   final Color backgroundColor;
@@ -110,6 +111,7 @@ class HoverStyle {
     this.contentMargin = EdgeInsets.zero,
     this.backgroundColor = Colors.transparent,
     this.hoverColor,
+    this.foregroundColorOnHover,
   });
 }
 
@@ -138,18 +140,17 @@ class FlowyHoverContainer extends StatelessWidget {
         borderRadius: style.borderRadius,
       ),
       child:
-          //override text's theme with new color when it is hovered
+          //override text's theme with foregroundColorOnHover when it is hovered
           Theme(
         data: Theme.of(context).copyWith(
           textTheme: Theme.of(context).textTheme.copyWith(
-                bodyMedium: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: Theme.of(context).colorScheme.onSurface),
+                bodyMedium: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: style.foregroundColorOnHover ??
+                        Theme.of(context).colorScheme.onSurface),
               ),
-          iconTheme: Theme.of(context)
-              .iconTheme
-              .copyWith(color: Theme.of(context).colorScheme.onSurface),
+          iconTheme: Theme.of(context).iconTheme.copyWith(
+              color: style.foregroundColorOnHover ??
+                  Theme.of(context).colorScheme.onSurface),
         ),
         child: child,
       ),

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/icon_button.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/icon_button.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra/size.dart';
+import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flutter/material.dart';
 
 class FlowyIconButton extends StatelessWidget {
@@ -11,6 +12,7 @@ class FlowyIconButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final Color? fillColor;
   final Color? hoverColor;
+  final Color? iconColorOnHover;
   final EdgeInsets iconPadding;
   final BorderRadius? radius;
   final String? tooltipText;
@@ -23,6 +25,7 @@ class FlowyIconButton extends StatelessWidget {
     this.onPressed,
     this.fillColor = Colors.transparent,
     this.hoverColor,
+    this.iconColorOnHover,
     this.iconPadding = EdgeInsets.zero,
     this.radius,
     this.tooltipText,
@@ -62,9 +65,17 @@ class FlowyIconButton extends StatelessWidget {
           highlightColor: Colors.transparent,
           elevation: 0,
           onPressed: onPressed,
-          child: Padding(
-            padding: iconPadding,
-            child: SizedBox.fromSize(size: childSize, child: child),
+          child: FlowyHover(
+            style: HoverStyle(
+              hoverColor: hoverColor,
+              foregroundColorOnHover:
+                  iconColorOnHover ?? Theme.of(context).iconTheme.color,
+              backgroundColor: fillColor ?? Colors.transparent,
+            ),
+            child: Padding(
+              padding: iconPadding,
+              child: SizedBox.fromSize(size: childSize, child: child),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This PR is to follow up PR #2345 and fix #2298. 

### Main Changes

I added a `foregroundColorOnHover` in the `HoverStyle`,so we can modify the icon and text color when it is hovered. Then I used it in `FlowyIconButton` to change the icon color when it is hovered. 

![image](https://user-images.githubusercontent.com/14248245/234405795-880959e7-fde4-4515-8859-c207bd85f5e4.png)

### Feature Preview
1. Update the hover effect in file location setting. I used the same hover style in setting(like theme and language) 
2. Update the hover effect on trash page. 


https://user-images.githubusercontent.com/14248245/234407831-6309f053-190b-4506-abdb-34377cdf9638.mov


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [X] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [X] I've listed at least one issue that this PR fixes in the description above.
- [X] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [X] All existing tests are passing.
