### PR TITLE
fix: don't show whitespace when no options are selected

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/calendar/presentation/calendar_day.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/calendar/presentation/calendar_day.dart
@@ -162,6 +162,9 @@ class CalendarDayCard extends StatelessWidget {
     });
 
     renderHook.addSelectOptionHook((selectedOptions, cardData, _) {
+      if (selectedOptions.isEmpty) {
+        return const SizedBox.shrink();
+      }
       final children = selectedOptions.map(
         (option) {
           return SelectOptionTag.fromOption(


### PR DESCRIPTION
Notice how there is extra whitespace when the visibility of the select option field is being toggled

### Feature Preview

https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/365c9535-1e40-491f-9bd8-d7d0821d833f


---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
