### PR TITLE
fix: pasting a link in a URL grid crashes the app

### DIFF
--- a/frontend/appflowy_flutter/.gitignore
+++ b/frontend/appflowy_flutter/.gitignore
@@ -76,4 +76,4 @@ coverage/
 
 **/failures/*.png
 
-assets/translations/*.json
+assets/translations/

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_shortcuts.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/accessory/cell_shortcuts.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -22,23 +24,35 @@ class GridCellShortcuts extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Shortcuts(
-      shortcuts: {
-        LogicalKeySet(LogicalKeyboardKey.enter): const GridCellEnterIdent(),
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyC):
-            const GridCellCopyIntent(),
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
-            const GridCellPasteIntent(),
-      },
+      shortcuts: shortcuts,
       child: Actions(
-        actions: {
-          GridCellEnterIdent: GridCellEnterAction(child: child),
-          GridCellCopyIntent: GridCellCopyAction(child: child),
-          GridCellPasteIntent: GridCellPasteAction(child: child),
-        },
+        actions: actions,
         child: child,
       ),
     );
   }
+
+  Map<ShortcutActivator, Intent> get shortcuts => {
+        if (shouldAddKeyboardKey(CellKeyboardKey.onEnter))
+          LogicalKeySet(LogicalKeyboardKey.enter): const GridCellEnterIdent(),
+        if (shouldAddKeyboardKey(CellKeyboardKey.onCopy))
+          LogicalKeySet(
+            Platform.isMacOS
+                ? LogicalKeyboardKey.meta
+                : LogicalKeyboardKey.control,
+            LogicalKeyboardKey.keyC,
+          ): const GridCellCopyIntent(),
+      };
+
+  Map<Type, Action<Intent>> get actions => {
+        if (shouldAddKeyboardKey(CellKeyboardKey.onEnter))
+          GridCellEnterIdent: GridCellEnterAction(child: child),
+        if (shouldAddKeyboardKey(CellKeyboardKey.onCopy))
+          GridCellCopyIntent: GridCellCopyAction(child: child),
+      };
+
+  bool shouldAddKeyboardKey(CellKeyboardKey key) =>
+      child.shortcutHandlers.containsKey(key);
 }
 
 class GridCellEnterIdent extends Intent {

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cell_builder.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cell_builder.dart
@@ -1,6 +1,5 @@
 import 'package:appflowy/plugins/database_view/application/cell/cell_controller_builder.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/field_entities.pb.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/material.dart';
 import '../../application/cell/cell_service.dart';
@@ -152,17 +151,9 @@ abstract class GridCellWidget extends StatefulWidget
 abstract class GridCellState<T extends GridCellWidget> extends State<T> {
   @override
   void initState() {
-    widget.requestFocus.setListener(requestBeginFocus);
-    widget.shortcutHandlers[CellKeyboardKey.onCopy] = () => onCopy();
-    widget.shortcutHandlers[CellKeyboardKey.onInsert] = () {
-      Clipboard.getData("text/plain").then((data) {
-        final s = data?.text;
-        if (s is String) {
-          onInsert(s);
-        }
-      });
-    };
     super.initState();
+
+    widget.requestFocus.setListener(requestBeginFocus);
   }
 
   @override
@@ -183,8 +174,6 @@ abstract class GridCellState<T extends GridCellWidget> extends State<T> {
   void requestBeginFocus();
 
   String? onCopy() => null;
-
-  void onInsert(String value) {}
 }
 
 abstract class GridEditableTextCell<T extends GridCellWidget>

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/number_cell/number_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/number_cell/number_cell.dart
@@ -88,9 +88,4 @@ class _NumberCellState extends GridEditableTextCell<GridNumberCell> {
   String? onCopy() {
     return _cellBloc.state.cellContent;
   }
-
-  @override
-  void onInsert(String value) {
-    _cellBloc.add(NumberCellEvent.updateCell(value));
-  }
 }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/text_cell/text_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/text_cell/text_cell.dart
@@ -126,11 +126,6 @@ class _GridTextCellState extends GridEditableTextCell<GridTextCell> {
   String? onCopy() => _cellBloc.state.content;
 
   @override
-  void onInsert(String value) {
-    _cellBloc.add(TextCellEvent.updateText(value));
-  }
-
-  @override
   Future<void> focusChanged() {
     _cellBloc.add(
       TextCellEvent.updateText(_controller.text),

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/url_cell/url_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/url_cell/url_cell.dart
@@ -191,9 +191,6 @@ class _GridURLCellState extends GridEditableTextCell<GridURLCell> {
 
   @override
   String? onCopy() => _cellBloc.state.content;
-
-  @override
-  void onInsert(String value) => _cellBloc.add(URLCellEvent.updateURL(value));
 }
 
 class _EditURLAccessory extends StatefulWidget {

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -53,8 +53,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "33b18d9"
-      resolved-ref: "33b18d98dcc6db996eef3d6b869f293da3da3615"
+      ref: "023f3c8"
+      resolved-ref: "023f3c835dc427a932bb2022a0d213c0084ffb99"
       url: "https://github.com/AppFlowy-IO/appflowy-editor.git"
     source: git
     version: "1.2.0"


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes #2965 

- remove the paste shortcut, use the built-in paste function of the text field instead.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
