### PR TITLE
fix: Divider shortcut does not work on lines with existing text

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
@@ -10,6 +10,8 @@ import 'package:flutter/material.dart';
 ///   - web
 ///   - mobile
 ///
+const dividerShortcutToken = '--';
+
 final CharacterShortcutEvent convertMinusesToDivider = CharacterShortcutEvent(
   key: 'insert a divider',
   character: '-',
@@ -19,29 +21,24 @@ final CharacterShortcutEvent convertMinusesToDivider = CharacterShortcutEvent(
 CharacterShortcutEventHandler _convertMinusesToDividerHandler =
     (editorState) async {
   final selection = editorState.selection;
-  
   if (selection == null || !selection.isCollapsed) {
     return false;
   }
-
   final path = selection.end.path;
   final node = editorState.getNodeAtPath(path);
   final delta = node?.delta;
-
   if (node == null || delta == null) {
     return false;
   }
-
-  if (!_hasTwoConsecutiveDashes(node.delta!.toPlainText(), selection.start.offset)) {
+  if (!_hasTwoConsecutiveDashes(delta.toPlainText(), selection.start.offset)) {
     return false;
   }
-
-  final dashStartPosition = selection.start.offset - 2;
+  final dashStartPosition = selection.start.offset - dividerShortcutToken.length;
   Transaction transaction;
 
-  if (node.delta!.length > 2) {
+  if (node.delta!.length > dividerShortcutToken.length) {
     transaction = editorState.transaction
-      ..deleteText(node, dashStartPosition, 2)
+      ..deleteText(node, dashStartPosition, dividerShortcutToken.length)
       ..insertNode(selection.end.path.next, dividerNode());
   } else {
     transaction = editorState.transaction
@@ -55,10 +52,11 @@ CharacterShortcutEventHandler _convertMinusesToDividerHandler =
 };
 
 bool _hasTwoConsecutiveDashes(String text, int end) {
-  if (text.length < 2 || end > text.length) {
+  if (text.length < dividerShortcutToken.length || end > text.length
+      || end < dividerShortcutToken.length) {
     return false;
   }
-  return text[end - 1] == '-' && text[end - 2] == '-';
+  return text[end - 1] == '-' && text[end - dividerShortcutToken.length] == '-';
 }
 
 SelectionMenuItem dividerMenuItem = SelectionMenuItem(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/divider/divider_character_shortcut_event.dart
@@ -33,15 +33,15 @@ CharacterShortcutEventHandler _convertMinusesToDividerHandler =
   if (!_hasTwoConsecutiveDashes(delta.toPlainText(), selection.start.offset)) {
     return false;
   }
-  final dashStartPosition = selection.start.offset - dividerShortcutToken.length;
-  Transaction transaction;
-
-  if (node.delta!.length > dividerShortcutToken.length) {
-    transaction = editorState.transaction
+  final dashStartPosition =
+      selection.start.offset - dividerShortcutToken.length;
+  final transaction = editorState.transaction;
+  if (delta.length > dividerShortcutToken.length) {
+    transaction
       ..deleteText(node, dashStartPosition, dividerShortcutToken.length)
       ..insertNode(selection.end.path.next, dividerNode());
   } else {
-    transaction = editorState.transaction
+    transaction
       ..insertNode(path, dividerNode())
       ..insertNode(path, paragraphNode())
       ..deleteNode(node)
@@ -52,11 +52,11 @@ CharacterShortcutEventHandler _convertMinusesToDividerHandler =
 };
 
 bool _hasTwoConsecutiveDashes(String text, int end) {
-  if (text.length < dividerShortcutToken.length || end > text.length
-      || end < dividerShortcutToken.length) {
+  if (end < dividerShortcutToken.length) {
     return false;
   }
-  return text[end - 1] == '-' && text[end - dividerShortcutToken.length] == '-';
+  return text.substring(end - dividerShortcutToken.length, end) ==
+      dividerShortcutToken;
 }
 
 SelectionMenuItem dividerMenuItem = SelectionMenuItem(


### PR DESCRIPTION
fixes [#2140](https://github.com/AppFlowy-IO/AppFlowy/issues/2140)

This PR makes the divider shortcut (---) work on lines with existing text

### Issue Video
https://www.loom.com/share/50083bab0556446fb2b4c0c005e14c64

### Fix video
https://www.loom.com/share/b132d5076eab4b58b1a05869e7988f7c

---
### PR Checklist
 - [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
 - [x] I've listed at least one issue that this PR fixes in the description above.
- [x]  I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
 - [x] All existing tests are passing.
---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.