### PR TITLE
chore: share button text color in document

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/share/share_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/share/share_button.dart
@@ -112,7 +112,7 @@ class ShareActionListState extends State<ShareActionList> {
         return RoundedTextButton(
           title: LocaleKeys.shareAction_buttonText.tr(),
           onPressed: () => controller.show(),
-          textColor: Theme.of(context).colorScheme.onSurface,
+          textColor: Theme.of(context).colorScheme.onPrimary,
         );
       },
       onSelected: (action, controller) async {


### PR DESCRIPTION
This PR makes the text color uniform with the one for database views

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
