### PR TITLE
fix: mobile url cell focusnode fix

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/row/cells/mobile_url_cell.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/row/cells/mobile_url_cell.dart
@@ -26,6 +26,7 @@ class MobileURLCell extends GridCellWidget {
 
 class _GridURLCellState extends GridCellState<MobileURLCell> {
   late final URLCellBloc _cellBloc;
+  final FocusNode _focusNode = FocusNode();
 
   @override
   void initState() {
@@ -39,6 +40,7 @@ class _GridURLCellState extends GridCellState<MobileURLCell> {
   @override
   Future<void> dispose() async {
     _cellBloc.close();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -51,6 +53,7 @@ class _GridURLCellState extends GridCellState<MobileURLCell> {
         builder: (context, content) {
           if (content.isEmpty) {
             return TextField(
+              focusNode: _focusNode,
               keyboardType: TextInputType.url,
               decoration: InputDecoration(
                 enabledBorder: InputBorder.none,
@@ -62,11 +65,8 @@ class _GridURLCellState extends GridCellState<MobileURLCell> {
               // close keyboard when tapping outside of the text field
               onTapOutside: (event) =>
                   FocusManager.instance.primaryFocus?.unfocus(),
-              onSubmitted: (value) {
-                _cellBloc.add(
-                  URLCellEvent.updateURL(value),
-                );
-              },
+              onSubmitted: (value) =>
+                  _cellBloc.add(URLCellEvent.updateURL(value)),
             );
           }
 
@@ -92,9 +92,7 @@ class _GridURLCellState extends GridCellState<MobileURLCell> {
                     autofocus: true,
                     keyboardType: TextInputType.url,
                     onEditingComplete: () {
-                      _cellBloc.add(
-                        URLCellEvent.updateURL(controller.text),
-                      );
+                      _cellBloc.add(URLCellEvent.updateURL(controller.text));
                       context.pop();
                     },
                   );
@@ -115,5 +113,7 @@ class _GridURLCellState extends GridCellState<MobileURLCell> {
   }
 
   @override
-  void requestBeginFocus() {}
+  void requestBeginFocus() {
+    _focusNode.requestFocus();
+  }
 }


### PR DESCRIPTION
- When you press on a URL cell, no matter where in the internal padding of the cell, the textfield will be focused

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
