### PR TITLE
fix: padding issue with the select tags

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/select_option_cell/extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/select_option_cell/extension.dart
@@ -5,7 +5,6 @@ import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra/size.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flowy_infra_ui/style_widget/icon_button.dart';
-import 'package:flowy_infra_ui/style_widget/text.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -93,7 +92,7 @@ class SelectOptionTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     EdgeInsets padding =
-        const EdgeInsets.symmetric(vertical: 1.5, horizontal: 8.0);
+        const EdgeInsets.symmetric(vertical: 2, horizontal: 8.0);
     if (onRemove != null) {
       padding = padding.copyWith(right: 2.0);
     }
@@ -108,11 +107,13 @@ class SelectOptionTag extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
-            child: FlowyText.medium(
+            child: Text(
               name,
-              fontSize: FontSizes.s11,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontSize: FontSizes.s11,
+                    color: AFThemeExtension.of(context).textColor,
+                  ),
               overflow: TextOverflow.ellipsis,
-              color: AFThemeExtension.of(context).textColor,
             ),
           ),
           if (onRemove != null) ...[

--- a/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/select_option_cell/extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/widgets/row/cells/select_option_cell/extension.dart
@@ -3,9 +3,8 @@ import 'package:appflowy_backend/protobuf/flowy-database2/select_option.pb.dart'
 
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra/size.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
-import 'package:flowy_infra_ui/style_widget/icon_button.dart';
-import 'package:flowy_infra_ui/widget/spacing.dart';
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
@@ -107,13 +106,11 @@ class SelectOptionTag extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
-            child: Text(
+            child: FlowyText.medium(
               name,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontSize: FontSizes.s11,
-                    color: AFThemeExtension.of(context).textColor,
-                  ),
+              fontSize: FontSizes.s11,
               overflow: TextOverflow.ellipsis,
+              color: AFThemeExtension.of(context).textColor,
             ),
           ),
           if (onRemove != null) ...[

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 class FlowyText extends StatelessWidget {
@@ -89,10 +91,12 @@ class FlowyText extends StatelessWidget {
         maxLines: maxLines,
         textAlign: textAlign,
         overflow: overflow ?? TextOverflow.clip,
-        textHeightBehavior: const TextHeightBehavior(
-          applyHeightToFirstAscent: false,
-          applyHeightToLastDescent: false,
-        ),
+        textHeightBehavior: Platform.isAndroid || Platform.isIOS
+            ? const TextHeightBehavior(
+                applyHeightToFirstAscent: false,
+                applyHeightToLastDescent: false,
+              )
+            : null,
         style: Theme.of(context).textTheme.bodyMedium!.copyWith(
               fontSize: fontSize,
               fontWeight: fontWeight,


### PR DESCRIPTION
`FlowyText` has a special behavior with the `TextHeightBehavior`. Also bump the vertical padding from 1.5 to 2.0

Before
![Screenshot 2023-11-13 at 6 04 18 PM](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/a725f662-628c-406e-ad9c-dabf91c89be0)

After
![Screenshot 2023-11-13 at 6 04 01 PM](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/307ee959-5958-4220-8a67-74c011871726)



### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
