### PR TITLE
fix: date group_id generation logic

### DIFF
--- a/frontend/appflowy_flutter/linux/flutter/dart_ffi/binding.h
+++ b/frontend/appflowy_flutter/linux/flutter/dart_ffi/binding.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-int64_t init_sdk(char *path);
+int64_t init_sdk(char *data);
 
 void async_event(int64_t port, const uint8_t *input, uintptr_t len);
 

--- a/frontend/rust-lib/flowy-database2/src/services/group/controller_impls/date_controller.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/group/controller_impls/date_controller.rs
@@ -1,11 +1,7 @@
 use std::format;
-use std::str::FromStr;
 
 use async_trait::async_trait;
-use chrono::{
-  DateTime, Datelike, Days, Duration, Local, NaiveDate, NaiveDateTime, Offset, TimeZone,
-};
-use chrono_tz::Tz;
+use chrono::{DateTime, Datelike, Days, Duration, Local, NaiveDate, NaiveDateTime};
 use collab_database::database::timestamp;
 use collab_database::fields::{Field, TypeOptionData};
 use collab_database::rows::{new_cell_builder, Cell, Cells, Row, RowDetail};
@@ -84,12 +80,7 @@ impl GroupCustomize for DateGroupController {
     content: &str,
     cell_data: &<Self::GroupTypeOption as TypeOption>::CellData,
   ) -> bool {
-    content
-      == group_id(
-        cell_data,
-        &self.type_option,
-        &self.context.get_setting_content(),
-      )
+    content == group_id(cell_data, &self.context.get_setting_content())
   }
 
   fn create_or_delete_group_when_cell_changed(
@@ -102,15 +93,10 @@ impl GroupCustomize for DateGroupController {
     let mut inserted_group = None;
     if self
       .context
-      .get_group(&group_id(
-        &_cell_data.into(),
-        &self.type_option,
-        &setting_content,
-      ))
+      .get_group(&group_id(&_cell_data.into(), &setting_content))
       .is_none()
     {
-      let group =
-        make_group_from_date_cell(&_cell_data.into(), &self.type_option, &setting_content);
+      let group = make_group_from_date_cell(&_cell_data.into(), &setting_content);
       let mut new_group = self.context.add_new_group(group)?;
       new_group.group.rows.push(RowMetaPB::from(_row_detail));
       inserted_group = Some(new_group);
@@ -118,11 +104,9 @@ impl GroupCustomize for DateGroupController {
 
     // Delete the old group if there are no rows in that group
     let deleted_group = match _old_cell_data.and_then(|old_cell_data| {
-      self.context.get_group(&group_id(
-        &old_cell_data.into(),
-        &self.type_option,
-        &setting_content,
-      ))
+      self
+        .context
+        .get_group(&group_id(&old_cell_data.into(), &setting_content))
     }) {
       None => None,
       Some((_, group)) => {
@@ -154,7 +138,7 @@ impl GroupCustomize for DateGroupController {
     let setting_content = self.context.get_setting_content();
     self.context.iter_mut_status_groups(|group| {
       let mut changeset = GroupRowsNotificationPB::new(group.id.clone());
-      if group.id == group_id(&cell_data.into(), &self.type_option, &setting_content) {
+      if group.id == group_id(&cell_data.into(), &setting_content) {
         if !group.contains_row(&row_detail.row.id) {
           changeset
             .inserted_rows
@@ -194,14 +178,13 @@ impl GroupCustomize for DateGroupController {
     });
 
     let setting_content = self.context.get_setting_content();
-    let deleted_group =
-      match self
-        .context
-        .get_group(&group_id(cell_data, &self.type_option, &setting_content))
-      {
-        Some((_, group)) if group.rows.len() == 1 => Some(group.clone()),
-        _ => None,
-      };
+    let deleted_group = match self
+      .context
+      .get_group(&group_id(cell_data, &setting_content))
+    {
+      Some((_, group)) if group.rows.len() == 1 => Some(group.clone()),
+      _ => None,
+    };
 
     let deleted_group = deleted_group.map(|group| {
       let _ = self.context.delete_group(&group.id);
@@ -232,11 +215,10 @@ impl GroupCustomize for DateGroupController {
   ) -> Option<GroupPB> {
     let mut deleted_group = None;
     let setting_content = self.context.get_setting_content();
-    if let Some((_, group)) = self.context.get_group(&group_id(
-      &_cell_data.into(),
-      &self.type_option,
-      &setting_content,
-    )) {
+    if let Some((_, group)) = self
+      .context
+      .get_group(&group_id(&_cell_data.into(), &setting_content))
+    {
       if group.rows.len() == 1 {
         deleted_group = Some(GroupPB::from(group.clone()));
       }
@@ -279,7 +261,7 @@ impl GroupsBuilder for DateGroupBuilder {
   async fn build(
     field: &Field,
     context: &Self::Context,
-    type_option: &Self::GroupTypeOption,
+    _type_option: &Self::GroupTypeOption,
   ) -> GeneratedGroups {
     // Read all the cells for the grouping field
     let cells = context.get_all_cells().await;
@@ -290,7 +272,7 @@ impl GroupsBuilder for DateGroupBuilder {
       .flat_map(|value| value.into_date_field_cell_data())
       .filter(|cell| cell.timestamp.is_some())
       .map(|cell| {
-        let group = make_group_from_date_cell(&cell, type_option, &context.get_setting_content());
+        let group = make_group_from_date_cell(&cell, &context.get_setting_content());
         GeneratedGroupConfig {
           filter_content: group.id.clone(),
           group,
@@ -307,27 +289,19 @@ impl GroupsBuilder for DateGroupBuilder {
   }
 }
 
-fn make_group_from_date_cell(
-  cell_data: &DateCellData,
-  type_option: &DateTypeOption,
-  setting_content: &str,
-) -> Group {
-  let group_id = group_id(cell_data, type_option, setting_content);
+fn make_group_from_date_cell(cell_data: &DateCellData, setting_content: &str) -> Group {
+  let group_id = group_id(cell_data, setting_content);
   Group::new(
     group_id.clone(),
-    group_name_from_id(&group_id, type_option, setting_content),
+    group_name_from_id(&group_id, setting_content),
   )
 }
 
 const GROUP_ID_DATE_FORMAT: &str = "%Y/%m/%d";
 
-fn group_id(
-  cell_data: &DateCellData,
-  type_option: &DateTypeOption,
-  setting_content: &str,
-) -> String {
+fn group_id(cell_data: &DateCellData, setting_content: &str) -> String {
   let config = DateGroupConfiguration::from_json(setting_content).unwrap_or_default();
-  let date_time = date_time_from_timestamp(cell_data.timestamp, &type_option.timezone_id);
+  let date_time = date_time_from_timestamp(cell_data.timestamp);
 
   let date_format = GROUP_ID_DATE_FORMAT;
   let month_format = &date_format.replace("%d", "01");
@@ -342,7 +316,7 @@ fn group_id(
       .unwrap()
       .format(date_format),
     DateCondition::Relative => {
-      let now = date_time_from_timestamp(Some(timestamp()), &type_option.timezone_id).date_naive();
+      let now = date_time_from_timestamp(Some(timestamp())).date_naive();
       let date_time = date_time.date_naive();
 
       let diff = date_time.signed_duration_since(now).num_days();
@@ -382,11 +356,7 @@ fn group_id(
   date.to_string()
 }
 
-fn group_name_from_id(
-  group_id: &str,
-  type_option: &DateTypeOption,
-  setting_content: &str,
-) -> String {
+fn group_name_from_id(group_id: &str, setting_content: &str) -> String {
   let config = DateGroupConfiguration::from_json(setting_content).unwrap_or_default();
   let date = NaiveDate::parse_from_str(group_id, GROUP_ID_DATE_FORMAT).unwrap();
 
@@ -421,7 +391,7 @@ fn group_name_from_id(
     },
     DateCondition::Year => date.year().to_string(),
     DateCondition::Relative => {
-      let now = date_time_from_timestamp(Some(timestamp()), &type_option.timezone_id);
+      let now = date_time_from_timestamp(Some(timestamp()));
 
       let diff = date.signed_duration_since(now.date_naive());
       let result = match diff.num_days() {
@@ -443,14 +413,11 @@ fn group_name_from_id(
   }
 }
 
-fn date_time_from_timestamp(timestamp: Option<i64>, timezone_id: &str) -> DateTime<Local> {
+fn date_time_from_timestamp(timestamp: Option<i64>) -> DateTime<Local> {
   match timestamp {
     Some(timestamp) => {
       let naive = NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap();
-      let offset = match Tz::from_str(timezone_id) {
-        Ok(timezone) => timezone.offset_from_utc_datetime(&naive).fix(),
-        Err(_) => *Local::now().offset(),
-      };
+      let offset = *Local::now().offset();
 
       DateTime::<Local>::from_naive_utc_and_offset(naive, offset)
     },
@@ -480,12 +447,11 @@ mod tests {
 
   #[test]
   fn group_id_name_test() {
-    struct GroupIDTest<'a> {
+    struct GroupIDTest {
       cell_data: DateCellData,
       setting_content: String,
       exp_group_id: String,
       exp_group_name: String,
-      type_option: &'a DateTypeOption,
     }
 
     let mar_14_2022 = NaiveDateTime::from_timestamp_opt(1647251762, 0).unwrap();
@@ -505,7 +471,6 @@ mod tests {
     let tests = vec![
       GroupIDTest {
         cell_data: mar_14_2022_cd.clone(),
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 0, "hide_empty": false}"#.to_string(),
         exp_group_id: "2022/03/01".to_string(),
         exp_group_name: "Mar 2022".to_string(),
@@ -516,7 +481,6 @@ mod tests {
           include_time: false,
           ..Default::default()
         },
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 0, "hide_empty": false}"#.to_string(),
         exp_group_id: today.format(GROUP_ID_DATE_FORMAT).to_string(),
         exp_group_name: "Today".to_string(),
@@ -527,7 +491,6 @@ mod tests {
           include_time: false,
           ..Default::default()
         },
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 0, "hide_empty": false}"#.to_string(),
         exp_group_id: today
           .checked_sub_days(Days::new(7))
@@ -538,7 +501,6 @@ mod tests {
       },
       GroupIDTest {
         cell_data: mar_14_2022_cd.clone(),
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 1, "hide_empty": false}"#.to_string(),
         exp_group_id: "2022/03/14".to_string(),
         exp_group_name: "Mar 14, 2022".to_string(),
@@ -554,21 +516,18 @@ mod tests {
           include_time: false,
           ..Default::default()
         },
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 2, "hide_empty": false}"#.to_string(),
         exp_group_id: "2022/03/14".to_string(),
         exp_group_name: "Week of Mar 14-20 2022".to_string(),
       },
       GroupIDTest {
         cell_data: mar_14_2022_cd.clone(),
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 3, "hide_empty": false}"#.to_string(),
         exp_group_id: "2022/03/01".to_string(),
         exp_group_name: "Mar 2022".to_string(),
       },
       GroupIDTest {
         cell_data: mar_14_2022_cd,
-        type_option: &local_date_type_option,
         setting_content: r#"{"condition": 4, "hide_empty": false}"#.to_string(),
         exp_group_id: "2022/01/01".to_string(),
         exp_group_name: "2022".to_string(),
@@ -579,7 +538,6 @@ mod tests {
           include_time: false,
           ..Default::default()
         },
-        type_option: &default_date_type_option,
         setting_content: r#"{"condition": 1, "hide_empty": false}"#.to_string(),
         exp_group_id: "2023/06/02".to_string(),
         exp_group_name: "".to_string(),
@@ -590,7 +548,6 @@ mod tests {
           include_time: false,
           ..Default::default()
         },
-        type_option: &default_date_type_option,
         setting_content: r#"{"condition": 1, "hide_empty": false}"#.to_string(),
         exp_group_id: "2023/06/03".to_string(),
         exp_group_name: "".to_string(),
@@ -598,11 +555,11 @@ mod tests {
     ];
 
     for (i, test) in tests.iter().enumerate() {
-      let group_id = group_id(&test.cell_data, test.type_option, &test.setting_content);
+      let group_id = group_id(&test.cell_data, &test.setting_content);
       assert_eq!(test.exp_group_id, group_id, "test {}", i);
 
       if !test.exp_group_name.is_empty() {
-        let group_name = group_name_from_id(&group_id, test.type_option, &test.setting_content);
+        let group_name = group_name_from_id(&group_id, &test.setting_content);
         assert_eq!(test.exp_group_name, group_name, "test {}", i);
       }
     }


### PR DESCRIPTION
initially discovered in `flowy-database2::tests::database::group_test::date_group_test::group_by_date_test` in California timezone any time around 5 PM local time.

Group building and determining the group of a row should only be done w.r.t the local time zone, not the time zone of the field.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
