### PR TITLE
fix: don't use timestamp fields to make calendar

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/entities/field_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/field_entities.rs
@@ -558,8 +558,6 @@ impl FieldType {
 
   pub fn is_date(&self) -> bool {
     matches!(self, FieldType::DateTime)
-      || matches!(self, FieldType::LastEditedTime)
-      || matches!(self, FieldType::CreatedTime)
   }
 
   pub fn is_single_select(&self) -> bool {

--- a/frontend/rust-lib/flowy-database2/src/services/cell/type_cell_data.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/cell/type_cell_data.rs
@@ -82,8 +82,6 @@ impl TypeCellData {
 
   pub fn is_date(&self) -> bool {
     self.field_type == FieldType::DateTime
-      || self.field_type == FieldType::LastEditedTime
-      || self.field_type == FieldType::CreatedTime
   }
 
   pub fn is_single_select(&self) -> bool {

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/layout_deps.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/layout_deps.rs
@@ -51,7 +51,7 @@ impl DatabaseLayoutDepsResolver {
           .lock()
           .get_fields(None)
           .into_iter()
-          .find(|field| FieldType::from(field.field_type).is_date())
+          .find(|field| FieldType::from(field.field_type) == FieldType::DateTime)
         {
           Some(field) => {
             let layout_setting = CalendarLayoutSetting::new(field.id).into();

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option.rs
@@ -184,7 +184,10 @@ impl CellDataDecoder for NumberTypeOption {
     decoded_field_type: &FieldType,
     _field: &Field,
   ) -> FlowyResult<<Self as TypeOption>::CellData> {
-    if decoded_field_type.is_date() {
+    if decoded_field_type.is_date()
+      || decoded_field_type.is_created_time()
+      || decoded_field_type.is_last_edited_time()
+    {
       return Ok(Default::default());
     }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/timestamp_type_option/timestamp_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/timestamp_type_option/timestamp_type_option.rs
@@ -130,11 +130,8 @@ impl CellDataDecoder for TimestampTypeOption {
     decoded_field_type: &FieldType,
     _field: &Field,
   ) -> FlowyResult<<Self as TypeOption>::CellData> {
-    // Return default data if the type_option_cell_data is not FieldType::DateTime.
-    // It happens when switching from one field to another.
-    // For example:
-    // FieldType::RichText -> FieldType::DateTime, it will display empty content on the screen.
-    if !decoded_field_type.is_date() {
+    // Return default data if the type_option_cell_data is not FieldType::CreatedTime nor FieldType::LastEditedTime
+    if !decoded_field_type.is_last_edited_time() && !decoded_field_type.is_created_time() {
       return Ok(Default::default());
     }
 
@@ -177,7 +174,7 @@ impl TypeOptionCellDataFilter for TimestampTypeOption {
     field_type: &FieldType,
     cell_data: &<Self as TypeOption>::CellData,
   ) -> bool {
-    if !field_type.is_date() {
+    if !field_type.is_last_edited_time() && !field_type.is_created_time() {
       return true;
     }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
