### PR TITLE
fix: default include time

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
@@ -48,7 +48,14 @@ class DateCellDataPersistence implements CellDataPersistence<DateCellData> {
     // This is a bit of a hack. This converts the data.date which is in
     // UTC to Local but actually changes the timestamp instead of just
     // changing the isUtc flag
-    final dateTime = DateTime(data.date.year, data.date.month, data.date.day);
+    final dateTime = DateTime(
+      data.date.year,
+      data.date.month,
+      data.date.day,
+      data.date.hour,
+      data.date.minute,
+      data.date.second,
+    );
 
     final date = (dateTime.millisecondsSinceEpoch ~/ 1000).toString();
     payload.date = date;

--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/cell/cell_data_persistence.dart
@@ -45,19 +45,7 @@ class DateCellDataPersistence implements CellDataPersistence<DateCellData> {
   Future<Option<FlowyError>> save(DateCellData data) {
     var payload = DateChangesetPB.create()..cellPath = _makeCellPath(cellId);
 
-    // This is a bit of a hack. This converts the data.date which is in
-    // UTC to Local but actually changes the timestamp instead of just
-    // changing the isUtc flag
-    final dateTime = DateTime(
-      data.date.year,
-      data.date.month,
-      data.date.day,
-      data.date.hour,
-      data.date.minute,
-      data.date.second,
-    );
-
-    final date = (dateTime.millisecondsSinceEpoch ~/ 1000).toString();
+    final date = (data.date.millisecondsSinceEpoch ~/ 1000).toString();
     payload.date = date;
     payload.isUtc = data.date.isUtc;
     payload.includeTime = data.includeTime;

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -84,11 +84,24 @@ class DateCellCalendarBloc
     bool? includeTime,
   }) {
     final DateCellData newDateData = state.dateCellData.fold(
-      () => DateCellData(
-        date: date ?? DateTime.now(),
-        time: time,
-        includeTime: includeTime ?? false,
-      ),
+      () {
+        DateTime newDate = DateTime.now();
+        if (date != null) {
+          newDate = DateTime(
+            date.year,
+            date.month,
+            date.day,
+            newDate.hour,
+            newDate.minute,
+            newDate.second,
+          );
+        }
+        return DateCellData(
+          date: newDate,
+          time: time,
+          includeTime: includeTime ?? false,
+        );
+      },
       (dateData) {
         var newDateData = dateData;
         if (date != null && !isSameDay(newDateData.date, date)) {

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -87,14 +87,7 @@ class DateCellCalendarBloc
       () {
         DateTime newDate = DateTime.now();
         if (date != null) {
-          newDate = DateTime(
-            date.year,
-            date.month,
-            date.day,
-            newDate.hour,
-            newDate.minute,
-            newDate.second,
-          );
+          newDate = _utcToLocalAddTime(date);
         }
         return DateCellData(
           date: newDate,
@@ -105,7 +98,9 @@ class DateCellCalendarBloc
       (dateData) {
         var newDateData = dateData;
         if (date != null && !isSameDay(newDateData.date, date)) {
-          newDateData = newDateData.copyWith(date: date);
+          newDateData = newDateData.copyWith(
+            date: _utcToLocalAddTime(date),
+          );
         }
 
         if (newDateData.time != time) {
@@ -161,6 +156,21 @@ class DateCellCalendarBloc
           },
         );
       },
+    );
+  }
+
+  DateTime _utcToLocalAddTime(DateTime date) {
+    final now = DateTime.now();
+    // the incoming date is Utc. this trick converts it into Local
+    // and add the current time, though
+    // the time may be overwritten by explicitly provided time string
+    return DateTime(
+      date.year,
+      date.month,
+      date.day,
+      now.hour,
+      now.minute,
+      now.second,
     );
   }
 


### PR DESCRIPTION
Regardless of whether a date has previously been selected, clicking toggle include time in a cell that previously did not have time will enter the current time for you.

fix: #1800
fix: #2440


<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
