### PR TITLE
fix: some issues with the end date

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -40,6 +40,8 @@ class DateCellCalendarBloc
           didReceiveCellUpdate: (DateCellDataPB? cellData) {
             final (dateTime, endDateTime, time, endTime, includeTime, isRange) =
                 _dateDataFromCellData(cellData);
+            final newEnd =
+                isRange == state.isRange && isRange ? endDateTime : null;
             emit(
               state.copyWith(
                 dateTime: dateTime,
@@ -49,7 +51,7 @@ class DateCellCalendarBloc
                 includeTime: includeTime,
                 isRange: isRange,
                 startDay: isRange ? dateTime : null,
-                endDay: isRange ? endDateTime : null,
+                endDay: newEnd,
               ),
             );
           },
@@ -78,7 +80,16 @@ class DateCellCalendarBloc
             await _updateDateData(time: time);
           },
           selectDateRange: (DateTime? start, DateTime? end) async {
-            if (end == null) {
+            if (end == null && state.startDay != null && state.endDay == null) {
+              final (newStart, newEnd) = state.startDay!.isBefore(start!)
+                  ? (state.startDay!, start)
+                  : (start, state.startDay!);
+              emit(state.copyWith(startDay: null, endDay: null));
+              await _updateDateData(
+                date: newStart.toLocal().date,
+                endDate: newEnd.toLocal().date,
+              );
+            } else if (end == null) {
               emit(state.copyWith(startDay: start, endDay: null));
             } else {
               await _updateDateData(
@@ -313,15 +324,22 @@ class DateCellCalendarEvent with _$DateCellCalendarEvent {
 @freezed
 class DateCellCalendarState with _$DateCellCalendarState {
   const factory DateCellCalendarState({
+    // the date field's type option
     required DateTypeOptionPB dateTypeOptionPB,
+
+    // used when selecting a date range
     required DateTime? startDay,
     required DateTime? endDay,
+
+    // cell data from the backend
     required DateTime? dateTime,
     required DateTime? endDateTime,
     required String? time,
     required String? endTime,
     required bool includeTime,
     required bool isRange,
+
+    // error and hint text
     required String? parseTimeError,
     required String? parseEndTimeError,
     required String timeHintText,
@@ -365,7 +383,7 @@ String _timeHintText(DateTypeOptionPB typeOption) {
   DateCellDataPB? cellData,
 ) {
   // a null DateCellDataPB may be returned, indicating that all the fields are
-  // at their default values: empty strings and false booleans
+  // their default values: empty strings and false booleans
   if (cellData == null) {
     return (null, null, null, null, false, false);
   }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_cal_bloc.dart
@@ -40,7 +40,7 @@ class DateCellCalendarBloc
           didReceiveCellUpdate: (DateCellDataPB? cellData) {
             final (dateTime, endDateTime, time, endTime, includeTime, isRange) =
                 _dateDataFromCellData(cellData);
-            final newEnd =
+            final endDay =
                 isRange == state.isRange && isRange ? endDateTime : null;
             emit(
               state.copyWith(
@@ -51,7 +51,7 @@ class DateCellCalendarBloc
                 includeTime: includeTime,
                 isRange: isRange,
                 startDay: isRange ? dateTime : null,
-                endDay: newEnd,
+                endDay: endDay,
               ),
             );
           },

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -177,7 +177,7 @@ class _DatePickerState extends State<DatePicker> {
       builder: (context, state) {
         final textStyle = Theme.of(context).textTheme.bodyMedium!;
         final boxDecoration = BoxDecoration(
-          color: Theme.of(context).colorScheme.surface,
+          color: Theme.of(context).cardColor,
           shape: BoxShape.circle,
         );
         return Padding(

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -100,55 +100,32 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final List<Widget> children = [
+      StartTextField(popoverMutex: popoverMutex),
+      EndTextField(popoverMutex: popoverMutex),
+      const DatePicker(),
+      const TypeOptionSeparator(spacing: 12.0),
+      const EndTimeButton(),
+      const VSpace(4.0),
+      const _IncludeTimeButton(),
+      const TypeOptionSeparator(spacing: 8.0),
+      DateTypeOptionButton(popoverMutex: popoverMutex),
+      const VSpace(4.0),
+      const ClearDateButton(),
+    ];
+
     return BlocProvider(
       create: (context) => DateCellCalendarBloc(
         dateTypeOptionPB: widget.dateTypeOptionPB,
         cellData: widget.cellContext.getCellData(),
         cellController: widget.cellContext,
       )..add(const DateCellCalendarEvent.initial()),
-      child: BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
-        builder: (context, state) {
-          final List<Widget> children = [
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 300),
-              child: state.includeTime
-                  ? _TimeTextField(
-                      isEndTime: false,
-                      timeStr: state.time,
-                      popoverMutex: popoverMutex,
-                    )
-                  : const SizedBox.shrink(),
-            ),
-            if (state.includeTime && state.isRange) const VSpace(8.0),
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 300),
-              child: state.includeTime && state.isRange
-                  ? _TimeTextField(
-                      isEndTime: true,
-                      timeStr: state.endTime,
-                      popoverMutex: popoverMutex,
-                    )
-                  : const SizedBox.shrink(),
-            ),
-            const DatePicker(),
-            const TypeOptionSeparator(spacing: 12.0),
-            const EndTimeButton(),
-            const VSpace(4.0),
-            const _IncludeTimeButton(),
-            const TypeOptionSeparator(spacing: 8.0),
-            DateTypeOptionButton(popoverMutex: popoverMutex),
-            const VSpace(4.0),
-            const ClearDateButton(),
-          ];
-
-          return ListView.builder(
-            shrinkWrap: true,
-            controller: ScrollController(),
-            itemCount: children.length,
-            itemBuilder: (BuildContext context, int index) => children[index],
-            padding: const EdgeInsets.only(top: 18.0, bottom: 12.0),
-          );
-        },
+      child: ListView.builder(
+        shrinkWrap: true,
+        controller: ScrollController(),
+        itemCount: children.length,
+        itemBuilder: (BuildContext context, int index) => children[index],
+        padding: const EdgeInsets.only(top: 18.0, bottom: 12.0),
       ),
     );
   }
@@ -157,6 +134,55 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
   void dispose() {
     popoverMutex.dispose();
     super.dispose();
+  }
+}
+
+class StartTextField extends StatelessWidget {
+  final PopoverMutex popoverMutex;
+  const StartTextField({super.key, required this.popoverMutex});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
+      builder: (context, state) {
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: state.includeTime
+              ? _TimeTextField(
+                  isEndTime: false,
+                  timeStr: state.time,
+                  popoverMutex: popoverMutex,
+                )
+              : const SizedBox.shrink(),
+        );
+      },
+    );
+  }
+}
+
+class EndTextField extends StatelessWidget {
+  final PopoverMutex popoverMutex;
+  const EndTextField({super.key, required this.popoverMutex});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<DateCellCalendarBloc, DateCellCalendarState>(
+      builder: (context, state) {
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          child: state.includeTime && state.isRange
+              ? Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: _TimeTextField(
+                    isEndTime: true,
+                    timeStr: state.endTime,
+                    popoverMutex: popoverMutex,
+                  ),
+                )
+              : const SizedBox.shrink(),
+        );
+      },
+    );
   }
 }
 

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/date_cell/date_editor.dart
@@ -100,32 +100,30 @@ class _CellCalendarWidgetState extends State<_CellCalendarWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> children = [
-      StartTextField(popoverMutex: popoverMutex),
-      EndTextField(popoverMutex: popoverMutex),
-      const DatePicker(),
-      const TypeOptionSeparator(spacing: 12.0),
-      const EndTimeButton(),
-      const VSpace(4.0),
-      const _IncludeTimeButton(),
-      const TypeOptionSeparator(spacing: 8.0),
-      DateTypeOptionButton(popoverMutex: popoverMutex),
-      const VSpace(4.0),
-      const ClearDateButton(),
-    ];
-
     return BlocProvider(
       create: (context) => DateCellCalendarBloc(
         dateTypeOptionPB: widget.dateTypeOptionPB,
         cellData: widget.cellContext.getCellData(),
         cellController: widget.cellContext,
       )..add(const DateCellCalendarEvent.initial()),
-      child: ListView.builder(
-        shrinkWrap: true,
-        controller: ScrollController(),
-        itemCount: children.length,
-        itemBuilder: (BuildContext context, int index) => children[index],
+      child: Padding(
         padding: const EdgeInsets.only(top: 18.0, bottom: 12.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            StartTextField(popoverMutex: popoverMutex),
+            EndTextField(popoverMutex: popoverMutex),
+            const DatePicker(),
+            const TypeOptionSeparator(spacing: 12.0),
+            const EndTimeButton(),
+            const VSpace(4.0),
+            const _IncludeTimeButton(),
+            const TypeOptionSeparator(spacing: 8.0),
+            DateTypeOptionButton(popoverMutex: popoverMutex),
+            const VSpace(4.0),
+            const ClearDateButton(),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
- color of the unselected days in darkmode. It should blend into the background now
- a day selected -> toggle end date -> click on another one . This should immediately set the range
- reorganized the editor to not rebuild everything in the top-level bloc builder. Without this, toggling include time will reset the focused day to this month. (sorry Mathias)

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
