### PR TITLE
fix: dispose the listener when the favorite bloc dispose

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/favorite/favorite_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/favorite/favorite_bloc.dart
@@ -58,6 +58,12 @@ class FavoriteBloc extends Bloc<FavoriteEvent, FavoriteState> {
     );
   }
 
+  @override
+  Future<void> close() async {
+    await _listener.stop();
+    return super.close();
+  }
+
   void _onFavoritesUpdated(
     Either<FlowyError, RepeatedViewPB> favoriteOrFailed,
     bool didFavorite,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

Error log
https://github.com/AppFlowy-IO/AppFlowy/actions/runs/5740386657/job/15558096157

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
