### PR TITLE
fix: removed the parent padding and instead applied padding individually.

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar.dart
@@ -87,6 +87,7 @@ class HomeSideBar extends StatelessWidget {
     List<ViewPB> views,
     List<ViewPB> favoriteViews,
   ) {
+    const menuHorizontalInset = EdgeInsets.symmetric(horizontal: 12);
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceVariant,
@@ -100,19 +101,19 @@ class HomeSideBar extends StatelessWidget {
         children: [
           // top menu
           const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 12),
+            padding: menuHorizontalInset,
             child: SidebarTopMenu(),
           ),
           // user, setting
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
+            padding: menuHorizontalInset,
             child: SidebarUser(user: user, views: views),
           ),
           const VSpace(20),
           // scrollable document list
           Expanded(
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
+              padding: menuHorizontalInset,
               child: SingleChildScrollView(
                 child: SidebarFolder(
                   views: views,
@@ -124,7 +125,7 @@ class HomeSideBar extends StatelessWidget {
           const VSpace(10),
           // trash
           const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 12),
+            padding: menuHorizontalInset,
             child: SidebarTrashButton(),
           ),
           const VSpace(10),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar.dart
@@ -94,19 +94,25 @@ class HomeSideBar extends StatelessWidget {
           right: BorderSide(color: Theme.of(context).dividerColor),
         ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            // top menu
-            const SidebarTopMenu(),
-            // user, setting
-            SidebarUser(user: user, views: views),
-            const VSpace(20),
-            // scrollable document list
-            Expanded(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          // top menu
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12),
+            child: SidebarTopMenu(),
+          ),
+          // user, setting
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: SidebarUser(user: user, views: views),
+          ),
+          const VSpace(20),
+          // scrollable document list
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
               child: SingleChildScrollView(
                 child: SidebarFolder(
                   views: views,
@@ -114,17 +120,17 @@ class HomeSideBar extends StatelessWidget {
                 ),
               ),
             ),
-            const VSpace(10),
-            // trash
-            const SidebarTrashButton(),
-            const VSpace(10),
-            // new page button
-            const Padding(
-              padding: EdgeInsets.only(left: 6.0),
-              child: SidebarNewPageButton(),
-            ),
-          ],
-        ),
+          ),
+          const VSpace(10),
+          // trash
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12),
+            child: SidebarTrashButton(),
+          ),
+          const VSpace(10),
+          // new page button
+          const SidebarNewPageButton(),
+        ],
       ),
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_new_page_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_new_page_button.dart
@@ -49,7 +49,7 @@ class SidebarNewPageButton extends StatelessWidget {
       child: TopBorder(
         color: Theme.of(context).dividerColor,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.symmetric(horizontal: 18),
           child: child,
         ),
       ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_new_page_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_new_page_button.dart
@@ -48,7 +48,10 @@ class SidebarNewPageButton extends StatelessWidget {
       height: 60,
       child: TopBorder(
         color: Theme.of(context).dividerColor,
-        child: child,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: child,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Fixes #3389 

The divider is now starting from the window and stretching to the edge of the Sidebar without hindering with rest of the Sidebar UI.

<img width="354" alt="Screenshot 2023-10-27 at 5 18 43 PM" src="https://github.com/AppFlowy-IO/AppFlowy/assets/42487588/5513e553-b0a5-4ded-97a1-1561c704ba1f">
<img width="354" alt="Screenshot 2023-10-27 at 5 18 56 PM" src="https://github.com/AppFlowy-IO/AppFlowy/assets/42487588/b9aa129f-fb9c-442f-8e7e-88c19875a1fa">

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->
<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
