### PR TITLE
Fix windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           cat CHANGELOG.md | sed -e '/./{H;$!d;}' -e "x;/##\ Version\ ${{ github.ref_name }}/"'!d;' >> ${{ env.RELEASE_NOTES_PATH }}
 
       - name: Create release
+        if: github.run_number == 1
         id: create_release
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,12 @@ jobs:
 
       - name: Build Windows app
         working-directory: frontend
+        # the cargo make script has to be run separately because of file locking issues
         run: |
           flutter config --enable-windows-desktop
+          dart ./scripts/flutter_release_build/build_flowy.dart exclude-directives . ${{ github.ref_name }}
           cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-windows-x86 appflowy
+          dart ./scripts/flutter_release_build/build_flowy.dart include-directives . ${{ github.ref_name }}
 
       - name: Archive Asset
         uses: vimtor/action-zip@v1
@@ -172,7 +175,7 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-macos-desktop
-          dart ./scripts/flutter_release_build/build_flowy.dart . ${{ github.ref_name }}
+          dart ./scripts/flutter_release_build/build_flowy.dart run . ${{ github.ref_name }}
 
       - name: Create macOS dmg
         run: |
@@ -369,7 +372,7 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-linux-desktop
-          dart ./scripts/flutter_release_build/build_flowy.dart . ${{ github.ref_name }}
+          dart ./scripts/flutter_release_build/build_flowy.dart run . ${{ github.ref_name }}
 
       - name: Archive Assert
         working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}

--- a/frontend/scripts/flutter_release_build/build_flowy.dart
+++ b/frontend/scripts/flutter_release_build/build_flowy.dart
@@ -9,25 +9,52 @@ Future<void> main(List<String> args) async {
   const help = '''
 A build script that modifies build assets before building the release version of AppFlowy.
 
-args[0]: The directory that contains the AppFlowy git repository. Should be the parent to appflowy_flutter. (absolute path)
-args[1]: The appflowy version to be built (github ref_name).
+args[0] (required): The subcommand to use (build, include-directives, exclude-directives, run).
+  - run: calls exclude-directives, build, include-directives.
+  - build: builds the release version of AppFlowy.
+  - include-directives: adds the directives from pubspec.yaml.
+  - exclude-directives: removes the directives from pubspec.yaml.
+
+args[1] (required): The repository root for appflowy (the directory containing pubspec.yaml).
+
+args[2] (required): version (only relevant for build). The version of the app to build.
+
 ''';
-  const numArgs = 2;
+  const numArgs = 3;
   assert(args.length == numArgs,
       'Expected ${numArgs}, got ${args.length}. Read the following for instructions about how to use this script.\n\n$help');
   if (args[0] == '-h' || args[0] == '--help') {
     stdout.write(help);
     stdout.flush();
   }
-  final repositoryRoot = Directory(args[0]);
+
+  // parse the vesrion
+  final version = args[2];
+
+  // parse the first required argument
+  final repositoryRoot = Directory(args[1]);
   assert(await repositoryRoot.exists(),
       '$repositoryRoot is an invalid directory. Please try again with a valid directory.\n\n$help');
-  final appVersion = args[1];
-  String? arch;
-  if (args.length > 2) arch = args[2];
-  await _BuildTool(
-    repositoryRoot: repositoryRoot.path,
-    appVersion: appVersion,
-    arch: arch,
-  ).run();
+
+  // parse the command
+  final command = args[0];
+  final tool =
+      BuildTool(repositoryRoot: repositoryRoot.path, appVersion: version);
+
+  switch (command) {
+    case 'run':
+      await tool.run();
+      break;
+    case 'build':
+      await tool.build();
+      break;
+    case 'include-directives':
+      await tool.directives(ModifyMode.include);
+      break;
+    case 'exclude-directives':
+      await tool.directives(ModifyMode.exclude);
+      break;
+    default:
+      throw StateError('Invalid command: $command');
+  }
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

On Windows, the dart script can't invoke `cargo make` to build the release application because the dart script owns a file that `cargo build` needs. As a result, `cargo build` hangs, which caused the timeout seen here: https://github.com/AppFlowy-IO/AppFlowy/issues/3161

As a fix, allowed calling the two parts of the script that clean the pubspec.yaml to exclude/include test dependencies.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
