### PR TITLE
fix: arrow keys on field name text field

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/header/field_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/header/field_editor.dart
@@ -1,7 +1,6 @@
 import 'package:appflowy/plugins/database_view/application/field/field_editor_bloc.dart';
 import 'package:appflowy/plugins/database_view/application/field/type_option/type_option_context.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
-import 'package:dartz/dartz.dart' show none;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/image.dart';
 import 'package:flowy_infra_ui/style_widget/button.dart';
@@ -163,6 +162,8 @@ class _FieldNameTextFieldState extends State<FieldNameTextField> {
 
   @override
   void initState() {
+    super.initState();
+
     focusNode.addListener(() {
       if (focusNode.hasFocus) {
         widget.popoverMutex.close();
@@ -174,39 +175,28 @@ class _FieldNameTextFieldState extends State<FieldNameTextField> {
         focusNode.unfocus();
       }
     });
-
-    super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<FieldEditorBloc, FieldEditorState>(
-      listenWhen: (p, c) => p.field == none(),
-      listener: (context, state) {
-        textController.text = state.name;
-        focusNode.requestFocus();
+    return BlocBuilder<FieldEditorBloc, FieldEditorState>(
+      builder: (context, state) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0),
+          child: FlowyTextField(
+            focusNode: focusNode,
+            controller: textController,
+            onSubmitted: (String _) => PopoverContainer.of(context).close(),
+            text: state.name,
+            errorText: state.errorText.isEmpty ? null : state.errorText,
+            onChanged: (newName) {
+              context
+                  .read<FieldEditorBloc>()
+                  .add(FieldEditorEvent.updateName(newName));
+            },
+          ),
+        );
       },
-      child: BlocBuilder<FieldEditorBloc, FieldEditorState>(
-        buildWhen: (previous, current) =>
-            previous.errorText != current.errorText,
-        builder: (context, state) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12.0),
-            child: FlowyTextField(
-              focusNode: focusNode,
-              controller: textController,
-              onSubmitted: (String _) => PopoverContainer.of(context).close(),
-              text: state.name,
-              errorText: state.errorText.isEmpty ? null : state.errorText,
-              onChanged: (newName) {
-                context
-                    .read<FieldEditorBloc>()
-                    .add(FieldEditorEvent.updateName(newName));
-              },
-            ),
-          );
-        },
-      ),
     );
   }
 }

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -54,15 +54,13 @@ class FlowyTextFieldState extends State<FlowyTextField> {
     focusNode = widget.focusNode ?? FocusNode();
     focusNode.addListener(notifyDidEndEditing);
 
-    if (widget.controller != null) {
-      controller = widget.controller!;
-    } else {
-      controller = TextEditingController();
-      controller.text = widget.text;
-    }
+    controller = widget.controller ?? TextEditingController();
+    controller.text = widget.text;
     if (widget.autoFocus) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         focusNode.requestFocus();
+        controller.selection = TextSelection.fromPosition(
+            TextPosition(offset: controller.text.length));
       });
     }
     super.initState();


### PR DESCRIPTION
resolves #3158

Also makes the cursor begin at the end of the text in a FlowyTextField if an initial value is provided.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
