### PR TITLE
chore: remove default ImageFilter

### DIFF
--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/widget/dialog/styled_dialogs.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/widget/dialog/styled_dialogs.dart
@@ -106,13 +106,14 @@ class DialogBarrier {
   String label;
   Color color;
   bool dismissible;
-  ImageFilter filter;
+  ImageFilter? filter;
 
   DialogBarrier({
     this.dismissible = true,
     this.color = Colors.transparent,
     this.label = '',
-  }) : filter = ImageFilter.blur(sigmaX: 4, sigmaY: 4);
+    this.filter,
+  });
 }
 
 class StyledDialogRoute<T> extends PopupRoute<T> {


### PR DESCRIPTION
To fix #3311 
 
I removed the default `ImageFilter` for the `DialogBarrier`, so the `StyledDialog` won't show a blur effect if we didn't give the value to `ImageFilter`.

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [X] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [X] I've listed at least one issue that this PR fixes in the description above.
- [X] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [X] All existing tests are passing.
