### PR TITLE
fix: Divider shortcut does not work on lines with existing text 

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/divider/divider_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/divider/divider_shortcut_event.dart
@@ -22,14 +22,14 @@ ShortcutEventHandler _insertDividerHandler = (editorState, event) {
     return KeyEventResult.ignored;
   }
   final dashStartPosition = selection.start.offset - 2;
-  Transaction transaction;
+  final transaction = editorState.transaction;
 
   if (textNode.toPlainText().length > 2) {
-    transaction = editorState.transaction
+    editorState.transaction
       ..deleteText(textNode, dashStartPosition, 2)
       ..insertNode(selection.end.path.next, Node(type: kDividerType));
   } else {
-    transaction = editorState.transaction
+    editorState.transaction
       ..deleteText(textNode, 0, 2) // remove the existing minuses.
       ..insertNode(textNode.path, Node(type: kDividerType)) // insert the divder
       ..afterSelection = Selection.single(
@@ -42,8 +42,8 @@ ShortcutEventHandler _insertDividerHandler = (editorState, event) {
   return KeyEventResult.handled;
 };
 
-_hasTwoConsecutiveDashes(String text, int end) {
-  if(text.length < 2) {
+bool _hasTwoConsecutiveDashes(String text, int end) {
+  if (text.length < 2 || end > text.length) {
     return false;
   }
   return text[end - 1] == '-' && text[end - 2] == '-';


### PR DESCRIPTION
fixes [#2140](https://github.com/AppFlowy-IO/AppFlowy/issues/2140)

This PR makes the divider shortcut (---) work on lines with existing text

### Issue Video
https://www.loom.com/share/50083bab0556446fb2b4c0c005e14c64

### Fix video
https://www.loom.com/share/b132d5076eab4b58b1a05869e7988f7c

---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
