### PR TITLE
build: bump super_clipboard version

### DIFF
--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -1451,18 +1451,18 @@ packages:
     dependency: "direct main"
     description:
       name: super_clipboard
-      sha256: "204284b1a721d33a65bcab077b191a3b7379b46a231f05688d17220153338ede"
+      sha256: b3fc2b3ec9577797f626aa6a4b4cf58bee4e417558be5928c3475dac2ee10cb7
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.2"
   super_native_extensions:
     dependency: transitive
     description:
       name: super_native_extensions
-      sha256: "1f15e9b1adb0bc59cf9b889a0b248f3c192fa17e2d5c923aeeec6d4fa2eeffd6"
+      sha256: e2830e33ba23814c5c24653bb20c09848537a04e48c99dcbbc624810490ea28d
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.2"
   sync_http:
     dependency: transitive
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -107,7 +107,7 @@ dependencies:
   url_protocol:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  super_clipboard: ^0.6.0
+  super_clipboard: ^0.6.2
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
super_clipboard v0.5 expects cargo binary in "\~/.cargo/bin" at least in linux. This made some problems for me at first and I think it might cause others to. So I made some comments [here](https://github.com/superlistapp/super_native_extensions/issues/128#issuecomment-1687010282) and the maintainer kindly made an update. I suggest using the updated version.

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
