### PR TITLE
Revert "Support regenerating ai results #2012"

### DIFF
--- a/frontend/appflowy_flutter/assets/translations/en.json
+++ b/frontend/appflowy_flutter/assets/translations/en.json
@@ -360,7 +360,6 @@
       "autoGeneratorGenerate": "Generate",
       "autoGeneratorHintText": "Ask OpenAI ...",
       "autoGeneratorCantGetOpenAIKey": "Can't get OpenAI key",
-      "autoGeneratorRewrite": "Rewrite",
       "smartEdit": "AI Assistants",
       "openAI": "OpenAI",
       "smartEditFixSpelling": "Fix spelling",

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/openai/widgets/auto_completion_plugins.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/openai/widgets/auto_completion_plugins.dart
@@ -14,7 +14,6 @@ SelectionMenuItem autoGeneratorMenuItem = SelectionMenuItem.node(
       type: kAutoCompletionInputType,
       attributes: {
         kAutoCompletionInputString: '',
-        kAutoCompletionGenerationCount: 0,
       },
     );
     return node;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/openai/widgets/smart_edit_node_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/plugins/openai/widgets/smart_edit_node_widget.dart
@@ -211,15 +211,15 @@ class _SmartEditInputState extends State<_SmartEditInput> {
   }
 
   Widget _buildResultWidget(BuildContext context) {
-    final loadingWidget = Padding(
+    final loading = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4.0),
       child: SizedBox.fromSize(
         size: const Size.square(14),
         child: const CircularProgressIndicator(),
       ),
     );
-    if (result.isEmpty || loading) {
-      return loadingWidget;
+    if (result.isEmpty) {
+      return loading;
     }
     return Flexible(
       child: Text(
@@ -231,18 +231,6 @@ class _SmartEditInputState extends State<_SmartEditInput> {
   Widget _buildInputFooterWidget(BuildContext context) {
     return Row(
       children: [
-        FlowyRichTextButton(
-          TextSpan(
-            children: [
-              TextSpan(
-                text: LocaleKeys.document_plugins_autoGeneratorRewrite.tr(),
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ],
-          ),
-          onPressed: () => _requestCompletions(rewrite: true),
-        ),
-        const Space(10, 0),
         FlowyRichTextButton(
           TextSpan(
             children: [
@@ -284,7 +272,7 @@ class _SmartEditInputState extends State<_SmartEditInput> {
           ),
           onPressed: () async => await _onExit(),
         ),
-        const Spacer(flex: 1),
+        const Spacer(flex: 2),
         Expanded(
           child: FlowyText.regular(
             overflow: TextOverflow.ellipsis,
@@ -371,13 +359,7 @@ class _SmartEditInputState extends State<_SmartEditInput> {
     );
   }
 
-  Future<void> _requestCompletions({bool rewrite = false}) async {
-    if (rewrite) {
-      setState(() {
-        loading = true;
-        result = "";
-      });
-    }
+  Future<void> _requestCompletions() async {
     final openAIRepository = await getIt.getAsync<OpenAIRepository>();
 
     var lines = input.split('\n\n');


### PR DESCRIPTION
`integration test` has been flaky for a while, and I'm fixing it. I noticed that integration tests for `open_ai_smart_menu_test` have been failing consistently lately. I ran a `git bisect` and tracked it to this PR.

**Issue** https://github.com/AppFlowy-IO/AppFlowy/issues/2346

Link to the workflow to show that tests failed when this PR was introduced
> https://github.com/AppFlowy-IO/AppFlowy/pull/2528/checks

PR that introduced `open_ai_smart_menu_test` (passed when introduced).
> https://github.com/AppFlowy-IO/AppFlowy/actions/runs/4869490828/jobs/8684057865