### PR TITLE
fix: euro currency number format

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_tests.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_tests.rs
@@ -80,6 +80,18 @@ mod tests {
     assert_number(&type_option, "0.2", "$0.2", &field_type, &field);
   }
 
+  #[test]
+  fn euro_type_option_test() {
+    let field_type = FieldType::Number;
+    let mut type_option = NumberTypeOption::new();
+    type_option.format = NumberFormat::EUR;
+    let field = FieldBuilder::new(field_type.clone(), type_option.clone()).build();
+
+    assert_number(&type_option, "0.2", "€0,2", &field_type, &field);
+    assert_number(&type_option, "1000", "€1.000", &field_type, &field);
+    assert_number(&type_option, "1234.56", "€1.234,56", &field_type, &field);
+  }
+
   fn assert_number(
     type_option: &NumberTypeOption,
     input_str: &str,

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option.rs
@@ -219,7 +219,7 @@ impl CellDataChangeset for NumberTypeOption {
         NumberCellData::from(formatter.to_string()),
       )),
       _ => Ok((
-        NumberCellData::from(formatter.to_string()).into(),
+        NumberCellData::from(formatter.to_unformatted_string()).into(),
         NumberCellData::from(formatter.to_string()),
       )),
     }

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option_entities.rs
@@ -7,7 +7,7 @@ use rust_decimal::Decimal;
 use rusty_money::Money;
 use std::str::FromStr;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct NumberCellFormat {
   decimal: Option<Decimal>,
   money: Option<String>,
@@ -67,6 +67,13 @@ impl NumberCellFormat {
 
   pub fn is_empty(&self) -> bool {
     self.decimal.is_none()
+  }
+
+  pub fn to_unformatted_string(&self) -> String {
+    match self.decimal {
+      None => String::default(),
+      Some(decimal) => decimal.to_string(),
+    }
   }
 }
 


### PR DESCRIPTION
This PR saves the number as the unformatted decimal string, instead of the formatted string. This was causing problems because

`1000` becomes `€1.000` when stored in the backend. Then upon parsing, since `.` is the decimal deparator in euros, this becomes one euro and zero euro cents, which then gets formatted to `€1,00`.

fixes #3096

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
