### PR TITLE
fix: remove icon button not working in popover

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/emoji_popover.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/emoji_popover.dart
@@ -39,7 +39,7 @@ class _EmojiPopoverState extends State<EmojiPopover> {
               padding: const EdgeInsets.only(bottom: 4.0),
               child: Align(
                 alignment: Alignment.centerRight,
-                child: DeleteButton(onPressed: widget.removeIcon),
+                child: DeleteButton(onTap: widget.removeIcon),
               ),
             ),
           Expanded(
@@ -67,13 +67,13 @@ class _EmojiPopoverState extends State<EmojiPopover> {
 }
 
 class DeleteButton extends StatelessWidget {
-  final VoidCallback onPressed;
-  const DeleteButton({required this.onPressed, Key? key}) : super(key: key);
+  final VoidCallback onTap;
+  const DeleteButton({required this.onTap, Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return FlowyButton(
-      onTap: () => onPressed,
+      onTap: onTap,
       useIntrinsicWidth: true,
       text: FlowyText(
         LocaleKeys.document_plugins_cover_removeIcon.tr(),


### PR DESCRIPTION
This is the same fix as #2518, I think the commit got lost during merging somewhere in the commit history.

### Feature Preview


---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
