### PR TITLE
fix: text overflow on time in event card

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/calendar/presentation/calendar_day.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/calendar/presentation/calendar_day.dart
@@ -122,17 +122,24 @@ class CalendarDayCard extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 2),
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              FlowyText.regular(
-                cellData.date,
-                fontSize: 10,
-                color: Theme.of(context).hintColor,
+              Flexible(
+                flex: 3,
+                child: FlowyText.regular(
+                  cellData.date,
+                  fontSize: 10,
+                  color: Theme.of(context).hintColor,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
-              const Spacer(),
-              FlowyText.regular(
-                cellData.time,
-                fontSize: 10,
-                color: Theme.of(context).hintColor,
+              Flexible(
+                child: FlowyText.regular(
+                  cellData.time,
+                  fontSize: 10,
+                  color: Theme.of(context).hintColor,
+                  overflow: TextOverflow.ellipsis,
+                ),
               )
             ],
           ),


### PR DESCRIPTION
This is a band-aid fix for the below issue. Ideally, the time should disappear completely before the date string starts getting ellided. But I've been playing with this since yesterday but to no avail.

### Feature Preview


https://user-images.githubusercontent.com/71320345/235703319-e107bdd6-cfcd-474a-a6cd-2b8aa9ff2f32.mp4


ref: #2403

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
