### PR TITLE
fix - Set default theme to `Default` from `light` in the `Appearance` tab

### DIFF
--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/colorscheme.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/colorscheme.dart
@@ -128,6 +128,9 @@ abstract class FlowyColorScheme {
   });
 
   factory FlowyColorScheme.builtIn(String themeName, Brightness brightness) {
+    if (!themeMap.containsKey(themeName)) {
+      throw Exception('The theme $themeName could not be found');
+    }
     switch (brightness) {
       case Brightness.light:
         return themeMap[themeName]?[0] ?? const DefaultColorScheme.light();

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/theme.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/theme.dart
@@ -5,6 +5,12 @@ class BuiltInTheme {
   static const String defaultTheme = 'Default';
   static const String dandelion = 'Dandelion';
   static const String lavender = 'Lavender';
+
+  static const List<String> themes = [
+    BuiltInTheme.defaultTheme,
+    BuiltInTheme.dandelion,
+    BuiltInTheme.lavender
+  ];
 }
 
 class AppTheme {
@@ -13,6 +19,11 @@ class AppTheme {
   final FlowyColorScheme lightTheme;
   final FlowyColorScheme darkTheme;
   // static final Map<String, dynamic> _cachedJsonData = {};
+  static AppTheme get fallbackTheme =>  AppTheme(
+    themeName: BuiltInTheme.defaultTheme,
+    lightTheme: FlowyColorScheme.builtIn(BuiltInTheme.defaultTheme, Brightness.light),
+    darkTheme: FlowyColorScheme.builtIn(BuiltInTheme.defaultTheme, Brightness.dark),
+  );
 
   const AppTheme({
     required this.themeName,
@@ -21,6 +32,9 @@ class AppTheme {
   });
 
   factory AppTheme.fromName(String themeName) {
+    if (!BuiltInTheme.themes.contains(themeName)) {
+      return fallbackTheme;
+    }
     return AppTheme(
       themeName: themeName,
       lightTheme: FlowyColorScheme.builtIn(themeName, Brightness.light),

--- a/frontend/appflowy_flutter/test/unit_test/select_app_theme_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/select_app_theme_test.dart
@@ -1,0 +1,26 @@
+import 'dart:ui';
+
+import 'package:flowy_infra/colorscheme/colorscheme.dart';
+import 'package:flowy_infra/theme.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../util.dart';
+
+void main() {
+  setUpAll(() async {
+    AppFlowyUnitTest.ensureInitialized();
+  });
+
+  group('Select App Theme', () {
+    test('Passing invalid theme name returns Default theme as fallback', () {
+      final AppTheme t = AppTheme.fromName('whatever');
+      expect(t.themeName, "Default");
+    });
+
+    test('Passing invalid color scheme throws exception', () {
+      expect(
+        () => {FlowyColorScheme.builtIn("light", Brightness.light)},
+        throwsException,
+      );
+    });
+  });
+}


### PR DESCRIPTION
### PR Description
This PR replaces 'light' text with 'Default' for the default Theme in the Appearance panel, fixes [#2402](https://github.com/AppFlowy-IO/AppFlowy/issues/2402).

> Issue screenshot
![image](https://user-images.githubusercontent.com/13991373/235838587-e843ec51-fc3b-4f6a-8035-f31a7ffd8cd8.png)

### Fix Description
The 'light' text that appears on the UI comes from the API, which is now replaced with `Default` text when being displayed on the UI.

> [Fix] Screenshot
![image](https://user-images.githubusercontent.com/13991373/235838696-2aa45ba1-5712-4ddc-b42f-f50347f67776.png)



> [Fix] Recording

https://user-images.githubusercontent.com/13991373/235838709-271a3a20-a7e7-46f1-ba63-06151ac873f7.mov


---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
