### PR TITLE
Feat/user awareness

### DIFF
--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev 
 collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
 appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
 collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
 
 #collab = { path = "../../../../AppFlowy-Collab/collab" }
 #collab-folder = { path = "../../../../AppFlowy-Collab/collab-folder" }
@@ -48,6 +49,7 @@ collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev =
 #collab-database = { path = "../../../../AppFlowy-Collab/collab-database" }
 #appflowy-integrate = { path = "../../../../AppFlowy-Collab/appflowy-integrate" }
 #collab-plugins = { path = "../../../../AppFlowy-Collab/collab-plugins" }
+#collab-user = { path = "../../../../AppFlowy-Collab/collab-user" }
 
 
 

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -34,14 +34,14 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 
 [patch.crates-io]
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-persistence = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-persistence = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
 
 #collab = { path = "../../../../AppFlowy-Collab/collab" }
 #collab-folder = { path = "../../../../AppFlowy-Collab/collab-folder" }

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -96,6 +96,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 [[package]]
 name = "appflowy-integrate"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "collab",
@@ -586,6 +587,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -603,6 +605,7 @@ dependencies = [
 [[package]]
 name = "collab-client-ws"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "bytes",
  "collab-sync",
@@ -620,6 +623,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -646,6 +650,7 @@ dependencies = [
 [[package]]
 name = "collab-derive"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -657,6 +662,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "collab",
@@ -675,6 +681,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -694,6 +701,7 @@ dependencies = [
 [[package]]
 name = "collab-persistence"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "bincode",
  "chrono",
@@ -713,6 +721,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -740,6 +749,7 @@ dependencies = [
 [[package]]
 name = "collab-sync"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "bytes",
  "collab",
@@ -761,6 +771,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=7f26d5#7f26d568b87fb0a14242bfa018f8f1df0d03665c"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -96,7 +96,6 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 [[package]]
 name = "appflowy-integrate"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "collab",
@@ -587,7 +586,6 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "bytes",
@@ -605,7 +603,6 @@ dependencies = [
 [[package]]
 name = "collab-client-ws"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "bytes",
  "collab-sync",
@@ -623,7 +620,6 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -650,7 +646,6 @@ dependencies = [
 [[package]]
 name = "collab-derive"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -662,7 +657,6 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "collab",
@@ -681,7 +675,6 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "chrono",
@@ -701,7 +694,6 @@ dependencies = [
 [[package]]
 name = "collab-persistence"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "bincode",
  "chrono",
@@ -721,7 +713,6 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -749,7 +740,6 @@ dependencies = [
 [[package]]
 name = "collab-sync"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=3881ba#3881bab021229020837ae65df604b9b87d0e8497"
 dependencies = [
  "bytes",
  "collab",
@@ -766,6 +756,20 @@ dependencies = [
  "tracing",
  "y-sync",
  "yrs",
+]
+
+[[package]]
+name = "collab-user"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "collab",
+ "parking_lot 0.12.1",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -1667,6 +1671,7 @@ dependencies = [
  "collab",
  "collab-document",
  "collab-folder",
+ "collab-user",
  "diesel",
  "diesel_derives",
  "fake",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -38,19 +38,19 @@ opt-level = 3
 incremental = false
 
 [patch.crates-io]
-#collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-#collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "7f26d5" }
 
-collab = { path = "../AppFlowy-Collab/collab" }
-collab-folder = { path = "../AppFlowy-Collab/collab-folder" }
-collab-database= { path = "../AppFlowy-Collab/collab-database" }
-collab-document = { path = "../AppFlowy-Collab/collab-document" }
-collab-plugins = { path = "../AppFlowy-Collab/collab-plugins" }
-appflowy-integrate = { path = "../AppFlowy-Collab/appflowy-integrate" }
-collab-user = { path = "../AppFlowy-Collab/collab-user" }
+#collab = { path = "../AppFlowy-Collab/collab" }
+#collab-folder = { path = "../AppFlowy-Collab/collab-folder" }
+#collab-database= { path = "../AppFlowy-Collab/collab-database" }
+#collab-document = { path = "../AppFlowy-Collab/collab-document" }
+#collab-plugins = { path = "../AppFlowy-Collab/collab-plugins" }
+#appflowy-integrate = { path = "../AppFlowy-Collab/appflowy-integrate" }
+#collab-user = { path = "../AppFlowy-Collab/collab-user" }
 

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -38,17 +38,19 @@ opt-level = 3
 incremental = false
 
 [patch.crates-io]
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#appflowy-integrate = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
+#collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "3881ba" }
 
-#collab = { path = "../AppFlowy-Collab/collab" }
-#collab-folder = { path = "../AppFlowy-Collab/collab-folder" }
-#collab-database= { path = "../AppFlowy-Collab/collab-database" }
-#collab-document = { path = "../AppFlowy-Collab/collab-document" }
-#collab-plugins = { path = "../AppFlowy-Collab/collab-plugins" }
-#appflowy-integrate = { path = "../AppFlowy-Collab/appflowy-integrate" }
+collab = { path = "../AppFlowy-Collab/collab" }
+collab-folder = { path = "../AppFlowy-Collab/collab-folder" }
+collab-database= { path = "../AppFlowy-Collab/collab-database" }
+collab-document = { path = "../AppFlowy-Collab/collab-document" }
+collab-plugins = { path = "../AppFlowy-Collab/collab-plugins" }
+appflowy-integrate = { path = "../AppFlowy-Collab/appflowy-integrate" }
+collab-user = { path = "../AppFlowy-Collab/collab-user" }
 

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/collab_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/collab_deps.rs
@@ -11,7 +11,7 @@ use flowy_sqlite::{
   prelude::*,
   schema::{collab_snapshot, collab_snapshot::dsl},
 };
-use flowy_user::services::UserManager;
+use flowy_user::manager::UserManager;
 use lib_infra::util::timestamp;
 
 pub struct SnapshotDBImpl(pub Weak<UserManager>);

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/collab_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/collab_deps.rs
@@ -11,10 +11,10 @@ use flowy_sqlite::{
   prelude::*,
   schema::{collab_snapshot, collab_snapshot::dsl},
 };
-use flowy_user::services::UserSession;
+use flowy_user::services::UserManager;
 use lib_infra::util::timestamp;
 
-pub struct SnapshotDBImpl(pub Weak<UserSession>);
+pub struct SnapshotDBImpl(pub Weak<UserManager>);
 
 impl SnapshotPersistence for SnapshotDBImpl {
   fn get_snapshots(&self, uid: i64, object_id: &str) -> Vec<CollabSnapshot> {

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/database_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/database_deps.rs
@@ -8,13 +8,13 @@ use flowy_database2::{DatabaseManager, DatabaseUser};
 use flowy_database_deps::cloud::DatabaseCloudService;
 use flowy_error::FlowyError;
 use flowy_task::TaskDispatcher;
-use flowy_user::services::UserSession;
+use flowy_user::services::UserManager;
 
 pub struct DatabaseDepsResolver();
 
 impl DatabaseDepsResolver {
   pub async fn resolve(
-    user_session: Weak<UserSession>,
+    user_session: Weak<UserManager>,
     task_scheduler: Arc<RwLock<TaskDispatcher>>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
     cloud_service: Arc<dyn DatabaseCloudService>,
@@ -29,7 +29,7 @@ impl DatabaseDepsResolver {
   }
 }
 
-struct DatabaseUserImpl(Weak<UserSession>);
+struct DatabaseUserImpl(Weak<UserManager>);
 impl DatabaseUser for DatabaseUserImpl {
   fn user_id(&self) -> Result<i64, FlowyError> {
     self

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/database_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/database_deps.rs
@@ -8,18 +8,18 @@ use flowy_database2::{DatabaseManager, DatabaseUser};
 use flowy_database_deps::cloud::DatabaseCloudService;
 use flowy_error::FlowyError;
 use flowy_task::TaskDispatcher;
-use flowy_user::services::UserManager;
+use flowy_user::manager::UserManager;
 
 pub struct DatabaseDepsResolver();
 
 impl DatabaseDepsResolver {
   pub async fn resolve(
-    user_session: Weak<UserManager>,
+    user_manager: Weak<UserManager>,
     task_scheduler: Arc<RwLock<TaskDispatcher>>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
     cloud_service: Arc<dyn DatabaseCloudService>,
   ) -> Arc<DatabaseManager> {
-    let user = Arc::new(DatabaseUserImpl(user_session));
+    let user = Arc::new(DatabaseUserImpl(user_manager));
     Arc::new(DatabaseManager::new(
       user,
       task_scheduler,

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/document_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/document_deps.rs
@@ -7,17 +7,17 @@ use flowy_database2::DatabaseManager;
 use flowy_document2::manager::{DocumentManager, DocumentUser};
 use flowy_document_deps::cloud::DocumentCloudService;
 use flowy_error::FlowyError;
-use flowy_user::services::UserManager;
+use flowy_user::manager::UserManager;
 
 pub struct DocumentDepsResolver();
 impl DocumentDepsResolver {
   pub fn resolve(
-    user_session: Weak<UserManager>,
+    user_manager: Weak<UserManager>,
     _database_manager: &Arc<DatabaseManager>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
     cloud_service: Arc<dyn DocumentCloudService>,
   ) -> Arc<DocumentManager> {
-    let user: Arc<dyn DocumentUser> = Arc::new(DocumentUserImpl(user_session));
+    let user: Arc<dyn DocumentUser> = Arc::new(DocumentUserImpl(user_manager));
     Arc::new(DocumentManager::new(
       user.clone(),
       collab_builder,

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/document_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/document_deps.rs
@@ -7,12 +7,12 @@ use flowy_database2::DatabaseManager;
 use flowy_document2::manager::{DocumentManager, DocumentUser};
 use flowy_document_deps::cloud::DocumentCloudService;
 use flowy_error::FlowyError;
-use flowy_user::services::UserSession;
+use flowy_user::services::UserManager;
 
 pub struct DocumentDepsResolver();
 impl DocumentDepsResolver {
   pub fn resolve(
-    user_session: Weak<UserSession>,
+    user_session: Weak<UserManager>,
     _database_manager: &Arc<DatabaseManager>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
     cloud_service: Arc<dyn DocumentCloudService>,
@@ -26,7 +26,7 @@ impl DocumentDepsResolver {
   }
 }
 
-struct DocumentUserImpl(Weak<UserSession>);
+struct DocumentUserImpl(Weak<UserManager>);
 impl DocumentUser for DocumentUserImpl {
   fn user_id(&self) -> Result<i64, FlowyError> {
     self

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/folder_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/folder_deps.rs
@@ -23,14 +23,14 @@ use flowy_folder2::view_operation::{
 };
 use flowy_folder2::ViewLayout;
 use flowy_folder_deps::cloud::FolderCloudService;
-use flowy_user::services::UserSession;
+use flowy_user::services::UserManager;
 use lib_dispatch::prelude::ToBytes;
 use lib_infra::future::FutureResult;
 
 pub struct FolderDepsResolver();
 impl FolderDepsResolver {
   pub async fn resolve(
-    user_session: Weak<UserSession>,
+    user_session: Weak<UserManager>,
     document_manager: &Arc<DocumentManager>,
     database_manager: &Arc<DatabaseManager>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
@@ -63,7 +63,7 @@ fn folder_operation_handlers(
   Arc::new(map)
 }
 
-struct FolderUserImpl(Weak<UserSession>);
+struct FolderUserImpl(Weak<UserManager>);
 impl FolderUser for FolderUserImpl {
   fn user_id(&self) -> Result<i64, FlowyError> {
     self

--- a/frontend/rust-lib/flowy-core/src/deps_resolve/folder_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/folder_deps.rs
@@ -23,20 +23,20 @@ use flowy_folder2::view_operation::{
 };
 use flowy_folder2::ViewLayout;
 use flowy_folder_deps::cloud::FolderCloudService;
-use flowy_user::services::UserManager;
+use flowy_user::manager::UserManager;
 use lib_dispatch::prelude::ToBytes;
 use lib_infra::future::FutureResult;
 
 pub struct FolderDepsResolver();
 impl FolderDepsResolver {
   pub async fn resolve(
-    user_session: Weak<UserManager>,
+    user_manager: Weak<UserManager>,
     document_manager: &Arc<DocumentManager>,
     database_manager: &Arc<DatabaseManager>,
     collab_builder: Arc<AppFlowyCollabBuilder>,
     folder_cloud: Arc<dyn FolderCloudService>,
   ) -> Arc<FolderManager> {
-    let user: Arc<dyn FolderUser> = Arc::new(FolderUserImpl(user_session.clone()));
+    let user: Arc<dyn FolderUser> = Arc::new(FolderUserImpl(user_manager.clone()));
 
     let handlers = folder_operation_handlers(document_manager.clone(), database_manager.clone());
     Arc::new(

--- a/frontend/rust-lib/flowy-core/src/integrate/server.rs
+++ b/frontend/rust-lib/flowy-core/src/integrate/server.rs
@@ -152,7 +152,7 @@ impl AppFlowyServerProvider {
 }
 
 impl UserCloudServiceProvider for AppFlowyServerProvider {
-  fn update_supabase_config(&self, supabase_config: &SupabaseConfiguration) {
+  fn set_supabase_config(&self, supabase_config: &SupabaseConfiguration) {
     self
       .supabase_config
       .write()
@@ -185,6 +185,10 @@ impl UserCloudServiceProvider for AppFlowyServerProvider {
         }
       },
     }
+  }
+
+  fn set_device_id(&self, device_id: &str) {
+    *self.device_id.lock() = device_id.to_string();
   }
 
   /// Returns the [UserService] base on the current [ServerProviderType].

--- a/frontend/rust-lib/flowy-core/src/lib.rs
+++ b/frontend/rust-lib/flowy-core/src/lib.rs
@@ -293,7 +293,7 @@ impl UserStatusCallback for UserStatusCallbackImpl {
     &self,
     user_id: i64,
     user_workspace: &UserWorkspace,
-    device_id: &str,
+    _device_id: &str,
   ) -> Fut<FlowyResult<()>> {
     let user_id = user_id.to_owned();
     let user_workspace = user_workspace.clone();
@@ -325,7 +325,7 @@ impl UserStatusCallback for UserStatusCallbackImpl {
     &self,
     user_id: i64,
     user_workspace: &UserWorkspace,
-    device_id: &str,
+    _device_id: &str,
   ) -> Fut<FlowyResult<()>> {
     let user_id = user_id.to_owned();
     let user_workspace = user_workspace.clone();
@@ -356,7 +356,7 @@ impl UserStatusCallback for UserStatusCallbackImpl {
     context: SignUpContext,
     user_profile: &UserProfile,
     user_workspace: &UserWorkspace,
-    device_id: &str,
+    _device_id: &str,
   ) -> Fut<FlowyResult<()>> {
     let user_profile = user_profile.clone();
     let folder_manager = self.folder_manager.clone();

--- a/frontend/rust-lib/flowy-core/src/lib.rs
+++ b/frontend/rust-lib/flowy-core/src/lib.rs
@@ -20,7 +20,7 @@ use flowy_folder2::manager::{FolderInitializeData, FolderManager};
 use flowy_sqlite::kv::StorePreferences;
 use flowy_task::{TaskDispatcher, TaskRunner};
 use flowy_user::event_map::{SignUpContext, UserCloudServiceProvider, UserStatusCallback};
-use flowy_user::services::{get_supabase_config, UserSession, UserSessionConfig};
+use flowy_user::services::{get_supabase_config, UserManager, UserSessionConfig};
 use flowy_user_deps::entities::{AuthType, UserProfile, UserWorkspace};
 use lib_dispatch::prelude::*;
 use lib_dispatch::runtime::tokio_default_runtime;
@@ -114,7 +114,7 @@ fn create_log_filter(level: String, with_crates: Vec<String>) -> String {
 pub struct AppFlowyCore {
   #[allow(dead_code)]
   pub config: AppFlowyCoreConfig,
-  pub user_session: Arc<UserSession>,
+  pub user_session: Arc<UserManager>,
   pub document_manager: Arc<DocumentManager>,
   pub folder_manager: Arc<FolderManager>,
   pub database_manager: Arc<DatabaseManager>,
@@ -260,9 +260,9 @@ fn mk_user_session(
   config: &AppFlowyCoreConfig,
   storage_preference: &Arc<StorePreferences>,
   user_cloud_service_provider: Arc<dyn UserCloudServiceProvider>,
-) -> Arc<UserSession> {
+) -> Arc<UserManager> {
   let user_config = UserSessionConfig::new(&config.name, &config.storage_path);
-  Arc::new(UserSession::new(
+  Arc::new(UserManager::new(
     user_config,
     user_cloud_service_provider,
     storage_preference.clone(),

--- a/frontend/rust-lib/flowy-core/src/module.rs
+++ b/frontend/rust-lib/flowy-core/src/module.rs
@@ -3,13 +3,13 @@ use std::sync::Weak;
 use flowy_database2::DatabaseManager;
 use flowy_document2::manager::DocumentManager as DocumentManager2;
 use flowy_folder2::manager::FolderManager;
-use flowy_user::services::UserSession;
+use flowy_user::services::UserManager;
 use lib_dispatch::prelude::AFPlugin;
 
 pub fn make_plugins(
   folder_manager: Weak<FolderManager>,
   database_manager: Weak<DatabaseManager>,
-  user_session: Weak<UserSession>,
+  user_session: Weak<UserManager>,
   document_manager2: Weak<DocumentManager2>,
 ) -> Vec<AFPlugin> {
   let store_preferences = user_session

--- a/frontend/rust-lib/flowy-core/src/module.rs
+++ b/frontend/rust-lib/flowy-core/src/module.rs
@@ -3,7 +3,7 @@ use std::sync::Weak;
 use flowy_database2::DatabaseManager;
 use flowy_document2::manager::DocumentManager as DocumentManager2;
 use flowy_folder2::manager::FolderManager;
-use flowy_user::services::UserManager;
+use flowy_user::manager::UserManager;
 use lib_dispatch::prelude::AFPlugin;
 
 pub fn make_plugins(

--- a/frontend/rust-lib/flowy-document2/tests/document/util.rs
+++ b/frontend/rust-lib/flowy-document2/tests/document/util.rs
@@ -81,7 +81,7 @@ pub fn db() -> Arc<RocksCollabDB> {
 }
 
 pub fn default_collab_builder() -> Arc<AppFlowyCollabBuilder> {
-  let builder = AppFlowyCollabBuilder::new(DefaultCollabStorageProvider(), None);
+  let builder = AppFlowyCollabBuilder::new(DefaultCollabStorageProvider());
   builder.set_sync_device(uuid::Uuid::new_v4().to_string());
   Arc::new(builder)
 }

--- a/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
+++ b/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
@@ -110,6 +110,10 @@ impl UserService for LocalServerUserAuthServiceImpl {
   ) -> FutureResult<(), Error> {
     FutureResult::new(async { Ok(()) })
   }
+
+  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+    FutureResult::new(async { Ok(vec![]) })
+  }
 }
 
 fn make_user_workspace() -> UserWorkspace {

--- a/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
+++ b/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
@@ -111,7 +111,7 @@ impl UserService for LocalServerUserAuthServiceImpl {
     FutureResult::new(async { Ok(()) })
   }
 
-  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+  fn get_user_awareness_updates(&self, _uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
     FutureResult::new(async { Ok(vec![]) })
   }
 }

--- a/frontend/rust-lib/flowy-server/src/self_host/impls/user.rs
+++ b/frontend/rust-lib/flowy-server/src/self_host/impls/user.rs
@@ -123,7 +123,7 @@ impl UserService for SelfHostedUserAuthServiceImpl {
     FutureResult::new(async { Ok(()) })
   }
 
-  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+  fn get_user_awareness_updates(&self, _uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
     // TODO(nathan): implement the RESTful API for this
     FutureResult::new(async { Ok(vec![]) })
   }

--- a/frontend/rust-lib/flowy-server/src/self_host/impls/user.rs
+++ b/frontend/rust-lib/flowy-server/src/self_host/impls/user.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+
 use flowy_error::{ErrorCode, FlowyError};
 use flowy_user_deps::cloud::UserService;
 use flowy_user_deps::entities::*;
@@ -120,6 +121,11 @@ impl UserService for SelfHostedUserAuthServiceImpl {
   ) -> FutureResult<(), Error> {
     // TODO(nathan): implement the RESTful API for this
     FutureResult::new(async { Ok(()) })
+  }
+
+  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+    // TODO(nathan): implement the RESTful API for this
+    FutureResult::new(async { Ok(vec![]) })
   }
 }
 

--- a/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
@@ -202,7 +202,7 @@ where
     todo!()
   }
 
-  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+  fn get_user_awareness_updates(&self, _uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
     FutureResult::new(async { Ok(vec![]) })
   }
 }

--- a/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
@@ -17,17 +17,17 @@ use crate::supabase::entities::GetUserProfileParams;
 use crate::supabase::entities::UidResponse;
 use crate::supabase::entities::UserProfileResponse;
 
-pub struct RESTfulSupabaseUserAuthServiceImpl<T> {
+pub struct RESTfulSupabaseUserServiceImpl<T> {
   server: T,
 }
 
-impl<T> RESTfulSupabaseUserAuthServiceImpl<T> {
+impl<T> RESTfulSupabaseUserServiceImpl<T> {
   pub fn new(server: T) -> Self {
     Self { server }
   }
 }
 
-impl<T> UserService for RESTfulSupabaseUserAuthServiceImpl<T>
+impl<T> UserService for RESTfulSupabaseUserServiceImpl<T>
 where
   T: SupabaseServerService,
 {
@@ -200,6 +200,10 @@ where
     _workspace_id: String,
   ) -> FutureResult<(), Error> {
     todo!()
+  }
+
+  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+    FutureResult::new(async { Ok(vec![]) })
   }
 }
 

--- a/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Error;
+use tokio::sync::oneshot::channel;
 use uuid::Uuid;
 
 use flowy_user_deps::cloud::*;
@@ -10,6 +11,7 @@ use flowy_user_deps::DEFAULT_USER_NAME;
 use lib_infra::box_any::BoxAny;
 use lib_infra::future::FutureResult;
 
+use crate::supabase::api::request::FetchObjectUpdateAction;
 use crate::supabase::api::util::{ExtendedResponse, InsertParamsBuilder};
 use crate::supabase::api::{PostgresWrapper, SupabaseServerService};
 use crate::supabase::define::*;
@@ -17,17 +19,17 @@ use crate::supabase::entities::GetUserProfileParams;
 use crate::supabase::entities::UidResponse;
 use crate::supabase::entities::UserProfileResponse;
 
-pub struct RESTfulSupabaseUserServiceImpl<T> {
+pub struct SupabaseUserServiceImpl<T> {
   server: T,
 }
 
-impl<T> RESTfulSupabaseUserServiceImpl<T> {
+impl<T> SupabaseUserServiceImpl<T> {
   pub fn new(server: T) -> Self {
     Self { server }
   }
 }
 
-impl<T> UserService for RESTfulSupabaseUserServiceImpl<T>
+impl<T> UserService for SupabaseUserServiceImpl<T>
 where
   T: SupabaseServerService,
 {
@@ -202,8 +204,22 @@ where
     todo!()
   }
 
-  fn get_user_awareness_updates(&self, _uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
-    FutureResult::new(async { Ok(vec![]) })
+  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error> {
+    let try_get_postgrest = self.server.try_get_weak_postgrest();
+    let awareness_id = uid.to_string();
+    let (tx, rx) = channel();
+    tokio::spawn(async move {
+      tx.send(
+        async move {
+          let postgrest = try_get_postgrest?;
+          let action =
+            FetchObjectUpdateAction::new(awareness_id, CollabType::UserAwareness, postgrest);
+          action.run_with_fix_interval(5, 10).await
+        }
+        .await,
+      )
+    });
+    FutureResult::new(async { rx.await? })
   }
 }
 

--- a/frontend/rust-lib/flowy-server/src/supabase/define.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/define.rs
@@ -28,6 +28,7 @@ pub fn table_name(ty: &CollabType) -> String {
     CollabType::Database => format!("{}_database", AF_COLLAB_UPDATE_TABLE),
     CollabType::WorkspaceDatabase => format!("{}_w_database", AF_COLLAB_UPDATE_TABLE),
     CollabType::Folder => format!("{}_folder", AF_COLLAB_UPDATE_TABLE),
+    CollabType::UserAwareness => format!("{}_user_awareness", AF_COLLAB_UPDATE_TABLE),
   }
 }
 

--- a/frontend/rust-lib/flowy-server/src/supabase/server.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/server.rs
@@ -12,9 +12,9 @@ use flowy_server_config::supabase_config::SupabaseConfiguration;
 use flowy_user_deps::cloud::UserService;
 
 use crate::supabase::api::{
-  RESTfulPostgresServer, RESTfulSupabaseUserServiceImpl, SupabaseCollabStorageImpl,
-  SupabaseDatabaseServiceImpl, SupabaseDocumentServiceImpl, SupabaseFolderServiceImpl,
-  SupabaseServerServiceImpl,
+  RESTfulPostgresServer, SupabaseCollabStorageImpl, SupabaseDatabaseServiceImpl,
+  SupabaseDocumentServiceImpl, SupabaseFolderServiceImpl, SupabaseServerServiceImpl,
+  SupabaseUserServiceImpl,
 };
 use crate::supabase::entities::RealtimeCollabUpdateEvent;
 use crate::AppFlowyServer;
@@ -102,9 +102,9 @@ impl AppFlowyServer for SupabaseServer {
   }
 
   fn user_service(&self) -> Arc<dyn UserService> {
-    Arc::new(RESTfulSupabaseUserServiceImpl::new(
-      SupabaseServerServiceImpl(self.restful_postgres.clone()),
-    ))
+    Arc::new(SupabaseUserServiceImpl::new(SupabaseServerServiceImpl(
+      self.restful_postgres.clone(),
+    )))
   }
 
   fn folder_service(&self) -> Arc<dyn FolderCloudService> {

--- a/frontend/rust-lib/flowy-server/src/supabase/server.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/server.rs
@@ -12,7 +12,7 @@ use flowy_server_config::supabase_config::SupabaseConfiguration;
 use flowy_user_deps::cloud::UserService;
 
 use crate::supabase::api::{
-  RESTfulPostgresServer, RESTfulSupabaseUserAuthServiceImpl, SupabaseCollabStorageImpl,
+  RESTfulPostgresServer, RESTfulSupabaseUserServiceImpl, SupabaseCollabStorageImpl,
   SupabaseDatabaseServiceImpl, SupabaseDocumentServiceImpl, SupabaseFolderServiceImpl,
   SupabaseServerServiceImpl,
 };
@@ -102,7 +102,7 @@ impl AppFlowyServer for SupabaseServer {
   }
 
   fn user_service(&self) -> Arc<dyn UserService> {
-    Arc::new(RESTfulSupabaseUserAuthServiceImpl::new(
+    Arc::new(RESTfulSupabaseUserServiceImpl::new(
       SupabaseServerServiceImpl(self.restful_postgres.clone()),
     ))
   }

--- a/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
+++ b/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 use flowy_database_deps::cloud::DatabaseCloudService;
 use flowy_folder_deps::cloud::FolderCloudService;
 use flowy_server::supabase::api::{
-  RESTfulPostgresServer, RESTfulSupabaseUserServiceImpl, SupabaseCollabStorageImpl,
-  SupabaseDatabaseServiceImpl, SupabaseFolderServiceImpl, SupabaseServerServiceImpl,
+  RESTfulPostgresServer, SupabaseCollabStorageImpl, SupabaseDatabaseServiceImpl,
+  SupabaseFolderServiceImpl, SupabaseServerServiceImpl, SupabaseUserServiceImpl,
 };
 use flowy_server::supabase::define::{USER_EMAIL, USER_UUID};
 use flowy_server_config::supabase_config::SupabaseConfiguration;
@@ -42,7 +42,7 @@ pub fn database_service() -> Arc<dyn DatabaseCloudService> {
 pub fn user_auth_service() -> Arc<dyn UserService> {
   let config = SupabaseConfiguration::from_env().unwrap();
   let server = Arc::new(RESTfulPostgresServer::new(config));
-  Arc::new(RESTfulSupabaseUserServiceImpl::new(
+  Arc::new(SupabaseUserServiceImpl::new(
     SupabaseServerServiceImpl::new(server),
   ))
 }

--- a/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
+++ b/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use flowy_database_deps::cloud::DatabaseCloudService;
 use flowy_folder_deps::cloud::FolderCloudService;
 use flowy_server::supabase::api::{
-  RESTfulPostgresServer, RESTfulSupabaseUserAuthServiceImpl, SupabaseCollabStorageImpl,
+  RESTfulPostgresServer, RESTfulSupabaseUserServiceImpl, SupabaseCollabStorageImpl,
   SupabaseDatabaseServiceImpl, SupabaseFolderServiceImpl, SupabaseServerServiceImpl,
 };
 use flowy_server::supabase::define::{USER_EMAIL, USER_UUID};
@@ -42,7 +42,7 @@ pub fn database_service() -> Arc<dyn DatabaseCloudService> {
 pub fn user_auth_service() -> Arc<dyn UserService> {
   let config = SupabaseConfiguration::from_env().unwrap();
   let server = Arc::new(RESTfulPostgresServer::new(config));
-  Arc::new(RESTfulSupabaseUserAuthServiceImpl::new(
+  Arc::new(RESTfulSupabaseUserServiceImpl::new(
     SupabaseServerServiceImpl::new(server),
   ))
 }

--- a/frontend/rust-lib/flowy-test/tests/folder/supabase_test/helper.rs
+++ b/frontend/rust-lib/flowy-test/tests/folder/supabase_test/helper.rs
@@ -44,7 +44,7 @@ impl FlowySupabaseFolderTest {
   pub async fn get_collab_update(&self, workspace_id: &str) -> Vec<u8> {
     let cloud_service = self.folder_manager.get_cloud_service().clone();
     let remote_updates = cloud_service
-      .get_folder_updates(workspace_id, self.user_session.user_id().unwrap())
+      .get_folder_updates(workspace_id, self.user_manager.user_id().unwrap())
       .await
       .unwrap();
 

--- a/frontend/rust-lib/flowy-test/tests/user/local_test/mod.rs
+++ b/frontend/rust-lib/flowy-test/tests/user/local_test/mod.rs
@@ -1,3 +1,4 @@
 mod auth_test;
 mod helper;
+mod user_awareness_test;
 mod user_profile_test;

--- a/frontend/rust-lib/flowy-test/tests/user/local_test/user_awareness_test.rs
+++ b/frontend/rust-lib/flowy-test/tests/user/local_test/user_awareness_test.rs
@@ -1,0 +1,33 @@
+use flowy_test::event_builder::EventBuilder;
+use flowy_test::FlowyCoreTest;
+use flowy_user::entities::{ReminderPB, RepeatedReminderPB};
+use flowy_user::event_map::UserEvent::*;
+
+#[tokio::test]
+async fn user_update_with_name() {
+  let sdk = FlowyCoreTest::new();
+  let _ = sdk.sign_up_as_guest().await;
+  let payload = ReminderPB {
+    id: "".to_string(),
+    scheduled_at: 0,
+    is_ack: false,
+    ty: 0,
+    title: "".to_string(),
+    message: "".to_string(),
+    reminder_object_id: "".to_string(),
+  };
+  let _ = EventBuilder::new(sdk.clone())
+    .event(CreateReminder)
+    .payload(payload)
+    .async_send()
+    .await;
+
+  let reminders = EventBuilder::new(sdk.clone())
+    .event(GetAllReminders)
+    .async_send()
+    .await
+    .parse::<RepeatedReminderPB>()
+    .items;
+
+  assert_eq!(reminders.len(), 1);
+}

--- a/frontend/rust-lib/flowy-user-deps/src/cloud.rs
+++ b/frontend/rust-lib/flowy-user-deps/src/cloud.rs
@@ -58,6 +58,8 @@ pub trait UserService: Send + Sync {
     user_email: String,
     workspace_id: String,
   ) -> FutureResult<(), Error>;
+
+  fn get_user_awareness_updates(&self, uid: i64) -> FutureResult<Vec<Vec<u8>>, Error>;
 }
 
 pub fn third_party_params_from_box_any(any: BoxAny) -> Result<ThirdPartyParams, Error> {

--- a/frontend/rust-lib/flowy-user/Cargo.toml
+++ b/frontend/rust-lib/flowy-user/Cargo.toml
@@ -17,6 +17,7 @@ appflowy-integrate = { version = "0.1.0" }
 collab = { version = "0.1.0" }
 collab-folder = { version = "0.1.0" }
 collab-document = { version = "0.1.0" }
+collab-user = { version = "0.1.0" }
 flowy-user-deps = { path = "../flowy-user-deps" }
 
 tracing = { version = "0.1", features = ["log"] }

--- a/frontend/rust-lib/flowy-user/src/entities/mod.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/mod.rs
@@ -1,10 +1,12 @@
 pub use auth::*;
 pub use realtime::*;
+pub use reminder::*;
 pub use user_profile::*;
 pub use user_setting::*;
 
 pub mod auth;
 pub mod parser;
 pub mod realtime;
+mod reminder;
 mod user_profile;
 mod user_setting;

--- a/frontend/rust-lib/flowy-user/src/entities/reminder.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/reminder.rs
@@ -1,0 +1,67 @@
+use collab_user::core::Reminder;
+
+use flowy_derive::ProtoBuf;
+
+#[derive(ProtoBuf, Default, Clone)]
+pub struct ReminderPB {
+  #[pb(index = 1)]
+  pub id: String,
+
+  #[pb(index = 2)]
+  pub scheduled_at: i64,
+
+  #[pb(index = 3)]
+  pub is_ack: bool,
+
+  #[pb(index = 4)]
+  pub ty: i64,
+
+  #[pb(index = 5)]
+  pub title: String,
+
+  #[pb(index = 6)]
+  pub message: String,
+
+  #[pb(index = 7)]
+  pub reminder_object_id: String,
+}
+
+#[derive(ProtoBuf, Default, Clone)]
+pub struct RepeatedReminderPB {
+  #[pb(index = 1)]
+  pub items: Vec<ReminderPB>,
+}
+
+impl From<ReminderPB> for Reminder {
+  fn from(value: ReminderPB) -> Self {
+    Self {
+      id: value.id,
+      scheduled_at: value.scheduled_at,
+      is_ack: value.is_ack,
+      ty: value.ty,
+      title: value.title,
+      message: value.message,
+      reminder_object_id: value.reminder_object_id,
+    }
+  }
+}
+
+impl From<Reminder> for ReminderPB {
+  fn from(value: Reminder) -> Self {
+    Self {
+      id: value.id,
+      scheduled_at: value.scheduled_at,
+      is_ack: value.is_ack,
+      ty: value.ty,
+      title: value.title,
+      message: value.message,
+      reminder_object_id: value.reminder_object_id,
+    }
+  }
+}
+
+impl From<Vec<ReminderPB>> for RepeatedReminderPB {
+  fn from(value: Vec<ReminderPB>) -> Self {
+    Self { items: value }
+  }
+}

--- a/frontend/rust-lib/flowy-user/src/entities/user_profile.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/user_profile.rs
@@ -6,7 +6,7 @@ use flowy_user_deps::entities::*;
 use crate::entities::parser::{UserEmail, UserIcon, UserName, UserOpenaiKey, UserPassword};
 use crate::entities::AuthTypePB;
 use crate::errors::ErrorCode;
-use crate::services::HistoricalUser;
+use crate::services::entities::HistoricalUser;
 
 #[derive(Default, ProtoBuf)]
 pub struct UserTokenPB {

--- a/frontend/rust-lib/flowy-user/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-user/src/event_handler.rs
@@ -316,13 +316,11 @@ pub async fn get_all_reminder_event_handler(
   manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<RepeatedReminderPB, FlowyError> {
   let manager = upgrade_manager(manager)?;
-  data_result_ok(
-    manager
-      .get_all_reminders()
-      .await
-      .into_iter()
-      .map(ReminderPB::from)
-      .collect::<Vec<_>>()
-      .into(),
-  )
+  let reminders = manager
+    .get_all_reminders()
+    .await
+    .into_iter()
+    .map(ReminderPB::from)
+    .collect::<Vec<_>>();
+  data_result_ok(reminders.into())
 }

--- a/frontend/rust-lib/flowy-user/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-user/src/event_handler.rs
@@ -12,13 +12,13 @@ use lib_dispatch::prelude::*;
 use lib_infra::box_any::BoxAny;
 
 use crate::entities::*;
-use crate::services::{get_supabase_config, UserSession};
+use crate::services::{get_supabase_config, UserManager};
 
-fn upgrade_session(session: AFPluginState<Weak<UserSession>>) -> FlowyResult<Arc<UserSession>> {
-  let session = session
+fn upgrade_manager(manager: AFPluginState<Weak<UserManager>>) -> FlowyResult<Arc<UserManager>> {
+  let manager = manager
     .upgrade()
     .ok_or(FlowyError::internal().context("The user session is already drop"))?;
-  Ok(session)
+  Ok(manager)
 }
 
 fn upgrade_store_preferences(
@@ -30,17 +30,17 @@ fn upgrade_store_preferences(
   Ok(store)
 }
 
-#[tracing::instrument(level = "debug", name = "sign_in", skip(data, session), fields(email = %data.email), err)]
+#[tracing::instrument(level = "debug", name = "sign_in", skip(data, manager), fields(email = %data.email), err)]
 pub async fn sign_in(
   data: AFPluginData<SignInPayloadPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<UserProfilePB, FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params: SignInParams = data.into_inner().try_into()?;
   let auth_type = params.auth_type.clone();
-  session.update_auth_type(&auth_type).await;
+  manager.update_auth_type(&auth_type).await;
 
-  let user_profile: UserProfilePB = session
+  let user_profile: UserProfilePB = manager
     .sign_in(BoxAny::new(params), auth_type)
     .await?
     .into();
@@ -50,7 +50,7 @@ pub async fn sign_in(
 #[tracing::instrument(
     level = "debug",
     name = "sign_up",
-    skip(data, session),
+    skip(data, manager),
     fields(
         email = %data.email,
         name = %data.name,
@@ -59,60 +59,60 @@ pub async fn sign_in(
 )]
 pub async fn sign_up(
   data: AFPluginData<SignUpPayloadPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<UserProfilePB, FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params: SignUpParams = data.into_inner().try_into()?;
   let auth_type = params.auth_type.clone();
-  session.update_auth_type(&auth_type).await;
+  manager.update_auth_type(&auth_type).await;
 
-  let user_profile = session.sign_up(auth_type, BoxAny::new(params)).await?;
+  let user_profile = manager.sign_up(auth_type, BoxAny::new(params)).await?;
   data_result_ok(user_profile.into())
 }
 
-#[tracing::instrument(level = "debug", skip(session))]
+#[tracing::instrument(level = "debug", skip(manager))]
 pub async fn init_user_handler(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
-  session.init_user().await?;
+  let manager = upgrade_manager(manager)?;
+  manager.init_user().await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(session))]
+#[tracing::instrument(level = "debug", skip(manager))]
 pub async fn check_user_handler(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
-  session.check_user().await?;
+  let manager = upgrade_manager(manager)?;
+  manager.check_user().await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(session))]
+#[tracing::instrument(level = "debug", skip(manager))]
 pub async fn get_user_profile_handler(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<UserProfilePB, FlowyError> {
-  let session = upgrade_session(session)?;
-  let uid = session.get_session()?.user_id;
-  let user_profile: UserProfilePB = session.get_user_profile(uid, true).await?.into();
+  let manager = upgrade_manager(manager)?;
+  let uid = manager.get_session()?.user_id;
+  let user_profile: UserProfilePB = manager.get_user_profile(uid, true).await?.into();
   data_result_ok(user_profile)
 }
 
-#[tracing::instrument(level = "debug", skip(session))]
-pub async fn sign_out(session: AFPluginState<Weak<UserSession>>) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
-  session.sign_out().await?;
+#[tracing::instrument(level = "debug", skip(manager))]
+pub async fn sign_out(manager: AFPluginState<Weak<UserManager>>) -> Result<(), FlowyError> {
+  let manager = upgrade_manager(manager)?;
+  manager.sign_out().await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session))]
+#[tracing::instrument(level = "debug", skip(data, manager))]
 pub async fn update_user_profile_handler(
   data: AFPluginData<UpdateUserProfilePayloadPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params: UpdateUserProfileParams = data.into_inner().try_into()?;
-  session.update_user_profile(params).await?;
+  manager.update_user_profile(params).await?;
   Ok(())
 }
 
@@ -158,104 +158,103 @@ pub async fn get_appearance_setting(
 
 #[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn get_user_setting(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<UserSettingPB, FlowyError> {
-  let session = upgrade_session(session)?;
-  let user_setting = session.user_setting()?;
+  let manager = upgrade_manager(manager)?;
+  let user_setting = manager.user_setting()?;
   data_result_ok(user_setting)
 }
 
 /// Only used for third party auth.
 /// Use [UserEvent::SignIn] or [UserEvent::SignUp] If the [AuthType] is Local or SelfHosted
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn third_party_auth_handler(
   data: AFPluginData<ThirdPartyAuthPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<UserProfilePB, FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params = data.into_inner();
   let auth_type: AuthType = params.auth_type.into();
-  session.update_auth_type(&auth_type).await;
-  let user_profile = session.sign_up(auth_type, BoxAny::new(params.map)).await?;
+  manager.update_auth_type(&auth_type).await;
+  let user_profile = manager.sign_up(auth_type, BoxAny::new(params.map)).await?;
   data_result_ok(user_profile.into())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn set_supabase_config_handler(
   data: AFPluginData<SupabaseConfigPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let config = SupabaseConfiguration::try_from(data.into_inner())?;
-  session.save_supabase_config(config);
+  manager.save_supabase_config(config);
   Ok(())
 }
 
 #[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn get_supabase_config_handler(
   store_preferences: AFPluginState<Weak<StorePreferences>>,
-  _session: AFPluginState<Weak<UserSession>>,
 ) -> DataResult<SupabaseConfigPB, FlowyError> {
   let store_preferences = upgrade_store_preferences(store_preferences)?;
   let config = get_supabase_config(&store_preferences).unwrap_or_default();
   data_result_ok(config.into())
 }
 
-#[tracing::instrument(level = "debug", skip(session), err)]
+#[tracing::instrument(level = "debug", skip(manager), err)]
 pub async fn get_all_user_workspace_handler(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<RepeatedUserWorkspacePB, FlowyError> {
-  let session = upgrade_session(session)?;
-  let uid = session.get_session()?.user_id;
-  let user_workspaces = session.get_all_user_workspaces(uid)?;
+  let manager = upgrade_manager(manager)?;
+  let uid = manager.get_session()?.user_id;
+  let user_workspaces = manager.get_all_user_workspaces(uid)?;
   data_result_ok(user_workspaces.into())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn open_workspace_handler(
   data: AFPluginData<UserWorkspacePB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params = data.into_inner();
-  session.open_workspace(&params.id).await?;
+  manager.open_workspace(&params.id).await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn add_user_to_workspace_handler(
   data: AFPluginData<AddWorkspaceUserPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params = data.into_inner();
-  session
+  manager
     .add_user_to_workspace(params.email, params.workspace_id)
     .await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn remove_user_from_workspace_handler(
   data: AFPluginData<RemoveWorkspaceUserPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let params = data.into_inner();
-  session
+  manager
     .remove_user_to_workspace(params.email, params.workspace_id)
     .await?;
   Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(data, session), err)]
+#[tracing::instrument(level = "debug", skip(data, manager), err)]
 pub async fn update_network_state_handler(
   data: AFPluginData<NetworkStatePB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let reachable = data.into_inner().ty.is_reachable();
-  session
+  manager
     .user_status_callback
     .read()
     .await
@@ -265,34 +264,34 @@ pub async fn update_network_state_handler(
 
 #[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn get_historical_users_handler(
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> DataResult<RepeatedHistoricalUserPB, FlowyError> {
-  let session = upgrade_session(session)?;
-  let users = RepeatedHistoricalUserPB::from(session.get_historical_users());
+  let manager = upgrade_manager(manager)?;
+  let users = RepeatedHistoricalUserPB::from(manager.get_historical_users());
   data_result_ok(users)
 }
 
 #[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn open_historical_users_handler(
   user: AFPluginData<HistoricalUserPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
   let user = user.into_inner();
-  let session = upgrade_session(session)?;
+  let manager = upgrade_manager(manager)?;
   let auth_type = AuthType::from(user.auth_type);
-  session.open_historical_user(user.user_id, user.device_id, auth_type)?;
+  manager.open_historical_user(user.user_id, user.device_id, auth_type)?;
   Ok(())
 }
 
 #[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn push_realtime_event_handler(
   payload: AFPluginData<RealtimePayloadPB>,
-  session: AFPluginState<Weak<UserSession>>,
+  manager: AFPluginState<Weak<UserManager>>,
 ) -> Result<(), FlowyError> {
   match serde_json::from_str::<Value>(&payload.into_inner().json_str) {
     Ok(json) => {
-      let session = upgrade_session(session)?;
-      session.receive_realtime_event(json).await;
+      let manager = upgrade_manager(manager)?;
+      manager.receive_realtime_event(json).await;
     },
     Err(e) => {
       tracing::error!("Deserialize RealtimePayload failed: {:?}", e);

--- a/frontend/rust-lib/flowy-user/src/event_map.rs
+++ b/frontend/rust-lib/flowy-user/src/event_map.rs
@@ -13,9 +13,9 @@ use lib_dispatch::prelude::*;
 use lib_infra::future::{to_fut, Fut};
 
 use crate::event_handler::*;
-use crate::{errors::FlowyError, services::UserSession};
+use crate::{errors::FlowyError, services::UserManager};
 
-pub fn init(user_session: Weak<UserSession>) -> AFPlugin {
+pub fn init(user_session: Weak<UserManager>) -> AFPlugin {
   let store_preferences = user_session
     .upgrade()
     .map(|session| session.get_store_preferences())

--- a/frontend/rust-lib/flowy-user/src/event_map.rs
+++ b/frontend/rust-lib/flowy-user/src/event_map.rs
@@ -53,7 +53,7 @@ pub fn init(user_session: Weak<UserManager>) -> AFPlugin {
     .event(UserEvent::OpenHistoricalUser, open_historical_users_handler)
     .event(UserEvent::PushRealtimeEvent, push_realtime_event_handler)
     .event(UserEvent::CreateReminder, create_reminder_event_handler)
-    .event(UserEvent::GetAllReminders, create_reminder_event_handler)
+    .event(UserEvent::GetAllReminders, get_all_reminder_event_handler)
 }
 
 pub struct SignUpContext {
@@ -256,7 +256,7 @@ pub enum UserEvent {
   #[event(input = "RealtimePayloadPB")]
   PushRealtimeEvent = 27,
 
-  #[event(input = "CreateReminderPayloadPB")]
+  #[event(input = "ReminderPB")]
   CreateReminder = 28,
 
   #[event(output = "RepeatedReminderPB")]

--- a/frontend/rust-lib/flowy-user/src/lib.rs
+++ b/frontend/rust-lib/flowy-user/src/lib.rs
@@ -4,6 +4,7 @@ extern crate flowy_sqlite;
 pub mod entities;
 mod event_handler;
 pub mod event_map;
+pub mod manager;
 mod migrations;
 mod notification;
 pub mod protobuf;

--- a/frontend/rust-lib/flowy-user/src/manager.rs
+++ b/frontend/rust-lib/flowy-user/src/manager.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::string::ToString;
 use std::sync::{Arc, Weak};
 

--- a/frontend/rust-lib/flowy-user/src/migrations/define.rs
+++ b/frontend/rust-lib/flowy-user/src/migrations/define.rs
@@ -1,5 +1,6 @@
-use crate::services::session_serde::Session;
 use flowy_user_deps::entities::UserProfile;
+
+use crate::services::entities::Session;
 
 pub struct UserMigrationContext {
   pub user_profile: UserProfile,

--- a/frontend/rust-lib/flowy-user/src/migrations/historical_document.rs
+++ b/frontend/rust-lib/flowy-user/src/migrations/historical_document.rs
@@ -10,7 +10,7 @@ use collab_folder::core::Folder;
 use flowy_error::{internal_error, FlowyResult};
 
 use crate::migrations::migration::UserDataMigration;
-use crate::services::session_serde::Session;
+use crate::services::entities::Session;
 
 /// Migrate the first level documents of the workspace by inserting documents
 pub struct HistoricalEmptyDocumentMigration;

--- a/frontend/rust-lib/flowy-user/src/migrations/migration.rs
+++ b/frontend/rust-lib/flowy-user/src/migrations/migration.rs
@@ -1,11 +1,14 @@
-use crate::services::session_serde::Session;
+use std::sync::Arc;
+
 use appflowy_integrate::RocksCollabDB;
 use chrono::NaiveDateTime;
 use diesel::{RunQueryDsl, SqliteConnection};
+
 use flowy_error::FlowyResult;
 use flowy_sqlite::schema::user_data_migration_records;
 use flowy_sqlite::ConnectionPool;
-use std::sync::Arc;
+
+use crate::services::entities::Session;
 
 pub struct UserLocalDataMigration {
   session: Session,

--- a/frontend/rust-lib/flowy-user/src/services/historical_user.rs
+++ b/frontend/rust-lib/flowy-user/src/services/historical_user.rs
@@ -12,7 +12,19 @@ use crate::services::user_workspace_sql::UserWorkspaceTable;
 
 const HISTORICAL_USER: &str = "af_historical_users";
 impl UserManager {
-  pub fn log_user(
+  /// Logs a user's details for historical tracking.
+  ///
+  /// This function adds a user's details to a local historical tracking system, useful for
+  /// keeping track of past sign-ins or any other historical activities.
+  ///
+  /// # Parameters
+  /// - `uid`: The user ID.
+  /// - `device_id`: The ID of the device the user is using.
+  /// - `user_name`: The name of the user.
+  /// - `auth_type`: The type of authentication used.
+  /// - `storage_path`: Path where user data is stored.
+  ///
+  pub fn log_historical_user(
     &self,
     uid: i64,
     device_id: &str,
@@ -37,6 +49,9 @@ impl UserManager {
       .set_object(HISTORICAL_USER, logger_users);
   }
 
+  /// Fetches a list of historical users, sorted by their sign-in timestamp.
+  ///
+  /// This function retrieves a list of users who have previously been logged for historical tracking.
   pub fn get_historical_users(&self) -> Vec<HistoricalUser> {
     let mut users = self
       .store_preferences
@@ -47,6 +62,11 @@ impl UserManager {
     users
   }
 
+  /// Opens a historical user's session based on their user ID, device ID, and authentication type.
+  ///
+  /// This function facilitates the re-opening of a user's session from historical tracking.
+  /// It retrieves the user's workspace and establishes a new session for the user.
+  ///
   pub fn open_historical_user(
     &self,
     uid: i64,

--- a/frontend/rust-lib/flowy-user/src/services/historical_user.rs
+++ b/frontend/rust-lib/flowy-user/src/services/historical_user.rs
@@ -6,9 +6,9 @@ use flowy_sqlite::{query_dsl::*, ExpressionMethods};
 use flowy_user_deps::entities::{AuthType, UserWorkspace};
 use lib_infra::util::timestamp;
 
+use crate::manager::UserManager;
 use crate::services::entities::{HistoricalUser, HistoricalUsers, Session};
 use crate::services::user_workspace_sql::UserWorkspaceTable;
-use crate::services::UserManager;
 
 const HISTORICAL_USER: &str = "af_historical_users";
 impl UserManager {

--- a/frontend/rust-lib/flowy-user/src/services/historical_user.rs
+++ b/frontend/rust-lib/flowy-user/src/services/historical_user.rs
@@ -1,0 +1,71 @@
+use diesel::RunQueryDsl;
+
+use flowy_error::FlowyResult;
+use flowy_sqlite::schema::user_workspace_table;
+use flowy_sqlite::{query_dsl::*, ExpressionMethods};
+use flowy_user_deps::entities::{AuthType, UserWorkspace};
+use lib_infra::util::timestamp;
+
+use crate::services::entities::{HistoricalUser, HistoricalUsers, Session};
+use crate::services::user_workspace_sql::UserWorkspaceTable;
+use crate::services::UserManager;
+
+const HISTORICAL_USER: &str = "af_historical_users";
+impl UserManager {
+  pub fn log_user(
+    &self,
+    uid: i64,
+    device_id: &str,
+    user_name: String,
+    auth_type: &AuthType,
+    storage_path: String,
+  ) {
+    let mut logger_users = self
+      .store_preferences
+      .get_object::<HistoricalUsers>(HISTORICAL_USER)
+      .unwrap_or_default();
+    logger_users.add_user(HistoricalUser {
+      user_id: uid,
+      user_name,
+      auth_type: auth_type.clone(),
+      sign_in_timestamp: timestamp(),
+      storage_path,
+      device_id: device_id.to_string(),
+    });
+    let _ = self
+      .store_preferences
+      .set_object(HISTORICAL_USER, logger_users);
+  }
+
+  pub fn get_historical_users(&self) -> Vec<HistoricalUser> {
+    let mut users = self
+      .store_preferences
+      .get_object::<HistoricalUsers>(HISTORICAL_USER)
+      .unwrap_or_default()
+      .users;
+    users.sort_by(|a, b| b.sign_in_timestamp.cmp(&a.sign_in_timestamp));
+    users
+  }
+
+  pub fn open_historical_user(
+    &self,
+    uid: i64,
+    device_id: String,
+    auth_type: AuthType,
+  ) -> FlowyResult<()> {
+    let conn = self.db_connection(uid)?;
+    let row = user_workspace_table::dsl::user_workspace_table
+      .filter(user_workspace_table::uid.eq(uid))
+      .first::<UserWorkspaceTable>(&*conn)?;
+    let user_workspace = UserWorkspace::from(row);
+    let session = Session {
+      user_id: uid,
+      device_id,
+      user_workspace,
+    };
+    debug_assert!(auth_type.is_local());
+    self.cloud_services.set_auth_type(auth_type);
+    self.set_current_session(Some(session))?;
+    Ok(())
+  }
+}

--- a/frontend/rust-lib/flowy-user/src/services/mod.rs
+++ b/frontend/rust-lib/flowy-user/src/services/mod.rs
@@ -1,10 +1,7 @@
-pub use manager::*;
-
 pub mod database;
 pub mod entities;
-mod historical_user;
-mod manager;
-mod user_awareness;
-mod user_sql;
-mod user_workspace;
-mod user_workspace_sql;
+pub(crate) mod historical_user;
+pub(crate) mod user_awareness;
+pub(crate) mod user_sql;
+pub(crate) mod user_workspace;
+pub(crate) mod user_workspace_sql;

--- a/frontend/rust-lib/flowy-user/src/services/mod.rs
+++ b/frontend/rust-lib/flowy-user/src/services/mod.rs
@@ -1,7 +1,10 @@
-pub use user_session::*;
+pub use manager::*;
 
 pub mod database;
-pub mod session_serde;
-mod user_session;
+pub mod entities;
+mod historical_user;
+mod manager;
+mod user_awareness;
 mod user_sql;
+mod user_workspace;
 mod user_workspace_sql;

--- a/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
@@ -1,0 +1,101 @@
+use std::sync::{Arc, Weak};
+
+use appflowy_integrate::{CollabType, RocksCollabDB};
+use collab::core::collab::{CollabRawData, MutexCollab};
+use collab_user::core::{MutexUserAwareness, Reminder, UserAwareness};
+
+use flowy_error::{ErrorCode, FlowyError, FlowyResult};
+
+use crate::entities::ReminderPB;
+use crate::manager::UserManager;
+use crate::services::entities::Session;
+
+impl UserManager {
+  pub async fn add_reminder(&self, payload: ReminderPB) -> FlowyResult<()> {
+    let reminder = Reminder::from(payload);
+    self.with_awareness((), |user_awareness| {
+      user_awareness.add_reminder(reminder);
+    });
+    Ok(())
+  }
+
+  pub async fn get_all_reminders(&self) -> Vec<Reminder> {
+    self.with_awareness(vec![], |user_awareness| user_awareness.get_all_reminders())
+  }
+
+  pub async fn initialize_user_awareness(
+    &self,
+    session: &Session,
+    source: UserAwarenessDataSource,
+  ) {
+    match self.try_initial_user_awareness(session, source).await {
+      Ok(_) => {},
+      Err(e) => {
+        tracing::error!("Failed to initialize user awareness: {:?}", e);
+      },
+    }
+  }
+
+  async fn try_initial_user_awareness(
+    &self,
+    session: &Session,
+    source: UserAwarenessDataSource,
+  ) -> FlowyResult<()> {
+    tracing::trace!("Initializing user awareness from {:?}", source);
+    let collab_db = self.get_collab_db(session.user_id)?;
+    let user_awareness = match source {
+      UserAwarenessDataSource::Local => {
+        let collab = self.collab_for_user_awareness(session, collab_db, vec![])?;
+        MutexUserAwareness::new(UserAwareness::create(collab, None))
+      },
+      UserAwarenessDataSource::Remote => {
+        let data = self
+          .cloud_services
+          .get_user_service()?
+          .get_user_awareness_updates(session.user_id)
+          .await?;
+        let collab = self.collab_for_user_awareness(session, collab_db, data)?;
+        MutexUserAwareness::new(UserAwareness::create(collab, None))
+      },
+    };
+    self.user_awareness.lock().replace(user_awareness);
+    Ok(())
+  }
+
+  fn collab_for_user_awareness(
+    &self,
+    session: &Session,
+    collab_db: Weak<RocksCollabDB>,
+    raw_data: CollabRawData,
+  ) -> Result<Arc<MutexCollab>, FlowyError> {
+    let collab_builder = self.collab_builder.upgrade().ok_or(FlowyError::new(
+      ErrorCode::Internal,
+      "Unexpected error: collab builder is not available",
+    ))?;
+    let collab = collab_builder.build(
+      session.user_id,
+      &session.user_id.to_string(),
+      CollabType::UserAwareness,
+      raw_data,
+      collab_db,
+    )?;
+    Ok(collab)
+  }
+
+  fn with_awareness<F, Output>(&self, default_value: Output, f: F) -> Output
+  where
+    F: FnOnce(&UserAwareness) -> Output,
+  {
+    let user_awareness = self.user_awareness.lock();
+    match &*user_awareness {
+      None => default_value,
+      Some(user_awareness) => f(&*user_awareness.lock()),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum UserAwarenessDataSource {
+  Local,
+  Remote,
+}

--- a/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
@@ -89,7 +89,7 @@ impl UserManager {
     let user_awareness = self.user_awareness.lock();
     match &*user_awareness {
       None => default_value,
-      Some(user_awareness) => f(&*user_awareness.lock()),
+      Some(user_awareness) => f(&user_awareness.lock()),
     }
   }
 }

--- a/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_awareness.rs
@@ -11,16 +11,42 @@ use crate::manager::UserManager;
 use crate::services::entities::Session;
 
 impl UserManager {
-  pub async fn add_reminder(&self, payload: ReminderPB) -> FlowyResult<()> {
-    let reminder = Reminder::from(payload);
-    self.with_awareness((), |user_awareness| {
-      user_awareness.add_reminder(reminder);
-    });
+  /// Adds a new reminder based on the given payload.
+  ///
+  /// This function creates a new `Reminder` from the provided payload and adds it to the user's reminders.
+  /// It leverages the `with_awareness` function to ensure the reminder is added in the context of the
+  /// current user's awareness.
+  ///
+  /// # Parameters
+  /// - `reminder_pb`: The pb for the new reminder.
+  ///
+  /// # Returns
+  /// - Returns `Ok(())` if the reminder is successfully added.
+  /// - May return errors of type `FlowyError` if any issues arise during the process.
+  ///
+  pub async fn add_reminder(&self, reminder_pb: ReminderPB) -> FlowyResult<()> {
+    let reminder = Reminder::from(reminder_pb);
+    self
+      .with_awareness((), |user_awareness| {
+        user_awareness.add_reminder(reminder);
+      })
+      .await;
     Ok(())
   }
 
+  /// Retrieves all reminders for the user.
+  ///
+  /// This function fetches all reminders associated with the current user. It leverages the
+  /// `with_awareness` function to ensure the reminders are retrieved in the context of the
+  /// current user's awareness.
+  ///
+  /// # Returns
+  /// - Returns a vector of `Reminder` objects containing all reminders for the user.
+  ///
   pub async fn get_all_reminders(&self) -> Vec<Reminder> {
-    self.with_awareness(vec![], |user_awareness| user_awareness.get_all_reminders())
+    self
+      .with_awareness(vec![], |user_awareness| user_awareness.get_all_reminders())
+      .await
   }
 
   pub async fn initialize_user_awareness(
@@ -29,13 +55,28 @@ impl UserManager {
     source: UserAwarenessDataSource,
   ) {
     match self.try_initial_user_awareness(session, source).await {
-      Ok(_) => {},
+      Ok(_) => {
+        tracing::trace!("User awareness initialized");
+      },
       Err(e) => {
         tracing::error!("Failed to initialize user awareness: {:?}", e);
       },
     }
   }
 
+  /// Initializes the user's awareness based on the specified data source.
+  ///
+  /// This asynchronous function attempts to initialize the user's awareness from either a local or remote data source.
+  /// Depending on the chosen source, it will either construct the user awareness from an empty dataset or fetch it
+  /// from a remote service. Once obtained, the user's awareness is stored in a shared mutex-protected structure.
+  ///
+  /// # Parameters
+  /// - `session`: The current user's session data.
+  /// - `source`: The source from which the user's awareness data should be obtained, either local or remote.
+  ///
+  /// # Returns
+  /// - Returns `Ok(())` if the user's awareness is successfully initialized.
+  /// - May return errors of type `FlowyError` if any issues arise during the initialization.
   async fn try_initial_user_awareness(
     &self,
     session: &Session,
@@ -58,10 +99,15 @@ impl UserManager {
         MutexUserAwareness::new(UserAwareness::create(collab, None))
       },
     };
-    self.user_awareness.lock().replace(user_awareness);
+    self.user_awareness.lock().await.replace(user_awareness);
     Ok(())
   }
 
+  /// Creates a collaboration instance tailored for user awareness.
+  ///
+  /// This function constructs a collaboration instance based on the given session and raw data,
+  /// using a collaboration builder. This instance is specifically geared towards handling
+  /// user awareness.
   fn collab_for_user_awareness(
     &self,
     session: &Session,
@@ -82,18 +128,39 @@ impl UserManager {
     Ok(collab)
   }
 
-  fn with_awareness<F, Output>(&self, default_value: Output, f: F) -> Output
+  /// Executes a function with user awareness.
+  ///
+  /// This function takes an asynchronous closure `f` that accepts a reference to a `UserAwareness`
+  /// and returns an `Output`. If the current user awareness is set (i.e., is `Some`), it invokes
+  /// the closure `f` with the user awareness. If the user awareness is not set (i.e., is `None`),
+  /// it attempts to initialize the user awareness via a remote session. If the session fetch
+  /// or user awareness initialization fails, it returns the provided `default_value`.
+  ///
+  /// # Parameters
+  /// - `default_value`: A default value to return if the user awareness is `None` and cannot be initialized.
+  /// - `f`: The asynchronous closure to execute with the user awareness.
+  async fn with_awareness<F, Output>(&self, default_value: Output, f: F) -> Output
   where
     F: FnOnce(&UserAwareness) -> Output,
   {
-    let user_awareness = self.user_awareness.lock();
+    let user_awareness = self.user_awareness.lock().await;
     match &*user_awareness {
-      None => default_value,
+      None => {
+        if let Ok(session) = self.get_session() {
+          self
+            .initialize_user_awareness(&session, UserAwarenessDataSource::Remote)
+            .await;
+        }
+        default_value
+      },
       Some(user_awareness) => f(&user_awareness.lock()),
     }
   }
 }
 
+/// Indicate using which data source to initialize the user awareness
+/// If the user is not a new user, the local data source is used. Otherwise, the remote data source is used.
+/// When using the remote data source, the user awareness will be initialized from the remote server.
 #[derive(Debug)]
 pub enum UserAwarenessDataSource {
   Local,

--- a/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
@@ -1,0 +1,159 @@
+use std::convert::TryFrom;
+use std::sync::Arc;
+
+use flowy_error::{FlowyError, FlowyResult};
+use flowy_sqlite::schema::user_workspace_table;
+use flowy_sqlite::{query_dsl::*, ConnectionPool, ExpressionMethods};
+use flowy_user_deps::entities::UserWorkspace;
+
+use crate::entities::RepeatedUserWorkspacePB;
+use crate::notification::{send_notification, UserNotification};
+use crate::services::user_workspace_sql::UserWorkspaceTable;
+use crate::services::UserManager;
+
+impl UserManager {
+  pub async fn open_workspace(&self, workspace_id: &str) -> FlowyResult<()> {
+    let uid = self.user_id()?;
+    if let Some(user_workspace) = self.get_user_workspace(uid, workspace_id) {
+      if let Err(err) = self
+        .user_status_callback
+        .read()
+        .await
+        .open_workspace(uid, &user_workspace)
+        .await
+      {
+        tracing::error!("Open workspace failed: {:?}", err);
+      }
+    }
+    Ok(())
+  }
+
+  pub async fn add_user_to_workspace(
+    &self,
+    user_email: String,
+    to_workspace_id: String,
+  ) -> FlowyResult<()> {
+    self
+      .cloud_services
+      .get_user_service()?
+      .add_workspace_member(user_email, to_workspace_id)
+      .await?;
+    Ok(())
+  }
+
+  pub async fn remove_user_to_workspace(
+    &self,
+    user_email: String,
+    from_workspace_id: String,
+  ) -> FlowyResult<()> {
+    self
+      .cloud_services
+      .get_user_service()?
+      .remove_workspace_member(user_email, from_workspace_id)
+      .await?;
+    Ok(())
+  }
+
+  pub fn get_user_workspace(&self, uid: i64, workspace_id: &str) -> Option<UserWorkspace> {
+    let conn = self.db_connection(uid).ok()?;
+    let row = user_workspace_table::dsl::user_workspace_table
+      .filter(user_workspace_table::id.eq(workspace_id))
+      .first::<UserWorkspaceTable>(&*conn)
+      .ok()?;
+    Some(UserWorkspace::from(row))
+  }
+
+  pub fn get_all_user_workspaces(&self, uid: i64) -> FlowyResult<Vec<UserWorkspace>> {
+    let conn = self.db_connection(uid)?;
+    let rows = user_workspace_table::dsl::user_workspace_table
+      .filter(user_workspace_table::uid.eq(uid))
+      .load::<UserWorkspaceTable>(&*conn)?;
+
+    if let Ok(service) = self.cloud_services.get_user_service() {
+      if let Ok(pool) = self.db_pool(uid) {
+        tokio::spawn(async move {
+          if let Ok(new_user_workspaces) = service.get_user_workspaces(uid).await {
+            let _ = save_user_workspaces(
+              pool,
+              new_user_workspaces
+                .iter()
+                .flat_map(|user_workspace| UserWorkspaceTable::try_from((uid, user_workspace)).ok())
+                .collect(),
+            );
+
+            let repeated_workspace_pbs = RepeatedUserWorkspacePB::from(new_user_workspaces);
+            send_notification(&uid.to_string(), UserNotification::DidUpdateUserWorkspaces)
+              .payload(repeated_workspace_pbs)
+              .send();
+          }
+        });
+      }
+    }
+    Ok(rows.into_iter().map(UserWorkspace::from).collect())
+  }
+
+  pub async fn save_user_workspaces(
+    &self,
+    uid: i64,
+    user_workspaces: Vec<UserWorkspaceTable>,
+  ) -> FlowyResult<()> {
+    let conn = self.db_connection(uid)?;
+    conn.immediate_transaction(|| {
+      for user_workspace in user_workspaces {
+        if let Err(err) = diesel::update(
+          user_workspace_table::dsl::user_workspace_table
+            .filter(user_workspace_table::id.eq(user_workspace.id.clone())),
+        )
+        .set((
+          user_workspace_table::name.eq(&user_workspace.name),
+          user_workspace_table::created_at.eq(&user_workspace.created_at),
+          user_workspace_table::database_storage_id.eq(&user_workspace.database_storage_id),
+        ))
+        .execute(&*conn)
+        .and_then(|rows| {
+          if rows == 0 {
+            let _ = diesel::insert_into(user_workspace_table::table)
+              .values(user_workspace)
+              .execute(&*conn)?;
+          }
+          Ok(())
+        }) {
+          tracing::error!("Error saving user workspace: {:?}", err);
+        }
+      }
+      Ok::<(), FlowyError>(())
+    })
+  }
+}
+
+pub fn save_user_workspaces(
+  pool: Arc<ConnectionPool>,
+  user_workspaces: Vec<UserWorkspaceTable>,
+) -> FlowyResult<()> {
+  let conn = pool.get()?;
+  conn.immediate_transaction(|| {
+    for user_workspace in user_workspaces {
+      if let Err(err) = diesel::update(
+        user_workspace_table::dsl::user_workspace_table
+          .filter(user_workspace_table::id.eq(user_workspace.id.clone())),
+      )
+      .set((
+        user_workspace_table::name.eq(&user_workspace.name),
+        user_workspace_table::created_at.eq(&user_workspace.created_at),
+        user_workspace_table::database_storage_id.eq(&user_workspace.database_storage_id),
+      ))
+      .execute(&*conn)
+      .and_then(|rows| {
+        if rows == 0 {
+          let _ = diesel::insert_into(user_workspace_table::table)
+            .values(user_workspace)
+            .execute(&*conn)?;
+        }
+        Ok(())
+      }) {
+        tracing::error!("Error saving user workspace: {:?}", err);
+      }
+    }
+    Ok::<(), FlowyError>(())
+  })
+}

--- a/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
@@ -122,7 +122,7 @@ impl UserManager {
 pub fn save_user_workspaces(
   uid: i64,
   pool: Arc<ConnectionPool>,
-  user_workspaces: &Vec<UserWorkspace>,
+  user_workspaces: &[UserWorkspace],
 ) -> FlowyResult<()> {
   let user_workspaces = user_workspaces
     .iter()

--- a/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/services/user_workspace.rs
@@ -84,39 +84,6 @@ impl UserManager {
     }
     Ok(rows.into_iter().map(UserWorkspace::from).collect())
   }
-
-  pub async fn save_user_workspaces(
-    &self,
-    uid: i64,
-    user_workspaces: Vec<UserWorkspaceTable>,
-  ) -> FlowyResult<()> {
-    let conn = self.db_connection(uid)?;
-    conn.immediate_transaction(|| {
-      for user_workspace in user_workspaces {
-        if let Err(err) = diesel::update(
-          user_workspace_table::dsl::user_workspace_table
-            .filter(user_workspace_table::id.eq(user_workspace.id.clone())),
-        )
-        .set((
-          user_workspace_table::name.eq(&user_workspace.name),
-          user_workspace_table::created_at.eq(&user_workspace.created_at),
-          user_workspace_table::database_storage_id.eq(&user_workspace.database_storage_id),
-        ))
-        .execute(&*conn)
-        .and_then(|rows| {
-          if rows == 0 {
-            let _ = diesel::insert_into(user_workspace_table::table)
-              .values(user_workspace)
-              .execute(&*conn)?;
-          }
-          Ok(())
-        }) {
-          tracing::error!("Error saving user workspace: {:?}", err);
-        }
-      }
-      Ok::<(), FlowyError>(())
-    })
-  }
 }
 
 pub fn save_user_workspaces(


### PR DESCRIPTION
Use the UserAwareness object to store user awareness data, such as reminders or application settings. The UserAwareness can collaborate across different devices for the same user.

Todo:
1. Enable subscribe the awareness changes in flowy-user  crate.


#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
