### PR TITLE
fix:Updating UI

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/openai/widgets/auto_completion_node_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/openai/widgets/auto_completion_node_widget.dart
@@ -168,7 +168,6 @@ class _AutoCompletionBlockComponentState
     return FlowyTextField(
       hintText: LocaleKeys.document_plugins_autoGeneratorHintText.tr(),
       controller: controller,
-      maxLines: 3,
       focusNode: textFieldFocusNode,
       autoFocus: false,
     );

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -114,7 +114,7 @@ class FlowyTextFieldState extends State<FlowyTextField> {
       decoration: InputDecoration(
         constraints: BoxConstraints(
             maxHeight: widget.errorText?.isEmpty ?? true ? 32 : 58),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 12,vertical: 10),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 15,vertical: 12),
         enabledBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: Theme.of(context).colorScheme.outline,

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -20,7 +20,6 @@ class FlowyTextField extends StatefulWidget {
   final bool submitOnLeave;
   final Duration? debounceDuration;
   final String? errorText;
-  final int maxLines;
 
   const FlowyTextField({
     this.hintText = "",
@@ -38,7 +37,6 @@ class FlowyTextField extends StatefulWidget {
     this.submitOnLeave = false,
     this.debounceDuration,
     this.errorText,
-    this.maxLines = 1,
     Key? key,
   }) : super(key: key);
 
@@ -68,6 +66,7 @@ class FlowyTextFieldState extends State<FlowyTextField> {
             TextPosition(offset: controller.text.length));
       });
     }
+
     super.initState();
   }
 
@@ -88,7 +87,6 @@ class FlowyTextFieldState extends State<FlowyTextField> {
   void _onSubmitted(String text) {
     widget.onSubmitted?.call(text);
     if (widget.autoClearWhenDone) {
-      // using `controller.clear()` instead of `controller.text = ''` which will crash on Windows.
       controller.clear();
     }
   }
@@ -107,14 +105,15 @@ class FlowyTextFieldState extends State<FlowyTextField> {
       },
       onSubmitted: (text) => _onSubmitted(text),
       onEditingComplete: widget.onEditingComplete,
-      maxLines: widget.maxLines,
       maxLength: widget.maxLength,
       maxLengthEnforcement: MaxLengthEnforcement.truncateAfterCompositionEnds,
       style: widget.textStyle ?? Theme.of(context).textTheme.bodySmall,
+      keyboardType: TextInputType.multiline,
+      maxLines: null,
       decoration: InputDecoration(
-        constraints: BoxConstraints(
-            maxHeight: widget.errorText?.isEmpty ?? true ? 32 : 58),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 15,vertical: 12),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 13),
+        isDense: true,
         enabledBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: Theme.of(context).colorScheme.outline,
@@ -122,7 +121,6 @@ class FlowyTextFieldState extends State<FlowyTextField> {
           ),
           borderRadius: Corners.s8Border,
         ),
-        isDense: false,
         hintText: widget.hintText,
         errorText: widget.errorText,
         errorStyle: Theme.of(context)

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text_field.dart
@@ -114,7 +114,7 @@ class FlowyTextFieldState extends State<FlowyTextField> {
       decoration: InputDecoration(
         constraints: BoxConstraints(
             maxHeight: widget.errorText?.isEmpty ?? true ? 32 : 58),
-        contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12,vertical: 10),
         enabledBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: Theme.of(context).colorScheme.outline,


### PR DESCRIPTION
Added vertical padding because the text was appearing too close to the top.

Before:
![Before Screenshot](https://github.com/SUNIL-RAGHU/AppFlowy/assets/89726488/2f93adee-e0aa-4643-b122-085c17136b66)

After:
![After Screenshot](https://github.com/SUNIL-RAGHU/AppFlowy/assets/89726488/6ef7c244-5fc3-4f6d-88ad-c6d682e6311c)

In this commit, I adjusted the content padding to include both horizontal and vertical padding in order to improve the visual appearance. The text was previously too close to the top, which could lead to readability issues. This change enhances the overall user experience by providing better spacing.

- Modified contentPadding in the relevant widget.
- Included 'horizontal' and 'vertical' parameters with appropriate values.

Screenshots have been included for visual comparison between the original and modified layouts.
