### PR TITLE
fix: board unit test fix

### DIFF
--- a/frontend/appflowy_flutter/test/bloc_test/board_test/create_card_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/create_card_test.dart
@@ -20,9 +20,9 @@ void main() {
     )..add(const BoardEvent.initial());
     await boardResponseFuture();
 
-    final groupId = boardBloc.state.groupIds.first;
+    final groupId = boardBloc.state.groupIds.last;
 
-    // the group at index 0 is the 'No status' group;
+    // the group at index 3 is the 'No status' group;
     assert(boardBloc.groupControllers[groupId]!.group.rows.isEmpty);
     assert(
       boardBloc.state.groupIds.length == 4,

--- a/frontend/appflowy_flutter/test/bloc_test/board_test/create_card_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/create_card_test.dart
@@ -29,7 +29,7 @@ void main() {
       'but receive ${boardBloc.state.groupIds.length}',
     );
 
-    boardBloc.add(BoardEvent.createBottomRow(boardBloc.state.groupIds[0]));
+    boardBloc.add(BoardEvent.createBottomRow(boardBloc.state.groupIds[3]));
     await boardResponseFuture();
 
     assert(

--- a/frontend/appflowy_flutter/test/bloc_test/board_test/group_by_multi_select_field_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/group_by_multi_select_field_test.dart
@@ -39,7 +39,7 @@ void main() {
     );
     await boardResponseFuture();
 
-    //assert only have the 'No status' group
+    // assert only have the 'No status' group
     final boardBloc = BoardBloc(
       view: context.gridView,
       databaseController: DatabaseController(view: context.gridView),
@@ -107,8 +107,8 @@ void main() {
 
     final groups =
         boardBloc.groupControllers.values.map((e) => e.group).toList();
-    assert(groups[0].groupName == "No ${multiSelectField.name}");
-    assert(groups[1].groupName == "B");
-    assert(groups[2].groupName == "A");
+    assert(groups[0].groupName == "B");
+    assert(groups[1].groupName == "A");
+    assert(groups[2].groupName == "No ${multiSelectField.name}");
   });
 }


### PR DESCRIPTION
the ungrouped-item-stack is now positioned last, so tests need to be adjusted

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
