### PR TITLE
fix: Shortcut settings Reset to default is missing bottom margin #3710

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_customize_shortcuts_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_customize_shortcuts_view.dart
@@ -93,7 +93,8 @@ class ShortcutsListView extends StatelessWidget {
               },
             ),
           ],
-        )
+        ),
+        const VSpace(10),
       ],
     );
   }


### PR DESCRIPTION
bug: #3710
![button fixed](https://github.com/AppFlowy-IO/AppFlowy/assets/99664282/81840a01-f69a-4600-b878-13ed1d57b469)


<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview
Fixed missing bottom margin of "Reset to default" button in  Shortcut settings.
<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [:heavy_check_mark:] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [:heavy_check_mark: ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
