### PR TITLE
fix: Divider shortcut does not work on lines with existing text

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
@@ -49,7 +49,7 @@ CharacterShortcutEventHandler _convertMinusesToDividerHandler =
 };
 
 bool _hasTwoConsecutiveDashes(String text, int end) {
-  if (text.length < 2 || end > text.length || end == 0) {
+  if (text.length < 2 || end > text.length) {
     return false;
   }
   return text[end - 1] == '-' && text[end - 2] == '-';

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
@@ -27,17 +27,33 @@ CharacterShortcutEventHandler _convertMinusesToDividerHandler =
   if (node == null || delta == null) {
     return false;
   }
-  if (delta.toPlainText() != '--') {
+  if (!_hasTwoConsecutiveDashes(node.delta!.toPlainText(), selection.start.offset)) {
     return false;
   }
-  final transaction = editorState.transaction
-    ..insertNode(path, dividerNode())
-    ..insertNode(path, paragraphNode())
-    ..deleteNode(node)
-    ..afterSelection = Selection.collapse(path.next, 0);
+  final dashStartPosition = selection.start.offset - 2;
+  Transaction transaction;
+
+  if (node.delta!.length > 2) {
+    transaction = editorState.transaction
+      ..deleteText(node, dashStartPosition, 2)
+      ..insertNode(selection.end.path.next, dividerNode());
+  } else {
+    transaction = editorState.transaction
+      ..insertNode(path, dividerNode())
+      ..insertNode(path, paragraphNode())
+      ..deleteNode(node)
+      ..afterSelection = Selection.collapse(path.next, 0);
+  }
   editorState.apply(transaction);
   return true;
 };
+
+bool _hasTwoConsecutiveDashes(String text, int end) {
+  if (text.length < 2 || end > text.length || end == 0) {
+    return false;
+  }
+  return text[end - 1] == '-' && text[end - 2] == '-';
+}
 
 SelectionMenuItem dividerMenuItem = SelectionMenuItem(
   name: 'Divider',


### PR DESCRIPTION
fixes [#2140](https://github.com/AppFlowy-IO/AppFlowy/issues/2140)

This PR makes the divider shortcut (---) work on lines with existing text

### Issue Video
https://www.loom.com/share/50083bab0556446fb2b4c0c005e14c64

### Fix video
https://www.loom.com/share/b132d5076eab4b58b1a05869e7988f7c

---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
