### PR TITLE
chore: Support CI build universal macOS package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,19 +220,19 @@ jobs:
           asset_name: ${{ env.MACOS_DMG_NAME }}.dmg
           asset_content_type: application/octet-stream
 
-  build-for-macOS-aarch64:
+  build-for-macOS-universal:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }}) [${{ matrix.job.extra-build-args }}]
     runs-on: ${{ matrix.job.os }}
     needs: create-release
     env:
       MACOS_APP_RELEASE_PATH: frontend/appflowy_flutter/product/${{ github.ref_name }}/macos/Release
-      MACOS_AARCH64_ZIP_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64.zip
-      MACOS_DMG_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64
+      MACOS_AARCH64_ZIP_NAME: AppFlowy_${{ github.ref_name }}_macos-universal.zip
+      MACOS_DMG_NAME: AppFlowy_${{ github.ref_name }}_macos-universal
     strategy:
       fail-fast: false
       matrix:
         job:
-          - { target: aarch64-apple-darwin, os: macos-11, extra-build-args: "" }
+          - { targets: 'aarch64-apple-darwin,x86_64-apple-darwin', os: macos-11, extra-build-args: "" }
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -245,13 +245,11 @@ jobs:
           cache: true
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          target: ${{ matrix.job.target }}
-          override: true
+          targets: ${{ matrix.job.targets }}
           components: rustfmt
-          profile: minimal
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -268,7 +266,7 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-macos-desktop
-          cargo make --profile production-mac-arm64 appflowy
+          sh scripts/flutter_release_build/build_universal_package_for_macos.sh
 
       - name: Create macOS dmg
         run: |
@@ -456,7 +454,7 @@ jobs:
 
   notify-discord:
     runs-on: ubuntu-latest
-    needs: [build-for-linux, build-for-windows, build-for-macOS-x86_64, build-for-macOS-aarch64]
+    needs: [build-for-linux, build-for-windows, build-for-macOS-x86_64, build-for-macOS-universal]
     steps:
       - name: Notify Discord
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           asset_name: ${{ env.WINDOWS_INSTALLER_NAME }}.exe
           asset_content_type: application/octet-stream
 
-  build-for-macOS:
+  build-for-macOS-x86_64:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }}) [${{ matrix.job.extra-build-args }}]
     runs-on: ${{ matrix.job.os }}
     needs: create-release
@@ -208,6 +208,94 @@ jobs:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_X86_ZIP_NAME }}
           asset_name: ${{ env.MACOS_X86_ZIP_NAME }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload DMG Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg
+          asset_name: ${{ env.MACOS_DMG_NAME }}.dmg
+          asset_content_type: application/octet-stream
+
+  build-for-macOS-aarch64:
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }}) [${{ matrix.job.extra-build-args }}]
+    runs-on: ${{ matrix.job.os }}
+    needs: create-release
+    env:
+      MACOS_APP_RELEASE_PATH: frontend/appflowy_flutter/product/${{ github.ref_name }}/macos/Release
+      MACOS_AARCH64_ZIP_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64.zip
+      MACOS_DMG_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { target: aarch64-apple-darwin, os: macos-11, extra-build-args: "" }
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          target: ${{ matrix.job.target }}
+          override: true
+          components: rustfmt
+          profile: minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: appflowy-lib-cache
+          key: ${{ matrix.job.os }}-${{ matrix.job.target }}
+
+      - name: Install prerequisites
+        working-directory: frontend
+        run: |
+          cargo install --force cargo-make
+          cargo install --force duckscript_cli
+
+      - name: Build AppFlowy
+        working-directory: frontend
+        run: |
+          flutter config --enable-macos-desktop
+          cargo make --profile production-mac-arm64 appflowy
+
+      - name: Create macOS dmg
+        run: |
+          brew install create-dmg
+          create-dmg \
+          --volname ${{ env.MACOS_DMG_NAME }} \
+          --hide-extension "AppFlowy.app" \
+          --background frontend/scripts/dmg_assets/AppFlowyInstallerBackground.jpg \
+          --window-size 600 450 \
+          --icon-size 94 \
+          --icon "AppFlowy.app" 141 249 \
+          --app-drop-link 458 249 \
+          "${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg" \
+          "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app"
+
+      - name: Archive Asset
+        working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
+        run: zip --symlinks -qr ${{ env.MACOS_AARCH64_ZIP_NAME }} AppFlowy.app
+
+      - name: Upload Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_AARCH64_ZIP_NAME }}
+          asset_name: ${{ env.MACOS_AARCH64_ZIP_NAME }}
           asset_content_type: application/octet-stream
 
       - name: Upload DMG Asset
