### PR TITLE
feat: use user local timezone

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/database_controller.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/database_controller.dart
@@ -341,9 +341,10 @@ class RowDataBuilder {
     _cellDataByFieldId[fieldInfo.field.id] = num.toString();
   }
 
+  /// The date should use the UTC timezone. Becuase the backend uses UTC timezone to format the time string.
   void insertDate(FieldInfo fieldInfo, DateTime date) {
     assert(fieldInfo.fieldType == FieldType.DateTime);
-    final timestamp = (date.millisecondsSinceEpoch ~/ 1000);
+    final timestamp = (date.toUtc().millisecondsSinceEpoch ~/ 1000);
     _cellDataByFieldId[fieldInfo.field.id] = timestamp.toString();
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/database_view/calendar/application/calendar_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/calendar/application/calendar_bloc.dart
@@ -241,6 +241,8 @@ class CalendarBloc extends Bloc<CalendarEvent, CalendarState> {
         cellId: cellId,
       );
 
+      // The timestamp is using UTC in the backend, so we need to convert it
+      // to local time.
       final date = DateTime.fromMillisecondsSinceEpoch(
         eventPB.timestamp.toInt() * 1000,
       );


### PR DESCRIPTION
Use the local timezone to calculate the formatted date string. We can use the timezone specified by the user in the future.