### PR TITLE
fix: still show drag icon while dragging

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/row_property.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/row_property.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database_view/application/cell/cell_service.dart';
@@ -67,9 +69,11 @@ class RowPropertyList extends StatelessWidget {
             child: Stack(
               children: [
                 child,
-                const MouseRegion(
-                  cursor: SystemMouseCursors.grabbing,
-                  child: SizedBox(
+                MouseRegion(
+                  cursor: Platform.isWindows
+                      ? SystemMouseCursors.click
+                      : SystemMouseCursors.grabbing,
+                  child: const SizedBox(
                     width: 16,
                     height: 30,
                     child: FlowySvg(FlowySvgs.drag_element_s),
@@ -142,7 +146,9 @@ class _PropertyCellState extends State<_PropertyCell> {
     final cell = widget.cellBuilder.build(widget.cellContext, style: style);
 
     final dragThumb = MouseRegion(
-      cursor: SystemMouseCursors.grab,
+      cursor: Platform.isWindows
+          ? SystemMouseCursors.click
+          : SystemMouseCursors.grab,
       child: SizedBox(
         width: 16,
         height: 30,

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/row_property.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/row_property.dart
@@ -67,7 +67,14 @@ class RowPropertyList extends StatelessWidget {
             child: Stack(
               children: [
                 child,
-                const MouseRegion(cursor: SystemMouseCursors.grabbing),
+                const MouseRegion(
+                  cursor: SystemMouseCursors.grabbing,
+                  child: SizedBox(
+                    width: 16,
+                    height: 30,
+                    child: FlowySvg(FlowySvgs.drag_element_s),
+                  ),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
refer to the video in https://github.com/AppFlowy-IO/AppFlowy/pull/3328 the drag icon disappears when the drag starts.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