@@ -368,7 +456,7 @@ jobs:
 
   notify-discord:
     runs-on: ubuntu-latest
-    needs: [build-for-linux, build-for-windows, build-for-macOS]
+    needs: [build-for-linux, build-for-windows, build-for-macOS-x86_64, build-for-macOS-aarch64]
     steps:
       - name: Notify Discord
         run: |

--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -60,6 +60,7 @@ BUILD_FLAG = "debug"
 FLUTTER_OUTPUT_DIR = "Debug"
 PRODUCT_EXT = "app"
 BUILD_ARCHS = "arm64"
+BUILD_ACTIVE_ARCHS_ONLY = true
 CRATE_TYPE = "staticlib"
 
 [env.development-mac-x86_64]
@@ -70,6 +71,7 @@ BUILD_FLAG = "debug"
 FLUTTER_OUTPUT_DIR = "Debug"
 PRODUCT_EXT = "app"
 BUILD_ARCHS = "x86_64"
+BUILD_ACTIVE_ARCHS_ONLY = true
 CRATE_TYPE = "staticlib"
 
 [env.production-mac-arm64]
@@ -80,6 +82,7 @@ FLUTTER_OUTPUT_DIR = "Release"
 PRODUCT_EXT = "app"
 APP_ENVIRONMENT = "production"
 BUILD_ARCHS = "arm64"
+BUILD_ACTIVE_ARCHS_ONLY = false
 CRATE_TYPE = "staticlib"
 
 [env.production-mac-x86_64]
@@ -90,7 +93,16 @@ FLUTTER_OUTPUT_DIR = "Release"
 PRODUCT_EXT = "app"
 APP_ENVIRONMENT = "production"
 BUILD_ARCHS = "x86_64"
+BUILD_ACTIVE_ARCHS_ONLY = false
 CRATE_TYPE = "staticlib"
+
+[env.production-mac-universal]
+BUILD_FLAG = "release"
+TARGET_OS = "macos"
+FLUTTER_OUTPUT_DIR = "Release"
+PRODUCT_EXT = "app"
+BUILD_ACTIVE_ARCHS_ONLY = false
+APP_ENVIRONMENT = "production"
 
 [env.development-windows-x86]
 TARGET_OS = "windows"

--- a/frontend/appflowy_flutter/macos/Podfile
+++ b/frontend/appflowy_flutter/macos/Podfile
@@ -27,18 +27,31 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_macos_podfile_setup
 
 def build_specify_archs_only
-  # if ENV.has_key?('BUILD_ARCHS')
-  #   xcodeproj_path = File.dirname(__FILE__) + '/Runner.xcodeproj'
-  #   project = Xcodeproj::Project.open(xcodeproj_path)
-  #   project.targets.each do |target|
-  #     if target.name == 'Runner'
-  #       target.build_configurations.each do |config|
-  #         config.build_settings['ARCHS'] = ENV['BUILD_ARCHS']
-  #       end
-  #     end
-  #   end
-  #   project.save()
-  # end
+  if ENV.has_key?('BUILD_ACTIVE_ARCHS_ONLY')
+    xcodeproj_path = File.dirname(__FILE__) + '/Runner.xcodeproj'
+    project = Xcodeproj::Project.open(xcodeproj_path)
+    project.targets.each do |target|
+      if target.name == 'Runner'
+        target.build_configurations.each do |config|
+          config.build_settings['ONLY_ACTIVE_ARCH'] = ENV['BUILD_ACTIVE_ARCHS_ONLY']
+        end
+      end
+    end
+    project.save()
+  end
+
+  if ENV.has_key?('BUILD_ARCHS')
+    xcodeproj_path = File.dirname(__FILE__) + '/Runner.xcodeproj'
+    project = Xcodeproj::Project.open(xcodeproj_path)
+    project.targets.each do |target|
+      if target.name == 'Runner'
+        target.build_configurations.each do |config|
+          config.build_settings['ARCHS'] = ENV['BUILD_ARCHS']
+        end
+      end
+    end
+    project.save()
+  end
 end
 
 build_specify_archs_only()

--- a/frontend/appflowy_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/frontend/appflowy_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -598,7 +598,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.appflowy.appflowy.flutter;
 				PRODUCT_NAME = AppFlowy;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/frontend/scripts/flutter_release_build/build_universal_package_for_macos.sh
