### PR TITLE
fix: move translation jsons to right folder

### DIFF
--- a/frontend/scripts/code_generation/language_files/generate_language_files.sh
+++ b/frontend/scripts/code_generation/language_files/generate_language_files.sh
@@ -11,8 +11,9 @@ cd "$(dirname "$0")"
 cd ../../../appflowy_flutter
 
 # copy the resources/translations folder to
-#   the appflowy_flutter/assets/translation directory
-cp -rf ../resources/translations/ assets/translations/
+# the appflowy_flutter/assets/translation directory
+mkdir -p assets/translations/
+cp -f ../resources/translations/* assets/translations/
 
 flutter packages pub get
 

--- a/frontend/scripts/code_generation/language_files/generate_language_files.sh
+++ b/frontend/scripts/code_generation/language_files/generate_language_files.sh
@@ -12,8 +12,9 @@ cd ../../../appflowy_flutter
 
 # copy the resources/translations folder to
 # the appflowy_flutter/assets/translation directory
+rm -rf assets/translations/
 mkdir -p assets/translations/
-cp -f ../resources/translations/* assets/translations/
+cp -f ../resources/translations/*.json assets/translations/
 
 flutter packages pub get
 


### PR DESCRIPTION
Previously, the entire translation folder would be moved to `assets/translations` (i.e. `assets/translations/translations/en.json`) if the folder exists. This creates the folder if needed then moves the individual JSON files over instead.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
