### PR TITLE
chore: german translation for new property and shortcuts

### DIFF
--- a/frontend/resources/translations/de-DE.json
+++ b/frontend/resources/translations/de-DE.json
@@ -143,6 +143,13 @@
     "appearance": {
       "lightLabel": "Heller Modus",
       "darkLabel": "Dunkler Modus"
+    },
+    "shortcuts": {
+      "shortcutsLabel": "Verknüpfungen",
+      "addNewCommand": "Neuen Befehl hinzufügen",
+      "updateShortcutStep": "Drücken Sie die gewünschte Tastenkombination und drücken Sie ENTER",
+      "shortcutIsAlreadyUsed": "Diese Verknüpfung wird bereits verwendet für: {conflict}",
+      "resetToDefault": "Zurücksetzen keybindings"
     }
   },
   "sideBar": {
@@ -329,7 +336,7 @@
   "grid.field.optionTitle": "Optionen",
   "grid.field.addOption": "Option hinzufügen",
   "grid.field.editProperty": "Eigenschaft bearbeiten",
-  "grid.field.newProperty": "Neue Immobilie",
+  "grid.field.newProperty": "Neue Eigenschaft",
   "grid.field.deleteFieldPromptMessage": "Bist du dir sicher? Diese Eigenschaft wird gelöscht",
   "grid.sort.ascending": "Aufsteigend",
   "grid.sort.descending": "Absteigend",

--- a/frontend/resources/translations/de-DE.json
+++ b/frontend/resources/translations/de-DE.json
@@ -149,7 +149,7 @@
       "addNewCommand": "Neuen Befehl hinzufügen",
       "updateShortcutStep": "Drücken Sie die gewünschte Tastenkombination und drücken Sie ENTER",
       "shortcutIsAlreadyUsed": "Diese Verknüpfung wird bereits verwendet für: {conflict}",
-      "resetToDefault": "Zurücksetzen keybindings"
+      "resetToDefault": "Zurücksetzen"
     }
   },
   "sideBar": {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->
Solves: #3037 
I use 'Eigenschaft' which means property instead of the other suggestion: 'Spalte' which means column.
<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
