### PR TITLE
fix:The placeholder text for URL cells shouldn't be underlined

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/url_cell/url_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/url_cell/url_cell.dart
@@ -158,7 +158,9 @@ class _GridURLCellState extends GridEditableTextCell<GridURLCell> {
                       Theme.of(context).textTheme.bodyMedium)
                   ?.copyWith(
                 color: Theme.of(context).colorScheme.primary,
-                decoration: TextDecoration.underline,
+                decoration: _controller.text != ""
+                    ? TextDecoration.underline
+                    : TextDecoration.none,
               ),
               autofocus: false,
               decoration: InputDecoration(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->
[Bug] The placeholder text for URL cells shouldn't be underlined #3411

when the field is empty
<img width="775" alt="Screenshot 2023-10-01 at 7 25 44 PM" src="https://github.com/AppFlowy-IO/AppFlowy/assets/68163548/02faa315-9bc2-42b9-9f7e-64f8d5d524da">

When there is a text
<img width="775" alt="Screenshot 2023-10-01 at 7 26 04 PM" src="https://github.com/AppFlowy-IO/AppFlowy/assets/68163548/b68b7347-6780-4d8f-bec1-03ef0caae961">

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to the [AppFlowy Style Guide](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/software-contributions/submitting-code/style-guides)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
