### PR TITLE
feat: add lemonade theme color

### DIFF
--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/colorscheme.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/colorscheme.dart
@@ -6,6 +6,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'default_colorscheme.dart';
 import 'dandelion.dart';
 import 'lavender.dart';
+import 'lemonade.dart';
 
 part 'colorscheme.g.dart';
 
@@ -22,6 +23,10 @@ const Map<String, List<FlowyColorScheme>> themeMap = {
   BuiltInTheme.dandelion: [
     DandelionColorScheme.light(),
     DandelionColorScheme.dark(),
+  ],
+  BuiltInTheme.lemonade: [
+    LemonadeColorScheme.light(),
+    LemonadeColorScheme.dark(),
   ],
   BuiltInTheme.lavender: [
     LavenderColorScheme.light(),

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/lemonade.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/lemonade.dart
@@ -11,7 +11,6 @@ const _lightShader5 = Color(0xffe0e0e0);
 const _lightShader6 = Color(0xfff2f2f2);
 const _lightDandelionYellow = Color(0xffffcb00);
 const _lightDandelionLightYellow = Color(0xffffdf66);
-const _lightDandelionGreen = Color(0xff9bc53d);
 const _lightTint9 = Color(0xffe1fbff);
 
 const _darkShader1 = Color(0xff131720);
@@ -22,8 +21,11 @@ const _darkShader6 = Color(0xffF2F2F2);
 const _darkMain1 = Color(0xffffcb00);
 const _darkInput = Color(0xff282E3A);
 
-class DandelionColorScheme extends FlowyColorScheme {
-  const DandelionColorScheme.light()
+// Derive from [DandelionColorScheme]
+// Use a light yellow color in the sidebar intead of a green color in Dandelion
+// Some field name are still included 'Dandelion' to indicate they are the same color as the one in Dandelion
+class LemonadeColorScheme extends FlowyColorScheme {
+  const LemonadeColorScheme.light()
       : super(
           surface: Colors.white,
           hover: const Color(0xFFe0f8ff),
@@ -57,8 +59,8 @@ class DandelionColorScheme extends FlowyColorScheme {
           main1: _lightDandelionYellow,
           // cursor color
           main2: _lightDandelionYellow,
-          shadow: const Color.fromRGBO(0, 0, 0, 0.15),
-          sidebarBg: _lightDandelionGreen,
+          shadow: _black,
+          sidebarBg: const Color(0xfffaf0c8),
           divider: _lightShader6,
           topbarBg: _white,
           icon: _lightShader1,
@@ -81,7 +83,7 @@ class DandelionColorScheme extends FlowyColorScheme {
           gridRowCountColor: _black,
         );
 
-  const DandelionColorScheme.dark()
+  const LemonadeColorScheme.dark()
       : super(
           surface: const Color(0xff292929),
           hover: const Color(0xff1f1f1f),
@@ -111,8 +113,8 @@ class DandelionColorScheme extends FlowyColorScheme {
           tint9: const Color(0x4d0029FF),
           main1: _darkMain1,
           main2: _darkMain1,
-          shadow: const Color(0xff0F131C),
-          sidebarBg: const Color(0xff25300e),
+          shadow: _black,
+          sidebarBg: const Color(0xff232B38),
           divider: _darkShader3,
           topbarBg: _darkShader1,
           icon: _darkShader5,

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/theme.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/theme.dart
@@ -5,6 +5,7 @@ import 'plugins/service/plugin_service.dart';
 class BuiltInTheme {
   static const String defaultTheme = 'Default';
   static const String dandelion = 'Dandelion';
+  static const String lemonade = 'Lemonade';
   static const String lavender = 'Lavender';
 }
 

--- a/frontend/appflowy_flutter/test/unit_test/theme/theme_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/theme/theme_test.dart
@@ -47,6 +47,7 @@ void main() {
             BuiltInTheme.defaultTheme,
             BuiltInTheme.dandelion,
             BuiltInTheme.lavender,
+            BuiltInTheme.lemonade,
           ]),
         );
         expect(theme.lightTheme, isA<FlowyColorScheme>());


### PR DESCRIPTION
I made option B in #3550 become a new color theme called `Lemonade`. 

I changed the sidebar color to a deep green color in the dandelion theme to distinguish the dark mode for dandelion and lemonade. It is the only difference between these two dark modes so far. 

### Feature Preview
Lemonade theme in light mode:

<img width="1139" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/7d4261c5-789c-4fc9-873f-97a745d27c4b">


Lemonade theme in dark mode:
<img width="1145" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/539ceaa3-9d76-4c8d-a296-695f588f4c4f">

Dandelion theme in light mode(no change in this PR):
<img width="1143" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/cb451868-adac-49c8-8fe8-599ea66ef300">

Dandelion theme in dark mode(only sidebar color changed)
<img width="1142" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/4a8015b3-ad03-42dc-8123-e778a1f1c60d">

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->



<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