+++ b/frontend/scripts/flutter_release_build/build_universal_package_for_macos.sh
@@ -24,4 +24,4 @@ cp -rf rust-lib/target/libdart_ffi.a \
 
 echo '🚀 ---------------------------------------------------'
 echo '🚀 building the flutter application for macOS'
-flutter build macos --release
+cargo make --profile production-mac-universal appflowy-macos-unviersal

--- a/frontend/scripts/makefile/flutter.toml
+++ b/frontend/scripts/makefile/flutter.toml
@@ -13,6 +13,15 @@ run_task = { name = [
 ] }
 script_runner = "@shell"
 
+[tasks.appflowy-macos-universal]
+run_task = { name = [
+  "code_generation",
+  "set-app-version",
+  "flutter-build",
+  "copy-to-product",
+] }
+script_runner = "@shell"
+
 [tasks.appflowy-windows]
 dependencies = ["appflowy-core-release"]
 run_task = { name = [


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<img width="1022" alt="Screenshot 2023-08-06 at 11 00 47" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/d800e1e9-f2a9-423b-9e6b-95af8685b597">

## Command line
### build the universal macOS package (support on the m1 or intel chip)
```sh
cd frontend
sh scripts/flutter_release_build/build_universal_package_for_macos.sh
```

### build the arm64 macOS package (support on the m1 chip only)
```sh
cargo make --profile production-mac-arm64 appflowy
```

### build the x86_64 macOS package (support on the m1 or intel chip)
```sh
cargo make --profile production-mac-x86_64 appflowy
```

It doesn't support building the arm64 package only on Intel mac. The error log: https://github.com/LucasXu0/AppFlowy/actions/runs/5771555525/job/15645635129

```yaml
  build-for-macOS-arm64:
    name: ${{ matrix.job.target }} (${{ matrix.job.os }}) [${{ matrix.job.extra-build-args }}]
    runs-on: ${{ matrix.job.os }}
    needs: create-release
    env:
      MACOS_APP_RELEASE_PATH: frontend/appflowy_flutter/product/${{ github.ref_name }}/macos/Release
      MACOS_AARCH64_ZIP_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64.zip
      MACOS_DMG_NAME: AppFlowy_${{ github.ref_name }}_macos-aarch64
    strategy:
      fail-fast: false
      matrix:
        job:
          - { target: aarch64-apple-darwin, os: macos-11, extra-build-args: "" }
    steps:
      - name: Checkout source code
        uses: actions/checkout@v3

      - name: Install flutter
        uses: subosito/flutter-action@v2
        with:
          channel: "stable"
          flutter-version: ${{ env.FLUTTER_VERSION }}
          cache: true

      - name: Install Rust toolchain
        uses: actions-rs/toolchain@v1
        with:
          toolchain: ${{ env.RUST_TOOLCHAIN }}
          target: ${{ matrix.job.target }}
          override: true
          components: rustfmt
          profile: minimal

      - uses: Swatinem/rust-cache@v2
        with:
          prefix-key: appflowy-lib-cache
          key: ${{ matrix.job.os }}-${{ matrix.job.target }}

      - name: Install prerequisites
        working-directory: frontend
        run: |
          cargo install --force cargo-make
          cargo install --force duckscript_cli

      - name: Build AppFlowy
        working-directory: frontend
        run: |
          flutter config --enable-macos-desktop
          cargo make --profile production-mac-arm64 appflowy

      - name: Create macOS dmg
        run: |
          brew install create-dmg
          create-dmg \
          --volname ${{ env.MACOS_DMG_NAME }} \
          --hide-extension "AppFlowy.app" \
          --background frontend/scripts/dmg_assets/AppFlowyInstallerBackground.jpg \
          --window-size 600 450 \
          --icon-size 94 \
          --icon "AppFlowy.app" 141 249 \
          --app-drop-link 458 249 \
          "${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg" \
          "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app"

      - name: Archive Asset
        working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
        run: zip --symlinks -qr ${{ env.MACOS_AARCH64_ZIP_NAME }} AppFlowy.app

      - name: Upload Asset
        uses: actions/upload-release-asset@v1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          upload_url: ${{ needs.create-release.outputs.upload_url }}
          asset_path: ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_AARCH64_ZIP_NAME }}
          asset_name: ${{ env.MACOS_AARCH64_ZIP_NAME }}
          asset_content_type: application/octet-stream

      - name: Upload DMG Asset
        uses: actions/upload-release-asset@v1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          upload_url: ${{ needs.create-release.outputs.upload_url }}
          asset_path: ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg
          asset_name: ${{ env.MACOS_DMG_NAME }}.dmg
          asset_content_type: application/octet-stream
```

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
