### PR TITLE
Fix: Fix distorted/shrunken emojis in Callout option in the`Document` page

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/emoji_picker/src/default_emoji_picker_view.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/emoji_picker/src/default_emoji_picker_view.dart
@@ -270,7 +270,7 @@ class DefaultEmojiPickerViewState extends State<DefaultEmojiPickerView>
           widget.state.onEmojiSelected(categoryEmoji.category, emoji);
         },
         child: FittedBox(
-          fit: BoxFit.fill,
+          fit: BoxFit.scaleDown,
           child: Text(
             emoji.emoji,
             textScaleFactor: 1.0,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/emoji_picker/src/default_emoji_picker_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/emoji_picker/src/default_emoji_picker_view.dart
@@ -295,7 +295,7 @@ class DefaultEmojiPickerViewState extends State<DefaultEmojiPickerView>
         widget.state.onEmojiSelected(categoryEmoji.category, emoji);
       },
       child: FittedBox(
-        fit: BoxFit.fill,
+        fit: BoxFit.scaleDown,
         child: Text(
           emoji.emoji,
           textScaleFactor: 1.0,


### PR DESCRIPTION
### PR Description
This PR fixes distorted/shrunk emojis in `Document` page's Callout option, closes [Issue #2284](https://github.com/AppFlowy-IO/AppFlowy/issues/2284).

> Issue screenshot
<img src="https://user-images.githubusercontent.com/13991373/233542167-cf30a059-cbe8-481e-b36b-6d8e3ae75f32.png" width=700/>

### Fix Description
The parent wrapper container now has `BoxFit.scaleDown` option instead of `BixFit.fill`.

> [Fix] Screenshot

![fix-screenshot](https://user-images.githubusercontent.com/13991373/233542295-15a4d3b1-131f-4e8b-9d88-efa6229e62d0.png)

> [Fix] Recording

https://user-images.githubusercontent.com/13991373/233542336-18f4b74a-33a5-478d-baa5-e3e50c8fb961.mov

---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.


