### PR TITLE
chore: bump dart protobuf version

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_backend/pubspec.yaml
+++ b/frontend/appflowy_flutter/packages/appflowy_backend/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   ffi: ^2.0.2
   isolates: ^3.0.3+8
-  protobuf: ^2.0.0
+  protobuf: ^3.1.0
   dartz: ^0.10.1
   freezed_annotation:
   logger: ^1.0.0

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -1318,10 +1318,10 @@ packages:
     dependency: "direct main"
     description:
       name: protobuf
-      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.1.0"
   provider:
     dependency: "direct main"
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -83,7 +83,7 @@ dependencies:
   hotkey_manager: ^0.1.7
   fixnum: ^1.1.0
   flutter_svg: ^2.0.7
-  protobuf: ^2.1.0
+  protobuf: ^3.1.0
   charcode: ^1.3.1
   collection: ^1.17.1
   bloc: ^8.1.2

--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -sSfL \
     rm flutter.tar.xz
 RUN flutter config --enable-linux-desktop
 RUN flutter doctor
-RUN dart pub global activate protoc_plugin 20.0.1
+RUN dart pub global activate protoc_plugin 21.1.2
 
 # Install build dependencies for AppFlowy
 RUN yay -S --noconfirm jemalloc4 cargo-make cargo-binstall

--- a/frontend/scripts/makefile/protobuf.toml
+++ b/frontend/scripts/makefile/protobuf.toml
@@ -23,8 +23,7 @@ windows_alias = "install-protobuf-windows"
 linux_alias = "install-protobuf"
 
 [tasks.install-protobuf]
-condition_script = [
-    """
+condition_script = ["""
     if ! command -v protoc-gen-dart
     then
         exit 0
@@ -32,8 +31,7 @@ condition_script = [
 
     # installed
     exit 1
-    """,
-]
+    """]
 run_task = { name = ["install_flutter_protobuf_compiler"] }
 
 [tasks.install-protobuf-windows]
@@ -45,7 +43,7 @@ if is_empty ${ret}
 end
 ret = which protoc-gen-dart
 if is_empty ${ret}
-    exec cmd.exe /c dart pub global activate protoc_plugin 20.0.1
+    exec cmd.exe /c dart pub global activate protoc_plugin 21.1.2
 end
 ret = which protoc-gen-dart
 if is_empty ${ret}
@@ -60,18 +58,13 @@ script_runner = "@duckscript"
 [tasks.install_flutter_protobuf_compiler]
 script = """
 echo "Install protoc_plugin (Dart)"
-dart pub global activate protoc_plugin 20.0.1
+dart pub global activate protoc_plugin 21.1.2
 """
 script_runner = "@shell"
 
 [tasks.install_flutter_protobuf_compiler.linux]
 script = """
 echo "Install protoc_plugin (Dart)"
-dart pub global activate protoc_plugin 20.0.1
+dart pub global activate protoc_plugin 21.1.2
 """
 script_runner = "@shell"
-
-
-
-
-


### PR DESCRIPTION
makes it compatible with protoc_plugin 21.x.x

before testing, run 

```shell
dart pub global activate protoc_plugin
```

and see that the version has changed to 21.x.x (currently latest at 21.1.2)
 
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
