### PR TITLE
chore: clean up code

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_tests.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_tests.rs
@@ -259,7 +259,8 @@ mod tests {
     );
   }
 
-  /// The default time format is TwentyFourHour, so the include_time_str in twelve_hours_format will cause parser error.
+  /// The default time format is TwentyFourHour, so the include_time_str in
+  /// twelve_hours_format will cause parser error.
   #[test]
   #[should_panic]
   fn date_type_option_twelve_hours_include_time_str_in_twenty_four_hours_format() {
@@ -279,7 +280,8 @@ mod tests {
     );
   }
 
-  // Attempting to parse include_time_str as TwelveHour when TwentyFourHour format is given should cause parser error.
+  /// Attempting to parse include_time_str as TwelveHour when TwentyFourHour
+  /// format is given should cause parser error.
   #[test]
   #[should_panic]
   fn date_type_option_twenty_four_hours_include_time_str_in_twelve_hours_format() {

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
@@ -27,14 +27,7 @@ pub struct DateCellChangeset {
 
 impl DateCellChangeset {
   pub fn date_timestamp(&self) -> Option<i64> {
-    if let Some(date) = &self.date {
-      match date.parse::<i64>() {
-        Ok(date_timestamp) => Some(date_timestamp),
-        Err(_) => None,
-      }
-    } else {
-      None
-    }
+    self.date.as_ref().and_then(|date| date.parse::<i64>().ok())
   }
 }
 


### PR DESCRIPTION
- Split off a portion of repeated logic into a separate function in `apply_changeset`.
- Improve readability in some parts
- early escape from timezone parsing if the timezone_id string is empty

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
