### PR TITLE
fix: macOS build error(Library not loaded) in debug mode

### DIFF
--- a/frontend/appflowy_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/frontend/appflowy_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_HARDENED_RUNTIME = NO;
 				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = AppFlowy;
@@ -564,7 +564,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_HARDENED_RUNTIME = NO;
 				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = AppFlowy;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview
```log
dyld[95533]: Library not loaded: @rpath/HotKey.framework/Versions/A/HotKey
  Referenced from: <9EAE1F08-63E5-37C6-9DFD-90E6FC44FEE3> /Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/MacOS/AppFlowy
  Reason: tried: '/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file, not in dyld cache), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file), '/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file, not in dyld cache), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' (code signature in <49AE7F60-DEE7-3AA6-9A6C-C732E4B25352> '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/MacOS/Frameworks/HotKey.framework/Versions/A/HotKey' (no such file), '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/HotKey.framework/Versions/A/HotKey' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/HotKey.framework/Versions/A/HotKey' (no such file), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' (code signature in <49AE7F60-DEE7-3AA6-9A6C-C732E4B25352> '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)), '/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file, not in dyld cache), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file), '/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file, not in dyld cache), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/swift/HotKey.framework/Versions/A/HotKey' (no such file), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' (code signature in <49AE7F60-DEE7-3AA6-9A6C-C732E4B25352> '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/MacOS/Frameworks/HotKey.framework/Versions/A/HotKey' (no such file), '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/HotKey.framework/Versions/A/HotKey' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/HotKey.framework/Versions/A/HotKey' (no such file), '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' (code signature in <49AE7F60-DEE7-3AA6-9A6C-C732E4B25352> '/Users/lucas.xu/Desktop/AppFlowy/frontend/appflowy_flutter/build/macos/Build/Products/Debug/AppFlowy.app/Contents/Frameworks/HotKey.framework/Versions/A/HotKey' not valid for use in process: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)), '/Library/Frameworks/HotKey.framework/Versions/A/HotKey' (no such file), '/System/Library/Frameworks/HotKey.framework/Versions/A/HotKey' (no such file, not in dyld cache)
```

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
