### PR TITLE
fix: cannot open popovers

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
@@ -202,9 +202,9 @@ class PopoverState extends State<Popover> {
           showOverlay();
         }
       },
-      child: GestureDetector(
+      child: Listener(
         child: widget.child,
-        onTap: () {
+        onPointerDown: (_) {
           if (widget.triggerActions & PopoverTriggerFlags.click != 0) {
             showOverlay();
           }


### PR DESCRIPTION
The popovers in settings (Theme, Language, perhaps more) cannot trigger by clicking. This is a major regression from this PR: https://github.com/AppFlowy-IO/AppFlowy/pull/3380

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
