### PR TITLE
chore: always require two lines in recent view

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
@@ -97,10 +97,20 @@ class _MobileRecentViewState extends State<MobileRecentView> {
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(8, 18, 8, 2),
-                    child: FlowyText.medium(
-                      view.name,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                    // hack: minLines currently not supported in Text widget.
+                    // https://github.com/flutter/flutter/issues/31134
+                    child: Stack(
+                      children: [
+                        FlowyText(
+                          view.name,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const FlowyText(
+                          "\n\n",
+                          maxLines: 2,
+                        ),
+                      ],
                     ),
                   ),
                 ),


### PR DESCRIPTION
Before: something like this

![screenshot_2023-12-02_at_19 47 01](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/0ecea69b-b951-497f-90d0-1afe8a1813dc)

After: something like this
![Screenshot_20231202-203706](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/4664f46f-b3c9-476a-8da4-f6e3702f79cd)


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
