### PR TITLE
fix: close popover after item selection in settings view

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/application/appearance.dart';
+import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
@@ -27,12 +28,12 @@ class BrightnessSetting extends StatelessWidget {
           trailing: [
             ThemeValueDropDown(
               currentValue: _themeModeLabelText(currentThemeMode),
-              popupBuilder: (_) => Column(
+              popupBuilder: (_, controller) => Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _themeModeItemButton(context, ThemeMode.light),
-                  _themeModeItemButton(context, ThemeMode.dark),
-                  _themeModeItemButton(context, ThemeMode.system),
+                  _themeModeItemButton(context, controller, ThemeMode.light),
+                  _themeModeItemButton(context, controller, ThemeMode.dark),
+                  _themeModeItemButton(context, controller, ThemeMode.system),
                 ],
               ),
             ),
@@ -52,7 +53,11 @@ class BrightnessSetting extends StatelessWidget {
         ],
       );
 
-  Widget _themeModeItemButton(BuildContext context, ThemeMode themeMode) {
+  Widget _themeModeItemButton(
+    BuildContext context,
+    PopoverController controller,
+    ThemeMode themeMode,
+  ) {
     return SizedBox(
       height: 32,
       child: FlowyButton(
@@ -66,6 +71,7 @@ class BrightnessSetting extends StatelessWidget {
           if (currentThemeMode != themeMode) {
             context.read<AppearanceSettingsCubit>().setThemeMode(themeMode);
           }
+          controller.close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
@@ -28,12 +28,12 @@ class BrightnessSetting extends StatelessWidget {
           trailing: [
             ThemeValueDropDown(
               currentValue: _themeModeLabelText(currentThemeMode),
-              popupBuilder: (_, controller) => Column(
+              popupBuilder: (context) => Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _themeModeItemButton(context, controller, ThemeMode.light),
-                  _themeModeItemButton(context, controller, ThemeMode.dark),
-                  _themeModeItemButton(context, controller, ThemeMode.system),
+                  _themeModeItemButton(context, ThemeMode.light),
+                  _themeModeItemButton(context, ThemeMode.dark),
+                  _themeModeItemButton(context, ThemeMode.system),
                 ],
               ),
             ),
@@ -55,7 +55,6 @@ class BrightnessSetting extends StatelessWidget {
 
   Widget _themeModeItemButton(
     BuildContext context,
-    PopoverController controller,
     ThemeMode themeMode,
   ) {
     return SizedBox(
@@ -71,7 +70,7 @@ class BrightnessSetting extends StatelessWidget {
           if (currentThemeMode != themeMode) {
             context.read<AppearanceSettingsCubit>().setThemeMode(themeMode);
           }
-          controller.close();
+          PopoverContainer.of(context).close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/color_scheme.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/color_scheme.dart
@@ -75,7 +75,7 @@ class ColorSchemeUploadOverlayButton extends StatelessWidget {
   }
 }
 
-class ColorSchemeUploadPopover extends StatefulWidget {
+class ColorSchemeUploadPopover extends StatelessWidget {
   const ColorSchemeUploadPopover({
     super.key,
     required this.currentTheme,
@@ -86,20 +86,11 @@ class ColorSchemeUploadPopover extends StatefulWidget {
   final DynamicPluginBloc bloc;
 
   @override
-  State<ColorSchemeUploadPopover> createState() =>
-      _ColorSchemeUploadPopoverState();
-}
-
-class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
-  final PopoverController controller = PopoverController();
-
-  @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
-      controller: controller,
       direction: PopoverDirection.bottomWithRightAligned,
       child: FlowyTextButton(
-        widget.currentTheme,
+        currentTheme,
         fontColor: Theme.of(context).colorScheme.onBackground,
         fillColor: Colors.transparent,
         onPressed: () {},
@@ -107,7 +98,7 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
       popupBuilder: (BuildContext context) {
         return IntrinsicWidth(
           child: BlocBuilder<DynamicPluginBloc, DynamicPluginState>(
-            bloc: widget.bloc..add(DynamicPluginEvent.load()),
+            bloc: bloc..add(DynamicPluginEvent.load()),
             buildWhen: (previous, current) => current is Ready,
             builder: (context, state) {
               return state.maybeWhen(
@@ -116,11 +107,7 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
                   children: [
                     ...AppTheme.builtins
                         .map(
-                          (theme) => _themeItemButton(
-                            context,
-                            controller,
-                            theme.themeName,
-                          ),
+                          (theme) => _themeItemButton(context, theme.themeName),
                         )
                         .toList(),
                     if (plugins.isNotEmpty) ...[
@@ -131,7 +118,6 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
                           .map(
                             (theme) => _themeItemButton(
                               context,
-                              controller,
                               theme.themeName,
                               false,
                             ),
@@ -151,7 +137,6 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
 
   Widget _themeItemButton(
     BuildContext context,
-    PopoverController controller,
     String theme, [
     bool isBuiltin = true,
   ]) {
@@ -162,16 +147,16 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
           Expanded(
             child: FlowyButton(
               text: FlowyText.medium(theme),
-              rightIcon: widget.currentTheme == theme
+              rightIcon: currentTheme == theme
                   ? const FlowySvg(
                       FlowySvgs.check_s,
                     )
                   : null,
-              onTap: () async {
-                if (widget.currentTheme != theme) {
-                  await context.read<AppearanceSettingsCubit>().setTheme(theme);
+              onTap: () {
+                if (currentTheme != theme) {
+                  context.read<AppearanceSettingsCubit>().setTheme(theme);
                 }
-                controller.close();
+                PopoverContainer.of(context).close();
               },
             ),
           ),
@@ -182,7 +167,7 @@ class _ColorSchemeUploadPopoverState extends State<ColorSchemeUploadPopover> {
               ),
               width: 20,
               onPressed: () =>
-                  widget.bloc.add(DynamicPluginEvent.removePlugin(name: theme)),
+                  bloc.add(DynamicPluginEvent.removePlugin(name: theme)),
             )
         ],
       ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/direction_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/direction_setting.dart
@@ -2,6 +2,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
 import 'package:appflowy/workspace/application/appearance.dart';
+import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +26,7 @@ class LayoutDirectionSetting extends StatelessWidget {
       trailing: [
         ThemeValueDropDown(
           currentValue: _layoutDirectionLabelText(currentLayoutDirection),
-          popupBuilder: (_) => Column(
+          popupBuilder: (context) => Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               _layoutDirectionItemButton(context, LayoutDirection.ltrLayout),
@@ -54,6 +55,7 @@ class LayoutDirectionSetting extends StatelessWidget {
                 .read<AppearanceSettingsCubit>()
                 .setLayoutDirection(direction);
           }
+          PopoverContainer.of(context).close();
         },
       ),
     );
@@ -86,7 +88,7 @@ class TextDirectionSetting extends StatelessWidget {
         trailing: [
           ThemeValueDropDown(
             currentValue: _textDirectionLabelText(currentTextDirection),
-            popupBuilder: (_) => Column(
+            popupBuilder: (context) => Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 _textDirectionItemButton(context, null),
@@ -119,6 +121,7 @@ class TextDirectionSetting extends StatelessWidget {
                 .read<DocumentAppearanceCubit>()
                 .syncDefaultTextDirection(textDirection?.name);
           }
+          PopoverContainer.of(context).close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
@@ -131,18 +131,17 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                     FlowySvgs.check_s,
                   )
                 : null,
-        onTap: () async {
-          final popover = PopoverContainer.of(context);
+        onTap: () {
           if (parseFontFamilyName(widget.currentFontFamily) !=
               buttonFontFamily) {
             context
                 .read<AppearanceSettingsCubit>()
                 .setFontFamily(parseFontFamilyName(style.fontFamily!));
-            await context
+            context
                 .read<DocumentAppearanceCubit>()
                 .syncFontFamily(parseFontFamilyName(style.fontFamily!));
           }
-          popover.close();
+          PopoverContainer.of(context).close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
@@ -139,7 +139,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
             context
                 .read<AppearanceSettingsCubit>()
                 .setFontFamily(parseFontFamilyName(style.fontFamily!));
-            context
+            await context
                 .read<DocumentAppearanceCubit>()
                 .syncFontFamily(parseFontFamilyName(style.fontFamily!));
           }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
@@ -3,6 +3,7 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
 import 'package:appflowy/workspace/application/appearance.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
+import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
@@ -50,7 +51,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
           onClose: () {
             query.value = '';
           },
-          popupBuilder: (_) => CustomScrollView(
+          popupBuilder: (_, controller) => CustomScrollView(
             shrinkWrap: true,
             slivers: [
               SliverPadding(
@@ -88,6 +89,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                   return SliverFixedExtentList.builder(
                     itemBuilder: (context, index) => _fontFamilyItemButton(
                       context,
+                      controller,
                       GoogleFonts.getFont(displayed[index]),
                     ),
                     itemCount: displayed.length,
@@ -109,7 +111,11 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
         .replaceAllMapped(camelCase, (m) => ' ${m.group(0)}');
   }
 
-  Widget _fontFamilyItemButton(BuildContext context, TextStyle style) {
+  Widget _fontFamilyItemButton(
+    BuildContext context,
+    PopoverController controller,
+    TextStyle style,
+  ) {
     final buttonFontFamily = parseFontFamilyName(style.fontFamily!);
     return SizedBox(
       key: UniqueKey(),
@@ -127,7 +133,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                     FlowySvgs.check_s,
                   )
                 : null,
-        onTap: () {
+        onTap: () async {
           if (parseFontFamilyName(widget.currentFontFamily) !=
               buttonFontFamily) {
             context
@@ -137,6 +143,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                 .read<DocumentAppearanceCubit>()
                 .syncFontFamily(parseFontFamilyName(style.fontFamily!));
           }
+          controller.close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
@@ -51,7 +51,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
           onClose: () {
             query.value = '';
           },
-          popupBuilder: (_, controller) => CustomScrollView(
+          popupBuilder: (_) => CustomScrollView(
             shrinkWrap: true,
             slivers: [
               SliverPadding(
@@ -89,7 +89,6 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                   return SliverFixedExtentList.builder(
                     itemBuilder: (context, index) => _fontFamilyItemButton(
                       context,
-                      controller,
                       GoogleFonts.getFont(displayed[index]),
                     ),
                     itemCount: displayed.length,
@@ -113,7 +112,6 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
 
   Widget _fontFamilyItemButton(
     BuildContext context,
-    PopoverController controller,
     TextStyle style,
   ) {
     final buttonFontFamily = parseFontFamilyName(style.fontFamily!);
@@ -134,6 +132,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                   )
                 : null,
         onTap: () async {
+          final popover = PopoverContainer.of(context);
           if (parseFontFamilyName(widget.currentFontFamily) !=
               buttonFontFamily) {
             context
@@ -143,7 +142,7 @@ class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
                 .read<DocumentAppearanceCubit>()
                 .syncFontFamily(parseFontFamilyName(style.fontFamily!));
           }
-          controller.close();
+          popover.close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
@@ -64,7 +64,7 @@ class ThemeSettingEntryTemplateWidget extends StatelessWidget {
   }
 }
 
-class ThemeValueDropDown extends StatefulWidget {
+class ThemeValueDropDown extends StatelessWidget {
   const ThemeValueDropDown({
     super.key,
     required this.currentValue,
@@ -75,31 +75,23 @@ class ThemeValueDropDown extends StatefulWidget {
 
   final String currentValue;
   final Key? popoverKey;
-  final Widget Function(BuildContext, PopoverController) popupBuilder;
+  final Widget Function(BuildContext) popupBuilder;
   final void Function()? onClose;
-
-  @override
-  State<ThemeValueDropDown> createState() => _ThemeValueDropDownState();
-}
-
-class _ThemeValueDropDownState extends State<ThemeValueDropDown> {
-  final PopoverController controller = PopoverController();
 
   @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
-      key: widget.popoverKey,
-      controller: controller,
+      key: popoverKey,
       direction: PopoverDirection.bottomWithRightAligned,
-      popupBuilder: (context) => widget.popupBuilder(context, controller),
+      popupBuilder: popupBuilder,
       constraints: const BoxConstraints(
         minWidth: 80,
         maxWidth: 160,
         maxHeight: 400,
       ),
-      onClose: widget.onClose,
+      onClose: onClose,
       child: FlowyTextButton(
-        widget.currentValue,
+        currentValue,
         fontColor: Theme.of(context).colorScheme.onBackground,
         fillColor: Colors.transparent,
       ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
@@ -75,7 +75,7 @@ class ThemeValueDropDown extends StatefulWidget {
 
   final String currentValue;
   final Key? popoverKey;
-  final Widget Function(BuildContext) popupBuilder;
+  final Widget Function(BuildContext, PopoverController) popupBuilder;
   final void Function()? onClose;
 
   @override
@@ -83,12 +83,15 @@ class ThemeValueDropDown extends StatefulWidget {
 }
 
 class _ThemeValueDropDownState extends State<ThemeValueDropDown> {
+  final PopoverController controller = PopoverController();
+
   @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
       key: widget.popoverKey,
+      controller: controller,
       direction: PopoverDirection.bottomWithRightAligned,
-      popupBuilder: widget.popupBuilder,
+      popupBuilder: (context) => widget.popupBuilder(context, controller),
       constraints: const BoxConstraints(
         minWidth: 80,
         maxWidth: 160,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
@@ -64,7 +64,7 @@ class ThemeSettingEntryTemplateWidget extends StatelessWidget {
   }
 }
 
-class ThemeValueDropDown extends StatelessWidget {
+class ThemeValueDropDown extends StatefulWidget {
   const ThemeValueDropDown({
     super.key,
     required this.currentValue,
@@ -79,19 +79,24 @@ class ThemeValueDropDown extends StatelessWidget {
   final void Function()? onClose;
 
   @override
+  State<ThemeValueDropDown> createState() => _ThemeValueDropDownState();
+}
+
+class _ThemeValueDropDownState extends State<ThemeValueDropDown> {
+  @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
-      key: popoverKey,
+      key: widget.popoverKey,
       direction: PopoverDirection.bottomWithRightAligned,
-      popupBuilder: popupBuilder,
+      popupBuilder: widget.popupBuilder,
       constraints: const BoxConstraints(
         minWidth: 80,
         maxWidth: 160,
         maxHeight: 400,
       ),
-      onClose: onClose,
+      onClose: widget.onClose,
       child: FlowyTextButton(
-        currentValue,
+        widget.currentValue,
         fontColor: Theme.of(context).colorScheme.onBackground,
         fillColor: Colors.transparent,
       ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -57,10 +57,7 @@ class _LanguageSelectorState extends State<LanguageSelector> {
       ),
       popupBuilder: (BuildContext context) {
         final allLocales = EasyLocalization.of(context)!.supportedLocales;
-        return LanguageItemsListView(
-          controller: controller,
-          allLocales: allLocales,
-        );
+        return LanguageItemsListView(allLocales: allLocales);
       },
     );
   }
@@ -70,11 +67,9 @@ class LanguageItemsListView extends StatelessWidget {
   const LanguageItemsListView({
     super.key,
     required this.allLocales,
-    this.controller,
   });
 
   final List<Locale> allLocales;
-  final PopoverController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -86,7 +81,6 @@ class LanguageItemsListView extends StatelessWidget {
         itemBuilder: (context, index) {
           final locale = allLocales[index];
           return LanguageItem(
-            controller: controller,
             locale: locale,
             currentLocale: state.locale,
           );
@@ -100,13 +94,11 @@ class LanguageItemsListView extends StatelessWidget {
 class LanguageItem extends StatelessWidget {
   final Locale locale;
   final Locale currentLocale;
-  final PopoverController? controller;
 
   const LanguageItem({
     super.key,
     required this.locale,
     required this.currentLocale,
-    this.controller,
   });
 
   @override
@@ -123,7 +115,7 @@ class LanguageItem extends StatelessWidget {
           if (currentLocale != locale) {
             context.read<AppearanceSettingsCubit>().setLocale(context, locale);
           }
-          controller?.close();
+          PopoverContainer.of(context).close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -30,7 +30,7 @@ class SettingsLanguageView extends StatelessWidget {
   }
 }
 
-class LanguageSelector extends StatelessWidget {
+class LanguageSelector extends StatefulWidget {
   final Locale currentLocale;
   const LanguageSelector({
     super.key,
@@ -38,11 +38,19 @@ class LanguageSelector extends StatelessWidget {
   });
 
   @override
+  State<LanguageSelector> createState() => _LanguageSelectorState();
+}
+
+class _LanguageSelectorState extends State<LanguageSelector> {
+  final controller = PopoverController();
+
+  @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
+      controller: controller,
       direction: PopoverDirection.bottomWithRightAligned,
       child: FlowyTextButton(
-        languageFromLocale(currentLocale),
+        languageFromLocale(widget.currentLocale),
         fontColor: Theme.of(context).colorScheme.onBackground,
         fillColor: Colors.transparent,
         onPressed: () {},
@@ -50,6 +58,7 @@ class LanguageSelector extends StatelessWidget {
       popupBuilder: (BuildContext context) {
         final allLocales = EasyLocalization.of(context)!.supportedLocales;
         return LanguageItemsListView(
+          controller: controller,
           allLocales: allLocales,
         );
       },
@@ -61,9 +70,11 @@ class LanguageItemsListView extends StatelessWidget {
   const LanguageItemsListView({
     super.key,
     required this.allLocales,
+    this.controller,
   });
 
   final List<Locale> allLocales;
+  final PopoverController? controller;
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +85,11 @@ class LanguageItemsListView extends StatelessWidget {
       child: ListView.builder(
         itemBuilder: (context, index) {
           final locale = allLocales[index];
-          return LanguageItem(locale: locale, currentLocale: state.locale);
+          return LanguageItem(
+            controller: controller,
+            locale: locale,
+            currentLocale: state.locale,
+          );
         },
         itemCount: allLocales.length,
       ),
@@ -85,10 +100,13 @@ class LanguageItemsListView extends StatelessWidget {
 class LanguageItem extends StatelessWidget {
   final Locale locale;
   final Locale currentLocale;
+  final PopoverController? controller;
+
   const LanguageItem({
     super.key,
     required this.locale,
     required this.currentLocale,
+    this.controller,
   });
 
   @override
@@ -105,6 +123,7 @@ class LanguageItem extends StatelessWidget {
           if (currentLocale != locale) {
             context.read<AppearanceSettingsCubit>().setLocale(context, locale);
           }
+          controller?.close();
         },
       ),
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_language_view.dart
@@ -30,27 +30,20 @@ class SettingsLanguageView extends StatelessWidget {
   }
 }
 
-class LanguageSelector extends StatefulWidget {
+class LanguageSelector extends StatelessWidget {
   final Locale currentLocale;
+  
   const LanguageSelector({
     super.key,
     required this.currentLocale,
   });
 
   @override
-  State<LanguageSelector> createState() => _LanguageSelectorState();
-}
-
-class _LanguageSelectorState extends State<LanguageSelector> {
-  final controller = PopoverController();
-
-  @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(
-      controller: controller,
       direction: PopoverDirection.bottomWithRightAligned,
       child: FlowyTextButton(
-        languageFromLocale(widget.currentLocale),
+        languageFromLocale(currentLocale),
         fontColor: Theme.of(context).colorScheme.onBackground,
         fillColor: Colors.transparent,
         onPressed: () {},


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->
closes #3318 
---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
