### PR TITLE
fix: Filter UI popover pixels overflow with dynamic width and height

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/filter/choicechip/text.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/filter/choicechip/text.dart
@@ -117,18 +117,25 @@ class _TextFilterEditorState extends State<TextFilterEditor> {
       height: 20,
       child: Row(
         children: [
-          FlowyText(state.filterInfo.fieldInfo.name),
-          const HSpace(4),
-          TextFilterConditionPBList(
-            filterInfo: state.filterInfo,
-            popoverMutex: popoverMutex,
-            onCondition: (condition) {
-              context
-                  .read<TextFilterEditorBloc>()
-                  .add(TextFilterEditorEvent.updateCondition(condition));
-            },
+          Expanded(
+            child: FlowyText(
+              state.filterInfo.fieldInfo.name,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
-          const Spacer(),
+          const HSpace(4),
+          Expanded(
+            child: TextFilterConditionPBList(
+              filterInfo: state.filterInfo,
+              popoverMutex: popoverMutex,
+              onCondition: (condition) {
+                context
+                    .read<TextFilterEditorBloc>()
+                    .add(TextFilterEditorEvent.updateCondition(condition));
+              },
+            ),
+          ),
+          const HSpace(4),
           DisclosureButton(
             popoverMutex: popoverMutex,
             onAction: (action) {

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/filter/condition_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/filter/condition_button.dart
@@ -32,6 +32,7 @@ class ConditionButton extends StatelessWidget {
           conditionName,
           fontSize: 10,
           color: AFThemeExtension.of(context).textColor,
+          overflow: TextOverflow.ellipsis,
         ),
         margin: const EdgeInsets.symmetric(horizontal: 4),
         radius: const BorderRadius.all(Radius.circular(2)),


### PR DESCRIPTION
fixes [#2476](https://github.com/AppFlowy-IO/AppFlowy/issues/2476)
### PR Description
This PR fixes pixels overflow issue using by `Expandable` and text overflow rule `overflow: TextOverflow.ellipsis`.

### Issue Recording
https://www.loom.com/share/007bae93eabb4d819fc169d0239a15ff

###  Fix Recording
https://www.loom.com/share/0246a6cdc88f42558716c7364279b4aa

---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
