### PR TITLE
[Fix] Integration test flakes.

### DIFF
--- a/frontend/appflowy_flutter/integration_test/board_test.dart
+++ b/frontend/appflowy_flutter/integration_test/board_test.dart
@@ -34,6 +34,8 @@ void main() {
   group('board', () {
     setUpAll(() async => await service.setUpAll());
     setUp(() async => await service.setUp());
+    tearDown(() async => await service.tearDown());
+    tearDownAll(() async => await service.tearDownAll());
 
     testWidgets(
         'integration test unzips the proper workspace and loads it correctly.',

--- a/frontend/appflowy_flutter/integration_test/empty_document_test.dart
+++ b/frontend/appflowy_flutter/integration_test/empty_document_test.dart
@@ -30,6 +30,8 @@ void main() {
   group('Tests on a workspace with only an empty document', () {
     setUpAll(() async => await service.setUpAll());
     setUp(() async => await service.setUp());
+    tearDown(() async => await service.tearDown());
+    tearDownAll(() async => await service.tearDownAll());
 
     testWidgets('/board shortcut creates a new board and view of the board',
         (tester) async {
@@ -69,6 +71,7 @@ void main() {
         ],
         tester: tester,
       );
+      await tester.pumpAndSettle();
 
       // Checks whether new board is referenced and properly on the page.
       expect(find.byType(BuiltInPageWidget), findsOneWidget);
@@ -113,7 +116,12 @@ void main() {
       expect(find.byType(SelectionMenuItemWidget), findsAtLeastNWidgets(2));
 
       // Finalizes the slash command that creates the board.
-      await simulateKeyDownEvent(LogicalKeyboardKey.enter);
+      await FlowyTestKeyboard.simulateKeyDownEvent(
+        [
+          LogicalKeyboardKey.enter,
+        ],
+        tester: tester,
+      );
       await tester.pumpAndSettle();
 
       // Checks whether new board is referenced and properly on the page.

--- a/frontend/appflowy_flutter/integration_test/open_ai_smart_menu_test.dart
+++ b/frontend/appflowy_flutter/integration_test/open_ai_smart_menu_test.dart
@@ -16,6 +16,8 @@ void main() {
   group('integration tests for open-ai smart menu', () {
     setUpAll(() async => await service.setUpAll());
     setUp(() async => await service.setUp());
+    tearDown(() async => await service.tearDown());
+    tearDownAll(() async => await service.tearDownAll());
 
     testWidgets('testing selection on open-ai smart menu replace', (tester) async {
       final appFlowyEditor = await setUpOpenAITesting(tester);

--- a/frontend/appflowy_flutter/integration_test/util/data.dart
+++ b/frontend/appflowy_flutter/integration_test/util/data.dart
@@ -39,6 +39,13 @@ enum TestWorkspace {
     return root;
   }
 
+  Future<void> clean() async {
+    final Directory workspaceRoot = await root;
+    if (await workspaceRoot.exists()) {
+      workspaceRoot.delete(recursive: true);
+    }
+  }
+
   String get _asset => 'assets/test/workspaces/$_name.zip';
 }
 
@@ -66,5 +73,13 @@ class TestWorkspaceService {
       archive,
       await TestWorkspace._parent.then((value) => value.path),
     );
+  }
+
+  Future<void> tearDown() async {
+    await workspace.clean();
+  }
+
+  Future<void> tearDownAll() async {
+    await SharedPreferences.getInstance().then((value) => value.remove(kSettingsLocationDefaultLocation));
   }
 }


### PR DESCRIPTION
**Issue** https://github.com/AppFlowy-IO/AppFlowy/issues/2346

Tests on a workspace with an empty document flakes. It [succeeds in certain runs](https://github.com/AppFlowy-IO/AppFlowy/actions/runs/5086697721/jobs/9141396746#step:11:3083), but [fails in others](https://github.com/AppFlowy-IO/AppFlowy/actions/runs/5059606445/jobs/9081384873#step:11:3069).

Here are the two exceptions that I caught for the flaky test.
```
1. Tests on a workspace with only an empty document /grid shortcut creates a new grid and view of the grid (failed)

  The following TestFailure was thrown running a test:
  Expected: at least 2 matching nodes in the widget tree
    Actual: _WidgetTypeFinder:<zero widgets with type "SelectionMenuItemWidget" (ignoring offstage
  widgets)>
     Which: means none were found but some were expected

-- and --

2. The following assertion was thrown while running async test code:
pumpAndSettle timed out

When the exception was thrown, this was the stack:
#0      WidgetTester.pumpAndSettle.<anonymous closure> (package:flutter_test/src/widget_tester.dart:651:11)
<asynchronous suspension>
<asynchronous suspension>
```

Different errors happen in CI, but they all have the exact root cause.
1. The first test run on this workspace creates a new view of a board. https://github.com/AppFlowy-IO/AppFlowy/blob/18672b197cf8e4ef79b8bfd7cbeae90bbc7f9da8/frontend/appflowy_flutter/integration_test/empty_document_test.dart#L34
2. Since the previous test didn't clean the workspace, the editor looks for the board created in the previous test. 
3. The workspace can't find the board, so it returns a `CircularProgressIndicator.` (actively being worked on in https://github.com/AppFlowy-IO/AppFlowy/pull/2011/files). 
4. The second test runs and calls `pumpAndSettle` after it requests focus from the editor.
https://github.com/AppFlowy-IO/AppFlowy/blob/18672b197cf8e4ef79b8bfd7cbeae90bbc7f9da8/frontend/appflowy_flutter/integration_test/empty_document_test.dart#LL93C8-L93C8
5. The call never settles because of the infinite animation for `CircularProgressIndicator.` 

**Solution**: Remove the unzipped workspace before running the next test. 

Since the editor reads from the file system, all documents must be cleaned between tests!

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
