### PR TITLE
Support to break wrap the text block when triggering shift+enter

### DIFF
--- a/frontend/appflowy_tauri/src/appflowy_app/components/document/TextBlock/TextBlock.hooks.ts
+++ b/frontend/appflowy_tauri/src/appflowy_app/components/document/TextBlock/TextBlock.hooks.ts
@@ -1,6 +1,5 @@
-import { triggerHotkey } from '@/appflowy_app/utils/slate/hotkey';
-import { useCallback, useContext } from 'react';
-import { Range, Editor, Element, Text, Location } from 'slate';
+import { useCallback, useContext, useMemo } from 'react';
+import { Editor } from 'slate';
 import { TextDelta, TextSelection } from '$app/interfaces/document';
 import { useTextInput } from '../_shared/TextInput.hooks';
 import { useAppDispatch } from '@/appflowy_app/stores/store';
@@ -11,74 +10,23 @@ import {
   splitNodeThunk,
 } from '@/appflowy_app/stores/reducers/document/async_actions';
 import { documentActions } from '@/appflowy_app/stores/reducers/document/slice';
+import {
+  triggerHotkey,
+  canHandleEnterKey,
+  canHandleBackspaceKey,
+  canHandleTabKey,
+  onHandleEnterKey,
+} from '@/appflowy_app/utils/slate/hotkey';
 
 export function useTextBlock(id: string) {
   const { editor, onChange, value } = useTextInput(id);
-  const { onTab, onBackSpace, onEnter } = useActions(id);
-  const dispatch = useAppDispatch();
-
-  const keepSelection = useCallback(() => {
-    // This is a hack to make sure the selection is updated after next render
-    // It will save the selection to the store, and the selection will be restored
-    if (!editor.selection || !editor.selection.anchor || !editor.selection.focus) return;
-    const { anchor, focus } = editor.selection;
-    const selection = { anchor, focus } as TextSelection;
-    dispatch(documentActions.setTextSelection({ blockId: id, selection }));
-  }, [editor]);
+  const { onKeyDown } = useTextBlockKeyEvent(id, editor);
 
   const onKeyDownCapture = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      switch (event.key) {
-        // It should be handled when `Enter` is pressed
-        case 'Enter': {
-          if (!editor.selection) return;
-          event.stopPropagation();
-          event.preventDefault();
-          // get the retain content
-          const retainRange = getRetainRangeBy(editor);
-          const retain = getDelta(editor, retainRange);
-          // get the insert content
-          const insertRange = getInsertRangeBy(editor);
-          const insert = getDelta(editor, insertRange);
-          void (async () => {
-            // retain this node and insert a new node
-            await onEnter(retain, insert);
-          })();
-          return;
-        }
-        // It should be handled when `Backspace` is pressed
-        case 'Backspace': {
-          if (!editor.selection) {
-            return;
-          }
-          // It should be handled if the selection is collapsed and the cursor is at the beginning of the block
-          const { anchor } = editor.selection;
-          const isCollapsed = Range.isCollapsed(editor.selection);
-          if (isCollapsed && anchor.offset === 0 && anchor.path.toString() === '0,0') {
-            event.stopPropagation();
-            event.preventDefault();
-            keepSelection();
-            void (async () => {
-              await onBackSpace();
-            })();
-          }
-          return;
-        }
-        // It should be handled when `Tab` is pressed
-        case 'Tab': {
-          event.stopPropagation();
-          event.preventDefault();
-          keepSelection();
-          void (async () => {
-            await onTab();
-          })();
-
-          return;
-        }
-      }
-      triggerHotkey(event, editor);
+      onKeyDown(event);
     },
