### PR TITLE
fix: use same base width for all screen sizes

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
@@ -25,10 +25,7 @@ class HomeLayout {
 
     showEditPanel = homeSetting.panelContext.isSome();
 
-    menuWidth = Sizes.sideBarMed;
-    if (context.widthPx >= PageBreaks.desktop) {
-      menuWidth = Sizes.sideBarLg;
-    }
+    menuWidth = Sizes.sideBarWidth;
 
     menuWidth += homeSetting.resizeOffset;
 

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/size.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/size.dart
@@ -58,9 +58,7 @@ class Sizes {
 
   static double get iconMed => 20;
 
-  static double get sideBarMed => 225 * hitScale;
-
-  static double get sideBarLg => 290 * hitScale;
+  static double get sideBarWidth => 250 * hitScale;
 }
 
 class Corners {


### PR DESCRIPTION
resolves #2637

Title says all. I personally think that this is fine since we already set a minimum width on the window size.

However, if there are usability problems, please do let me know and I'll find another solution

### Feature Preview

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
