### PR TITLE
fix: missing dependency in appimage

### DIFF
--- a/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
+++ b/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
@@ -47,6 +47,7 @@ AppDir:
         main
     include:
     - libc6:amd64
+    - libnotify4:amd64
   files:
     include: []
     exclude:


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

**flathub**
https://github.com/flathub/io.appflowy.AppFlowy/pull/63/files

**snap**
https://github.com/LucasXu0/appflowy-snap/commit/ea980685b1746fe5c38e435363ee16c133c8e284

**appimage**
this PR.

**tar.gz**
```
sudo apt-get install libnotify4
```

or 

```
sudo dnf install libnotify
```

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