-    [editor, keepSelection, onEnter, onBackSpace, onTab]
+    [onKeyDown]
   );
 
   const onDOMBeforeInput = useCallback((e: InputEvent) => {
@@ -99,11 +47,81 @@ export function useTextBlock(id: string) {
   };
 }
 
+// eslint-disable-next-line no-shadow
+enum TextBlockKeyEvent {
+  Enter,
+  BackSpace,
+  Tab,
+}
+
+type TextBlockKeyEventHandlerParams = [React.KeyboardEvent<HTMLDivElement>, Editor];
+
+function useTextBlockKeyEvent(id: string, editor: Editor) {
+  const { tabAction, backSpaceAction, enterAction } = useActions(id);
+
+  const dispatch = useAppDispatch();
+  const keepSelection = useCallback(() => {
+    // This is a hack to make sure the selection is updated after next render
+    // It will save the selection to the store, and the selection will be restored
+    if (!editor.selection || !editor.selection.anchor || !editor.selection.focus) return;
+    const { anchor, focus } = editor.selection;
+    const selection = { anchor, focus } as TextSelection;
+    dispatch(documentActions.setTextSelection({ blockId: id, selection }));
+  }, [editor]);
+
+  // This is list of key events that can be handled by TextBlock
+  const keyEvents = useMemo(() => {
+    return [
+      {
+        key: TextBlockKeyEvent.Enter,
+        canHandle: canHandleEnterKey,
+        handler: (...args: TextBlockKeyEventHandlerParams) => {
+          onHandleEnterKey(...args, enterAction);
+        },
+      },
+      {
+        key: TextBlockKeyEvent.BackSpace,
+        canHandle: canHandleBackspaceKey,
+        handler: (..._args: TextBlockKeyEventHandlerParams) => {
+          keepSelection();
+          void backSpaceAction();
+        },
+      },
+      {
+        key: TextBlockKeyEvent.Tab,
+        canHandle: canHandleTabKey,
+        handler: (..._args: TextBlockKeyEventHandlerParams) => {
+          keepSelection();
+          void tabAction();
+        },
+      },
+    ];
+  }, [keepSelection, enterAction, tabAction, backSpaceAction]);
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const matchKey = keyEvents.find((keyEvent) => keyEvent.canHandle(event, editor));
+      if (!matchKey) {
+        triggerHotkey(event, editor);
+        return;
+      }
+
+      event.stopPropagation();
+      event.preventDefault();
+      matchKey.handler(event, editor);
+    },
+    [keyEvents, editor]
+  );
+
+  return {
+    onKeyDown,
+  };
+}
 function useActions(id: string) {
   const dispatch = useAppDispatch();
   const controller = useContext(DocumentControllerContext);
 
-  const onTab = useCallback(async () => {
+  const tabAction = useCallback(async () => {
     if (!controller) return;
     await dispatch(
       indentNodeThunk({
@@ -113,12 +131,12 @@ function useActions(id: string) {
     );
   }, [id, controller]);
 
-  const onBackSpace = useCallback(async () => {
+  const backSpaceAction = useCallback(async () => {
     if (!controller) return;
     await dispatch(backspaceNodeThunk({ id, controller }));
   }, [controller, id]);
 
-  const onEnter = useCallback(
+  const enterAction = useCallback(
     async (retain: TextDelta[], insert: TextDelta[]) => {
       if (!controller) return;
       await dispatch(splitNodeThunk({ id, retain, insert, controller }));
@@ -127,36 +145,8 @@ function useActions(id: string) {
   );
 
   return {
-    onTab,
-    onBackSpace,
-    onEnter,
-  };
-}
-
-function getDelta(editor: Editor, at: Location): TextDelta[] {
-  const baseElement = Editor.fragment(editor, at)[0] as Element;
-  return baseElement.children.map((item) => {
-    const { text, ...attributes } = item as Text;
-    return {
-      insert: text,
-      attributes,
-    };
-  });
-}
-
-function getRetainRangeBy(editor: Editor) {
-  const start = Editor.start(editor, editor.selection!);
-  return {
-    anchor: { path: [0, 0], offset: 0 },
-    focus: start,
-  };
-}
-
-function getInsertRangeBy(editor: Editor) {
-  const end = Editor.end(editor, editor.selection!);
-  const fragment = (editor.children[0] as Element).children;
-  return {
-    anchor: end,
-    focus: { path: [0, fragment.length - 1], offset: (fragment[fragment.length - 1] as Text).text.length },
+    tabAction,
+    backSpaceAction,
+    enterAction,
   };
 }

--- a/frontend/appflowy_tauri/src/appflowy_app/utils/slate/hotkey.ts
+++ b/frontend/appflowy_tauri/src/appflowy_app/utils/slate/hotkey.ts
@@ -1,6 +1,8 @@
 import isHotkey from 'is-hotkey';
 import { toggleFormat } from './format';
-import { Editor } from 'slate';
+import { Editor, Range } from 'slate';
+import { getRetainRangeBy, getDelta, getInsertRangeBy } from './text';
+import { TextDelta } from '$app/interfaces/document';
 
 const HOTKEYS: Record<string, string> = {
   'mod+b': 'bold',
@@ -14,9 +16,49 @@ const HOTKEYS: Record<string, string> = {
 export function triggerHotkey(event: React.KeyboardEvent<HTMLDivElement>, editor: Editor) {
   for (const hotkey in HOTKEYS) {
     if (isHotkey(hotkey, event)) {
-      event.preventDefault()
-      const format = HOTKEYS[hotkey]
-      toggleFormat(editor, format)
+      event.preventDefault();
+      const format = HOTKEYS[hotkey];
+      toggleFormat(editor, format);
     }
   }
+}
+
+export function canHandleEnterKey(event: React.KeyboardEvent<HTMLDivElement>, editor: Editor) {
+  const isEnter = event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.altKey;
+  if (!isEnter || !editor.selection) {
+    return false;
+  }
+  return true;
+}
+
+export function canHandleBackspaceKey(event: React.KeyboardEvent<HTMLDivElement>, editor: Editor) {
+  const isBackspaceKey = event.key === 'Backspace' && !event.shiftKey && !event.ctrlKey && !event.altKey;
+  if (!isBackspaceKey || !editor.selection) {
+    return false;
+  }
+  // It should be handled if the selection is collapsed and the cursor is at the beginning of the block
+  const { anchor } = editor.selection;
+  const isCollapsed = Range.isCollapsed(editor.selection);
+  return isCollapsed && anchor.offset === 0 && anchor.path.toString() === '0,0';
+}
+
+export function canHandleTabKey(event: React.KeyboardEvent<HTMLDivElement>, _: Editor) {
+  return event.key === 'Tab' && !event.shiftKey && !event.ctrlKey && !event.altKey;
+}
+
+export function onHandleEnterKey(
+  event: React.KeyboardEvent<HTMLDivElement>,
+  editor: Editor,
+  onEnter: (...args: [TextDelta[], TextDelta[]]) => Promise<void>
+) {
+  // get the retain content
+  const retainRange = getRetainRangeBy(editor);
+  const retain = getDelta(editor, retainRange);
+  // get the insert content
+  const insertRange = getInsertRangeBy(editor);
+  const insert = getDelta(editor, insertRange);
+  void (async () => {
+    // retain this node and insert a new node
+    await onEnter(retain, insert);
+  })();
 }

--- a/frontend/appflowy_tauri/src/appflowy_app/utils/slate/text.ts
+++ b/frontend/appflowy_tauri/src/appflowy_app/utils/slate/text.ts
@@ -1,0 +1,30 @@
+import { Editor, Element, Text, Location } from 'slate';
+import { TextDelta } from '$app/interfaces/document';
+
+export function getDelta(editor: Editor, at: Location): TextDelta[] {
+  const baseElement = Editor.fragment(editor, at)[0] as Element;
+  return baseElement.children.map((item) => {
+    const { text, ...attributes } = item as Text;
+    return {
+      insert: text,
+      attributes,
+    };
+  });
+}
+
+export function getRetainRangeBy(editor: Editor) {
+  const start = Editor.start(editor, editor.selection!);
+  return {
+    anchor: { path: [0, 0], offset: 0 },
+    focus: start,
+  };
+}
+
+export function getInsertRangeBy(editor: Editor) {
+  const end = Editor.end(editor, editor.selection!);
+  const fragment = (editor.children[0] as Element).children;
+  return {
+    anchor: end,
+    focus: { path: [0, fragment.length - 1], offset: (fragment[fragment.length - 1] as Text).text.length },
+  };
+}

--- a/frontend/appflowy_tauri/src/appflowy_app/utils/slate/text.ts
+++ b/frontend/appflowy_tauri/src/appflowy_app/utils/slate/text.ts
@@ -23,8 +23,10 @@ export function getRetainRangeBy(editor: Editor) {
 export function getInsertRangeBy(editor: Editor) {
   const end = Editor.end(editor, editor.selection!);
   const fragment = (editor.children[0] as Element).children;
+  const lastIndex = fragment.length - 1;
+  const lastNode = fragment[lastIndex] as Text;
   return {
     anchor: end,
-    focus: { path: [0, fragment.length - 1], offset: (fragment[fragment.length - 1] as Text).text.length },
+    focus: { path: [0, lastIndex], offset: lastNode.text.length },
   };
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- [x] Refactor: TextBlock's onKeyDown code 
- [x]  Support to break wrap the text block when triggering `shift+enter`

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
