### PR TITLE
fix: reorder rows on windows

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/grid_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database_view/application/row/row_service.dart';
 import 'package:appflowy/plugins/database_view/grid/presentation/widgets/toolbar/grid_setting_bar.dart';

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/grid_page.dart
@@ -257,59 +257,38 @@ class _GridRows extends StatelessWidget {
     GridState state,
     List<RowInfo> rowInfos,
   ) {
-    if (Platform.isWindows) {
-      // Workaround: On Windows, the focusing of the text cell is not working
-      // properly when the list is reorderable. So using the ListView instead.
-      return ListView.builder(
-        controller: scrollController.verticalController,
-        itemCount: rowInfos.length + 1, // the extra item is the footer
-        itemBuilder: (context, index) {
-          if (index < rowInfos.length) {
-            final rowInfo = rowInfos[index];
-            return _renderRow(
-              context,
-              rowInfo.rowId,
-              isDraggable: false,
-              index: index,
-            );
-          }
-          return const GridRowBottomBar(key: Key('gridFooter'));
-        },
-      );
-    } else {
-      return ReorderableListView.builder(
-        /// TODO(Xazin): Resolve inconsistent scrollbar behavior
-        ///  This is a workaround related to
-        ///  https://github.com/flutter/flutter/issues/25652
-        cacheExtent: 5000,
-        scrollController: scrollController.verticalController,
-        buildDefaultDragHandles: false,
-        proxyDecorator: (child, index, animation) => Material(
-          color: Colors.white.withOpacity(.1),
-          child: Opacity(opacity: .5, child: child),
-        ),
-        onReorder: (fromIndex, newIndex) {
-          final toIndex = newIndex > fromIndex ? newIndex - 1 : newIndex;
-          if (fromIndex == toIndex) {
-            return;
-          }
-          context.read<GridBloc>().add(GridEvent.moveRow(fromIndex, toIndex));
-        },
-        itemCount: rowInfos.length + 1, // the extra item is the footer
-        itemBuilder: (context, index) {
-          if (index < rowInfos.length) {
-            final rowInfo = rowInfos[index];
-            return _renderRow(
-              context,
-              rowInfo.rowId,
-              isDraggable: state.reorderable,
-              index: index,
-            );
-          }
-          return const GridRowBottomBar(key: Key('gridFooter'));
-        },
-      );
-    }
+    return ReorderableListView.builder(
+      /// TODO(Xazin): Resolve inconsistent scrollbar behavior
+      ///  This is a workaround related to
+      ///  https://github.com/flutter/flutter/issues/25652
+      cacheExtent: 5000,
+      scrollController: scrollController.verticalController,
+      buildDefaultDragHandles: false,
+      proxyDecorator: (child, index, animation) => Material(
+        color: Colors.white.withOpacity(.1),
+        child: Opacity(opacity: .5, child: child),
+      ),
+      onReorder: (fromIndex, newIndex) {
+        final toIndex = newIndex > fromIndex ? newIndex - 1 : newIndex;
+        if (fromIndex == toIndex) {
+          return;
+        }
+        context.read<GridBloc>().add(GridEvent.moveRow(fromIndex, toIndex));
+      },
+      itemCount: rowInfos.length + 1, // the extra item is the footer
+      itemBuilder: (context, index) {
+        if (index < rowInfos.length) {
+          final rowInfo = rowInfos[index];
+          return _renderRow(
+            context,
+            rowInfo.rowId,
+            isDraggable: state.reorderable,
+            index: index,
+          );
+        }
+        return const GridRowBottomBar(key: Key('gridFooter'));
+      },
+    );
   }
 
   Widget _renderRow(

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/row/row.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/row/row.dart
@@ -161,16 +161,12 @@ class _RowLeadingState extends State<_RowLeading> {
             index: widget.index!,
             child: RowMenuButton(
               isDragEnabled: isDraggable,
-              openMenu: () {
-                popoverController.show();
-              },
+              openMenu: popoverController.show,
             ),
           ),
         ] else ...[
           RowMenuButton(
-            openMenu: () {
-              popoverController.show();
-            },
+            openMenu: popoverController.show,
           ),
         ],
       ],


### PR DESCRIPTION
Closes: #3208

I checked on the issue that the temporary disable of Reorderable on Windows was supposed to fix, but even after undoing those changes, I wasn't able to reproduce according to #2794 - We might have to take note of if this bug reappears, and solve it in another manner.

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
