### PR TITLE
feat: customized cursor and selection color

### DIFF
--- a/frontend/appflowy_flutter/lib/core/config/kv_keys.dart
+++ b/frontend/appflowy_flutter/lib/core/config/kv_keys.dart
@@ -24,6 +24,10 @@ class KVKeys {
       'kDocumentAppearanceFontFamily';
   static const String kDocumentAppearanceDefaultTextDirection =
       'kDocumentAppearanceDefaultTextDirection';
+  static const String kDocumentAppearanceCursorColor =
+      'kDocumentAppearanceCursorColor';
+  static const String kDocumentAppearanceSelectionColor =
+      'kDocumentAppearanceSelectionColor';
 
   /// The key for saving the expanded views
   ///

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -6,6 +6,7 @@ import 'package:appflowy/plugins/document/presentation/editor_plugins/mobile_too
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
 import 'package:appflowy/plugins/inline_actions/inline_actions_menu.dart';
 import 'package:appflowy/util/google_font_family_extension.dart';
+import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:appflowy_editor/appflowy_editor.dart' hide Log;
 import 'package:collection/collection.dart';
@@ -51,8 +52,10 @@ class EditorStyleCustomizer {
     final codeFontSize = max(0.0, fontSize - 2);
     return EditorStyle.desktop(
       padding: padding,
-      cursorColor: cursorColor,
-      selectionColor: selectionColor,
+      cursorColor: cursorColor ??
+          DefaultAppearanceSettings.getDefaultDocumentCursorColor(context),
+      selectionColor: selectionColor ??
+          DefaultAppearanceSettings.getDefaultDocumentSelectionColor(context),
       defaultTextDirection: defaultTextDirection,
       textStyleConfiguration: TextStyleConfiguration(
         text: baseTextStyle(fontFamily).copyWith(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -41,12 +41,18 @@ class EditorStyleCustomizer {
     final theme = Theme.of(context);
     final fontSize = context.read<DocumentAppearanceCubit>().state.fontSize;
     final fontFamily = context.read<DocumentAppearanceCubit>().state.fontFamily;
+    final cursorColor =
+        context.read<DocumentAppearanceCubit>().state.cursorColor;
+
+    final selectionColor =
+        context.read<DocumentAppearanceCubit>().state.selectionColor;
     final defaultTextDirection =
         context.read<DocumentAppearanceCubit>().state.defaultTextDirection;
     final codeFontSize = max(0.0, fontSize - 2);
     return EditorStyle.desktop(
       padding: padding,
-      cursorColor: theme.colorScheme.primary,
+      cursorColor: cursorColor,
+      selectionColor: selectionColor,
       defaultTextDirection: defaultTextDirection,
       textStyleConfiguration: TextStyleConfiguration(
         text: baseTextStyle(fontFamily).copyWith(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -40,23 +40,18 @@ class EditorStyleCustomizer {
 
   EditorStyle desktop() {
     final theme = Theme.of(context);
-    final fontSize = context.read<DocumentAppearanceCubit>().state.fontSize;
-    final fontFamily = context.read<DocumentAppearanceCubit>().state.fontFamily;
-    final cursorColor =
-        context.read<DocumentAppearanceCubit>().state.cursorColor;
-
-    final selectionColor =
-        context.read<DocumentAppearanceCubit>().state.selectionColor;
-    final defaultTextDirection =
-        context.read<DocumentAppearanceCubit>().state.defaultTextDirection;
+    final appearance = context.read<DocumentAppearanceCubit>().state;
+    final fontSize = appearance.fontSize;
+    final fontFamily = appearance.fontFamily;
     final codeFontSize = max(0.0, fontSize - 2);
+
     return EditorStyle.desktop(
       padding: padding,
-      cursorColor: cursorColor ??
+      cursorColor: appearance.cursorColor ??
           DefaultAppearanceSettings.getDefaultDocumentCursorColor(context),
-      selectionColor: selectionColor ??
+      selectionColor: appearance.selectionColor ??
           DefaultAppearanceSettings.getDefaultDocumentSelectionColor(context),
-      defaultTextDirection: defaultTextDirection,
+      defaultTextDirection: appearance.defaultTextDirection,
       textStyleConfiguration: TextStyleConfiguration(
         text: baseTextStyle(fontFamily).copyWith(
           fontSize: fontSize,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
@@ -3,7 +3,6 @@ import 'package:appflowy/user/application/user_settings_service.dart';
 import 'package:appflowy/util/color_to_hex_string.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:bloc/bloc.dart';
-import 'package:flowy_infra_ui/style_widget/text_input.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -57,12 +56,35 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
     final defaultTextDirection =
         prefs.getString(KVKeys.kDocumentAppearanceDefaultTextDirection);
 
-    final selectionColor = await getSelectionColorFromBackend();
-    final cursorColor = await getCursorColorFromBackend();
+    final cursorColorString =
+        prefs.getString(KVKeys.kDocumentAppearanceCursorColor);
+    final selectionColorString =
+        prefs.getString(KVKeys.kDocumentAppearanceSelectionColor);
+    print('debug1 fetch cursorColorString : $cursorColorString');
+    print('debug1 fetch selectionColorString: $selectionColorString');
+    final cursorColor = cursorColorString == null
+        ? null
+        : Color(
+            int.parse(
+              cursorColorString,
+            ),
+          );
+    final selectionColor = selectionColorString == null
+        ? null
+        : Color(
+            int.parse(
+              selectionColorString,
+            ),
+          );
+
+    // final selectionColor = await getSelectionColorFromBackend();
+    // final cursorColor = await getCursorColorFromBackend();
 
     if (isClosed) {
       return;
     }
+    print('debug1 sharedPref fetch cursorColor: $cursorColor');
+    print('debug1 sharedPref fetch selectionColor: $selectionColor');
 
     emit(
       state.copyWith(
@@ -126,33 +148,88 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
       ),
     );
   }
+
+  Future<void> syncCursorColor(Color? cursorColor) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    if (cursorColor == null) {
+      prefs.remove(KVKeys.kDocumentAppearanceCursorColor);
+    } else {
+      prefs.setString(
+        KVKeys.kDocumentAppearanceCursorColor,
+        cursorColor.toHexString(),
+      );
+    }
+
+    if (isClosed) {
+      return;
+    }
+    print(
+      'debug1 sharedPref syncCursorColor: ${cursorColor?.toHexString()}',
+    );
+    emit(
+      state.copyWith(
+        cursorColor: cursorColor,
+      ),
+    );
+  }
+
+  Future<void> syncSelectionColor(Color? selectionColor) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    if (selectionColor == null) {
+      prefs.remove(KVKeys.kDocumentAppearanceSelectionColor);
+    } else {
+      prefs.setString(
+        KVKeys.kDocumentAppearanceSelectionColor,
+        selectionColor.toHexString(),
+      );
+    }
+
+    print(
+      'debug1  sharedPref s syncSelectionColor ${selectionColor?.toHexString()}',
+    );
+
+    if (isClosed) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        selectionColor: selectionColor,
+      ),
+    );
+  }
 }
 
-Future<Color?> getSelectionColorFromBackend() async {
-  final appearanceSetting =
-      await UserSettingsBackendService().getAppearanceSetting();
-  final selectionColor =
-      appearanceSetting.documentSetting.selectionColor.isEmpty
-          ? null
-          : Color(
-              int.parse(
-                appearanceSetting.documentSetting.selectionColor,
-              ),
-            );
 
-  return selectionColor;
-}
 
-Future<Color?> getCursorColorFromBackend() async {
-  final appearanceSetting =
-      await UserSettingsBackendService().getAppearanceSetting();
-  final cursorColor = appearanceSetting.documentSetting.cursorColor.isEmpty
-      ? null
-      : Color(
-          int.parse(
-            appearanceSetting.documentSetting.cursorColor,
-          ),
-        );
 
-  return cursorColor;
-}
+// Future<Color?> getSelectionColorFromBackend() async {
+//   final appearanceSetting =
+//       await UserSettingsBackendService().getAppearanceSetting();
+//   final selectionColor =
+//       appearanceSetting.documentSetting.selectionColor.isEmpty
+//           ? null
+//           : Color(
+//               int.parse(
+//                 appearanceSetting.documentSetting.selectionColor,
+//               ),
+//             );
+
+//   return selectionColor;
+// }
+
+// Future<Color?> getCursorColorFromBackend() async {
+//   final appearanceSetting =
+//       await UserSettingsBackendService().getAppearanceSetting();
+//   final cursorColor = appearanceSetting.documentSetting.cursorColor.isEmpty
+//       ? null
+//       : Color(
+//           int.parse(
+//             appearanceSetting.documentSetting.cursorColor,
+//           ),
+//         );
+
+//   return cursorColor;
+// }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
@@ -1,27 +1,39 @@
 import 'package:appflowy/core/config/kv_keys.dart';
+import 'package:appflowy/user/application/user_settings_service.dart';
+import 'package:appflowy/util/color_to_hex_string.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flowy_infra_ui/style_widget/text_input.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class DocumentAppearance {
   const DocumentAppearance({
     required this.fontSize,
     required this.fontFamily,
+    this.cursorColor,
+    this.selectionColor,
     this.defaultTextDirection,
   });
 
   final double fontSize;
   final String fontFamily;
+  final Color? cursorColor;
+  final Color? selectionColor;
   final String? defaultTextDirection;
 
   DocumentAppearance copyWith({
     double? fontSize,
     String? fontFamily,
     String? defaultTextDirection,
+    Color? cursorColor,
+    Color? selectionColor,
   }) {
     return DocumentAppearance(
       fontSize: fontSize ?? this.fontSize,
       fontFamily: fontFamily ?? this.fontFamily,
+      cursorColor: cursorColor,
+      selectionColor: selectionColor,
       defaultTextDirection: defaultTextDirection,
     );
   }
@@ -45,6 +57,9 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
     final defaultTextDirection =
         prefs.getString(KVKeys.kDocumentAppearanceDefaultTextDirection);
 
+    final selectionColor = await getSelectionColorFromBackend();
+    final cursorColor = await getCursorColorFromBackend();
+
     if (isClosed) {
       return;
     }
@@ -53,6 +68,8 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
       state.copyWith(
         fontSize: fontSize,
         fontFamily: fontFamily,
+        cursorColor: cursorColor,
+        selectionColor: selectionColor,
         defaultTextDirection: defaultTextDirection,
       ),
     );
@@ -109,4 +126,33 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
       ),
     );
   }
+}
+
+Future<Color?> getSelectionColorFromBackend() async {
+  final appearanceSetting =
+      await UserSettingsBackendService().getAppearanceSetting();
+  final selectionColor =
+      appearanceSetting.documentSetting.selectionColor.isEmpty
+          ? null
+          : Color(
+              int.parse(
+                appearanceSetting.documentSetting.selectionColor,
+              ),
+            );
+
+  return selectionColor;
+}
+
+Future<Color?> getCursorColorFromBackend() async {
+  final appearanceSetting =
+      await UserSettingsBackendService().getAppearanceSetting();
+  final cursorColor = appearanceSetting.documentSetting.cursorColor.isEmpty
+      ? null
+      : Color(
+          int.parse(
+            appearanceSetting.documentSetting.cursorColor,
+          ),
+        );
+
+  return cursorColor;
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
@@ -1,5 +1,4 @@
 import 'package:appflowy/core/config/kv_keys.dart';
-import 'package:appflowy/user/application/user_settings_service.dart';
 import 'package:appflowy/util/color_to_hex_string.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:bloc/bloc.dart';

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
@@ -21,19 +21,30 @@ class DocumentAppearance {
   final Color? selectionColor;
   final String? defaultTextDirection;
 
+  ///For nullable fields (like `cursorColor`),
+  /// use the corresponding `isNull` flag (like `cursorColorIsNull`) to explicitly set the field to `null`.
+  ///
+  /// This is necessary because simply passing `null` as the value does not distinguish between wanting to
+  /// set the field to `null` and not wanting to update the field at all.
   DocumentAppearance copyWith({
     double? fontSize,
     String? fontFamily,
-    String? defaultTextDirection,
     Color? cursorColor,
     Color? selectionColor,
+    String? defaultTextDirection,
+    bool cursorColorIsNull = false,
+    bool selectionColorIsNull = false,
+    bool textDirectionIsNull = false,
   }) {
     return DocumentAppearance(
       fontSize: fontSize ?? this.fontSize,
       fontFamily: fontFamily ?? this.fontFamily,
-      cursorColor: cursorColor,
-      selectionColor: selectionColor,
-      defaultTextDirection: defaultTextDirection,
+      cursorColor: cursorColorIsNull ? null : cursorColor ?? this.cursorColor,
+      selectionColor:
+          selectionColorIsNull ? null : selectionColor ?? this.selectionColor,
+      defaultTextDirection: textDirectionIsNull
+          ? null
+          : defaultTextDirection ?? this.defaultTextDirection,
     );
   }
 }
@@ -60,31 +71,15 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
         prefs.getString(KVKeys.kDocumentAppearanceCursorColor);
     final selectionColorString =
         prefs.getString(KVKeys.kDocumentAppearanceSelectionColor);
-    print('debug1 fetch cursorColorString : $cursorColorString');
-    print('debug1 fetch selectionColorString: $selectionColorString');
-    final cursorColor = cursorColorString == null
-        ? null
-        : Color(
-            int.parse(
-              cursorColorString,
-            ),
-          );
-    final selectionColor = selectionColorString == null
-        ? null
-        : Color(
-            int.parse(
-              selectionColorString,
-            ),
-          );
-
-    // final selectionColor = await getSelectionColorFromBackend();
-    // final cursorColor = await getCursorColorFromBackend();
+    final cursorColor =
+        cursorColorString != null ? Color(int.parse(cursorColorString)) : null;
+    final selectionColor = selectionColorString != null
+        ? Color(int.parse(selectionColorString))
+        : null;
 
     if (isClosed) {
       return;
     }
-    print('debug1 sharedPref fetch cursorColor: $cursorColor');
-    print('debug1 sharedPref fetch selectionColor: $selectionColor');
 
     emit(
       state.copyWith(
@@ -93,6 +88,9 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
         cursorColor: cursorColor,
         selectionColor: selectionColor,
         defaultTextDirection: defaultTextDirection,
+        cursorColorIsNull: cursorColor == null,
+        selectionColorIsNull: selectionColor == null,
+        textDirectionIsNull: defaultTextDirection == null,
       ),
     );
   }
@@ -145,6 +143,7 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
     emit(
       state.copyWith(
         defaultTextDirection: direction,
+        textDirectionIsNull: direction == null,
       ),
     );
   }
@@ -164,12 +163,11 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
     if (isClosed) {
       return;
     }
-    print(
-      'debug1 sharedPref syncCursorColor: ${cursorColor?.toHexString()}',
-    );
+
     emit(
       state.copyWith(
         cursorColor: cursorColor,
+        cursorColorIsNull: cursorColor == null,
       ),
     );
   }
@@ -186,10 +184,6 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
       );
     }
 
-    print(
-      'debug1  sharedPref s syncSelectionColor ${selectionColor?.toHexString()}',
-    );
-
     if (isClosed) {
       return;
     }
@@ -197,39 +191,8 @@ class DocumentAppearanceCubit extends Cubit<DocumentAppearance> {
     emit(
       state.copyWith(
         selectionColor: selectionColor,
+        selectionColorIsNull: selectionColor == null,
       ),
     );
   }
 }
-
-
-
-
-// Future<Color?> getSelectionColorFromBackend() async {
-//   final appearanceSetting =
-//       await UserSettingsBackendService().getAppearanceSetting();
-//   final selectionColor =
-//       appearanceSetting.documentSetting.selectionColor.isEmpty
-//           ? null
-//           : Color(
-//               int.parse(
-//                 appearanceSetting.documentSetting.selectionColor,
-//               ),
-//             );
-
-//   return selectionColor;
-// }
-
-// Future<Color?> getCursorColorFromBackend() async {
-//   final appearanceSetting =
-//       await UserSettingsBackendService().getAppearanceSetting();
-//   final cursorColor = appearanceSetting.documentSetting.cursorColor.isEmpty
-//       ? null
-//       : Color(
-//           int.parse(
-//             appearanceSetting.documentSetting.cursorColor,
-//           ),
-//         );
-
-//   return cursorColor;
-// }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/more/cubit/document_appearance_cubit.dart
@@ -20,7 +20,7 @@ class DocumentAppearance {
   final Color? selectionColor;
   final String? defaultTextDirection;
 
-  ///For nullable fields (like `cursorColor`),
+  /// For nullable fields (like `cursorColor`),
   /// use the corresponding `isNull` flag (like `cursorColorIsNull`) to explicitly set the field to `null`.
   ///
   /// This is necessary because simply passing `null` as the value does not distinguish between wanting to

--- a/frontend/appflowy_flutter/lib/util/color_to_hex_string.dart
+++ b/frontend/appflowy_flutter/lib/util/color_to_hex_string.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+extension ColorExtensionn on Color {
+  /// return a hex string in 0xff000000 format
+  String toHexString() {
+    return '0x${value.toRadixString(16).padLeft(8, '0')}';
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/application/appearance_defaults.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance_defaults.dart
@@ -7,8 +7,12 @@ class DefaultAppearanceSettings {
   static const kDefaultThemeMode = ThemeMode.system;
   static const kDefaultThemeName = "Default";
   static const kDefaultTheme = BuiltInTheme.defaultTheme;
-  // same color as the default color in appflowy_eidtor package
-  static const kDefaultDocumentCursorColor = Color(0xFF00BCF0);
-  static const kDefaultDocumentSelectionColor =
-      Color.fromARGB(53, 111, 201, 231);
+
+  static Color getDefaultDocumentCursorColor(BuildContext context) {
+    return Theme.of(context).colorScheme.primary;
+  }
+
+  static Color getDefaultDocumentSelectionColor(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.2);
+  }
 }

--- a/frontend/appflowy_flutter/lib/workspace/application/appearance_defaults.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/appearance_defaults.dart
@@ -7,4 +7,8 @@ class DefaultAppearanceSettings {
   static const kDefaultThemeMode = ThemeMode.system;
   static const kDefaultThemeName = "Default";
   static const kDefaultTheme = BuiltInTheme.defaultTheme;
+  // same color as the default color in appflowy_eidtor package
+  static const kDefaultDocumentCursorColor = Color(0xFF00BCF0);
+  static const kDefaultDocumentSelectionColor =
+      Color.fromARGB(53, 111, 201, 231);
 }

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
@@ -52,7 +52,9 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
             appearanceSettings.documentSetting.cursorColor.isEmpty
                 ? null
                 : Color(
-                    int.parse(appearanceSettings.documentSetting.cursorColor),
+                    int.parse(
+                      appearanceSettings.documentSetting.cursorColor,
+                    ),
                   ),
             appearanceSettings.documentSetting.selectionColor.isEmpty
                 ? null

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/user/application/user_settings_service.dart';
+import 'package:appflowy/util/color_to_hex_string.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:appflowy_backend/log.dart';
@@ -48,6 +49,18 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
             dateTimeSettings.dateFormat,
             dateTimeSettings.timeFormat,
             dateTimeSettings.timezoneId,
+            appearanceSettings.documentSetting.cursorColor.isEmpty
+                ? DefaultAppearanceSettings.kDefaultDocumentCursorColor
+                : Color(
+                    int.parse(appearanceSettings.documentSetting.cursorColor),
+                  ),
+            appearanceSettings.documentSetting.selectionColor.isEmpty
+                ? DefaultAppearanceSettings.kDefaultDocumentSelectionColor
+                : Color(
+                    int.parse(
+                      appearanceSettings.documentSetting.selectionColor,
+                    ),
+                  ),
           ),
         );
 
@@ -106,6 +119,30 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
   /// Resets the current font family for the user preferences
   void resetFontFamily() =>
       setFontFamily(DefaultAppearanceSettings.kDefaultFontFamily);
+
+  /// Update document cursor color in the apperance settings and emit an updated state.
+  void setDocumentCursorColor(Color color) {
+    _appearanceSettings.documentSetting.cursorColor = color.toHexString();
+    _saveAppearanceSettings();
+    emit(state.copyWith(documentCursorColor: color));
+  }
+
+  /// Reset document cursor color in the apperance settings
+  void resetDocumentCursorColor() => setDocumentCursorColor(
+        DefaultAppearanceSettings.kDefaultDocumentCursorColor,
+      );
+
+  /// Update document selection color in the apperance settings and emit an updated state.
+  void setDocumentSelectionColor(Color color) {
+    _appearanceSettings.documentSetting.selectionColor = color.toHexString();
+    _saveAppearanceSettings();
+    emit(state.copyWith(documentSelectionColor: color));
+  }
+
+  /// Reset document selection color in the apperance settings
+  void resetDocumentSelectionColor() => setDocumentSelectionColor(
+        DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
+      );
 
   /// Updates the current locale and notify the listeners the locale was
   /// changed. Fallback to [en] locale if [newLocale] is not supported.
@@ -308,6 +345,8 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
     required UserDateFormatPB dateFormat,
     required UserTimeFormatPB timeFormat,
     required String timezoneId,
+    required Color? documentCursorColor,
+    required Color? documentSelectionColor,
   }) = _AppearanceSettingsState;
 
   factory AppearanceSettingsState.initial(
@@ -323,6 +362,8 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
     UserDateFormatPB dateFormat,
     UserTimeFormatPB timeFormat,
     String timezoneId,
+    Color? documentCursorColor,
+    Color? documentSelectionColor,
   ) {
     return AppearanceSettingsState(
       appTheme: appTheme,
@@ -337,6 +378,8 @@ class AppearanceSettingsState with _$AppearanceSettingsState {
       dateFormat: dateFormat,
       timeFormat: timeFormat,
       timezoneId: timezoneId,
+      documentCursorColor: documentCursorColor,
+      documentSelectionColor: documentSelectionColor,
     );
   }
 

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
@@ -50,12 +50,12 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
             dateTimeSettings.timeFormat,
             dateTimeSettings.timezoneId,
             appearanceSettings.documentSetting.cursorColor.isEmpty
-                ? DefaultAppearanceSettings.kDefaultDocumentCursorColor
+                ? null
                 : Color(
                     int.parse(appearanceSettings.documentSetting.cursorColor),
                   ),
             appearanceSettings.documentSetting.selectionColor.isEmpty
-                ? DefaultAppearanceSettings.kDefaultDocumentSelectionColor
+                ? null
                 : Color(
                     int.parse(
                       appearanceSettings.documentSetting.selectionColor,
@@ -128,9 +128,11 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
   }
 
   /// Reset document cursor color in the apperance settings
-  void resetDocumentCursorColor() => setDocumentCursorColor(
-        DefaultAppearanceSettings.kDefaultDocumentCursorColor,
-      );
+  void resetDocumentCursorColor() {
+    _appearanceSettings.documentSetting.cursorColor = '';
+    _saveAppearanceSettings();
+    emit(state.copyWith(documentCursorColor: null));
+  }
 
   /// Update document selection color in the apperance settings and emit an updated state.
   void setDocumentSelectionColor(Color color) {
@@ -140,9 +142,11 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
   }
 
   /// Reset document selection color in the apperance settings
-  void resetDocumentSelectionColor() => setDocumentSelectionColor(
-        DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
-      );
+  void resetDocumentSelectionColor() {
+    _appearanceSettings.documentSetting.selectionColor = '';
+    _saveAppearanceSettings();
+    emit(state.copyWith(documentSelectionColor: null));
+  }
 
   /// Updates the current locale and notify the listeners the locale was
   /// changed. Fallback to [en] locale if [newLocale] is not supported.

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/brightness_setting.dart
@@ -18,12 +18,12 @@ class BrightnessSetting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: LocaleKeys.settings_appearance_themeMode_label.tr(),
       hint: hintText,
       onResetRequested: context.read<AppearanceSettingsCubit>().resetThemeMode,
       trailing: [
-        ThemeValueDropDown(
+        FlowySettingValueDropDown(
           currentValue: currentThemeMode.labelText,
           popupBuilder: (context) => Column(
             mainAxisSize: MainAxisSize.min,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/color_scheme.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/color_scheme.dart
@@ -27,7 +27,7 @@ class ColorSchemeSetting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: LocaleKeys.settings_appearance_theme.tr(),
       onResetRequested: context.read<AppearanceSettingsCubit>().resetTheme,
       trailing: [

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/create_file_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/create_file_setting.dart
@@ -16,7 +16,7 @@ class CreateFileSettings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label:
           LocaleKeys.settings_appearance_showNamingDialogWhenCreatingPage.tr(),
       trailing: [

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/date_format_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/date_format_setting.dart
@@ -18,10 +18,10 @@ class DateFormatSetting extends StatelessWidget {
   final UserDateFormatPB currentFormat;
 
   @override
-  Widget build(BuildContext context) => ThemeSettingEntryTemplateWidget(
+  Widget build(BuildContext context) => FlowySettingListTile(
         label: LocaleKeys.settings_appearance_dateFormat_label.tr(),
         trailing: [
-          ThemeValueDropDown(
+          FlowySettingValueDropDown(
             currentValue: _formatLabel(currentFormat),
             popupBuilder: (_) => Column(
               mainAxisSize: MainAxisSize.min,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/direction_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/direction_setting.dart
@@ -20,11 +20,11 @@ class LayoutDirectionSetting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: LocaleKeys.settings_appearance_layoutDirection_label.tr(),
       hint: LocaleKeys.settings_appearance_layoutDirection_hint.tr(),
       trailing: [
-        ThemeValueDropDown(
+        FlowySettingValueDropDown(
           key: const ValueKey('layout_direction_option_button'),
           currentValue: _layoutDirectionLabelText(currentLayoutDirection),
           popupBuilder: (context) => Column(
@@ -83,11 +83,11 @@ class TextDirectionSetting extends StatelessWidget {
   final AppFlowyTextDirection? currentTextDirection;
 
   @override
-  Widget build(BuildContext context) => ThemeSettingEntryTemplateWidget(
+  Widget build(BuildContext context) => FlowySettingListTile(
         label: LocaleKeys.settings_appearance_textDirection_label.tr(),
         hint: LocaleKeys.settings_appearance_textDirection_hint.tr(),
         trailing: [
-          ThemeValueDropDown(
+          FlowySettingValueDropDown(
             currentValue: _textDirectionLabelText(currentTextDirection),
             popupBuilder: (context) => Column(
               mainAxisSize: MainAxisSize.min,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -255,9 +255,9 @@ String? validateOpacityValue(String? value) {
     return LocaleKeys.settings_appearance_documentSettings_opacityEmptyError
         .tr();
   }
-  if (int.tryParse(value) == null ||
-      int.parse(value) > 100 ||
-      int.parse(value) <= 0) {
+
+  final opacityInt = int.tryParse(value);
+  if (opacityInt == null || opacityInt > 100 || opacityInt <= 0) {
     return LocaleKeys.settings_appearance_documentSettings_opacityRangeError
         .tr();
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -241,15 +241,18 @@ String? validateHexValue(
     return LocaleKeys.settings_appearance_documentSettings_hexLengthError.tr();
   }
 
-  final colorValue = int.tryParse(
-    _combineColorHexAndOpacity(
-      hexValue,
-      opacityValue,
-    ),
-  );
+  if (validateOpacityValue(opacityValue) == null) {
+    final colorValue = int.tryParse(
+      _combineColorHexAndOpacity(
+        hexValue,
+        opacityValue,
+      ),
+    );
 
-  if (colorValue == null) {
-    return LocaleKeys.settings_appearance_documentSettings_hexInvalidError.tr();
+    if (colorValue == null) {
+      return LocaleKeys.settings_appearance_documentSettings_hexInvalidError
+          .tr();
+    }
   }
 
   return null;

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -4,6 +4,7 @@ import 'package:appflowy/workspace/presentation/settings/widgets/utils/hex_opaci
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/dialog/styled_dialogs.dart';
+import 'package:flowy_infra_ui/widget/rounded_button.dart';
 import 'package:flutter/material.dart';
 
 class DocumentColorSettingButton extends StatelessWidget {
@@ -159,7 +160,10 @@ class DocumentColorSettingDialogState
               ),
             ),
             const VSpace(8),
-            ElevatedButton(
+            RoundedTextButton(
+              title: LocaleKeys.settings_appearance_documentSettings_apply.tr(),
+              width: 100,
+              height: 30,
               onPressed: () {
                 if (_formKey.currentState!.validate()) {
                   if (selectedColorOnDialog != null &&
@@ -172,9 +176,6 @@ class DocumentColorSettingDialogState
                 }
                 Navigator.of(context).pop();
               },
-              child: Text(
-                LocaleKeys.settings_appearance_documentSettings_apply.tr(),
-              ),
             ),
           ],
         ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -183,6 +183,7 @@ class _ColorSettingTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = Theme.of(context);
     return TextField(
       controller: controller,
       decoration: InputDecoration(
@@ -190,11 +191,16 @@ class _ColorSettingTextField extends StatelessWidget {
         hintText: hintText,
         border: OutlineInputBorder(
           borderSide: BorderSide(
-            color: Theme.of(context).colorScheme.outline,
+            color: style.colorScheme.outline,
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: style.colorScheme.outline,
           ),
         ),
       ),
-      style: Theme.of(context).textTheme.bodyMedium,
+      style: style.textTheme.bodyMedium,
       onChanged: onChanged,
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -74,7 +74,7 @@ class DocumentColorSettingDialogState
   late String currentColorHexString;
   late TextEditingController hexController;
   late TextEditingController opacityController;
-  final _formKey = GlobalKey<FormState>();
+  final _formKey = GlobalKey<FormState>(debugLabel: 'colorSettingForm');
 
   @override
   void initState() {
@@ -87,6 +87,13 @@ class DocumentColorSettingDialogState
     opacityController = TextEditingController(
       text: _convertHexToOpacity(currentColorHexString),
     );
+  }
+
+  @override
+  void dispose() {
+    hexController.dispose();
+    opacityController.dispose();
+    super.dispose();
   }
 
   @override
@@ -217,6 +224,7 @@ class _ColorSettingTextField extends StatelessWidget {
       style: style.textTheme.bodyMedium,
       onFieldSubmitted: onFieldSubmitted,
       validator: validator,
+      autovalidateMode: AutovalidateMode.onUserInteraction,
     );
   }
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -1,0 +1,241 @@
+import 'package:appflowy/util/color_to_hex_string.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flowy_infra_ui/widget/dialog/styled_dialogs.dart';
+import 'package:flutter/material.dart';
+
+class DocumentColorSettingButton extends StatelessWidget {
+  const DocumentColorSettingButton({
+    super.key,
+    required this.currentColor,
+    required this.previewWidgetBuilder,
+    required this.dialogTitle,
+    required this.onApply,
+  });
+
+  /// current color from backend
+  final Color currentColor;
+
+  /// Build a preview widget with the given color
+  /// It shows both on the [DocumentColorSettingButton] and [_DocumentColorSettingDialog]
+  final Widget Function(Color? color) previewWidgetBuilder;
+
+  final String dialogTitle;
+
+  final void Function(Color selectedColorOnDialog) onApply;
+
+  @override
+  Widget build(BuildContext context) {
+    return FlowyButton(
+      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      text: previewWidgetBuilder.call(currentColor),
+      hoverColor: Theme.of(context).colorScheme.secondaryContainer,
+      expandText: false,
+      onTap: () => Dialogs.show(
+        context,
+        child: _DocumentColorSettingDialog(
+          currentColor: currentColor,
+          previewWidgetBuilder: previewWidgetBuilder,
+          dialogTitle: dialogTitle,
+          onApply: onApply,
+        ),
+      ),
+    );
+  }
+}
+
+class _DocumentColorSettingDialog extends StatefulWidget {
+  const _DocumentColorSettingDialog({
+    required this.currentColor,
+    required this.previewWidgetBuilder,
+    required this.dialogTitle,
+    required this.onApply,
+  });
+
+  final Color currentColor;
+
+  final Widget Function(Color?) previewWidgetBuilder;
+
+  final String dialogTitle;
+
+  final void Function(Color selectedColorOnDialog) onApply;
+
+  @override
+  State<_DocumentColorSettingDialog> createState() =>
+      DocumentColorSettingDialogState();
+}
+
+class DocumentColorSettingDialogState
+    extends State<_DocumentColorSettingDialog> {
+  /// The color displayed in the dialog.
+  /// It is `null` when the user didn't enter a valid color value.
+  late Color? selectedColorOnDialog;
+  late String currentColorHexString;
+  late TextEditingController hexController;
+  late TextEditingController opacityController;
+  @override
+  void initState() {
+    super.initState();
+    selectedColorOnDialog = widget.currentColor;
+    currentColorHexString = widget.currentColor.toHexString();
+    hexController = TextEditingController(
+      text: _extractColorHex(currentColorHexString),
+    );
+    opacityController = TextEditingController(
+      text: _convertHexToOpacity(currentColorHexString),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    void updateSelectedColor() {
+      setState(() {
+        final colorValue = int.tryParse(
+          _combineColorHexAndOpacity(
+            hexController.text,
+            opacityController.text,
+          ),
+        );
+        selectedColorOnDialog = colorValue != null ? Color(colorValue) : null;
+      });
+    }
+
+    return FlowyDialog(
+      constraints: const BoxConstraints(maxWidth: 250, maxHeight: 250),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 24),
+        child: Column(
+          children: [
+            const Spacer(),
+            FlowyText(widget.dialogTitle),
+            const VSpace(16),
+            SizedBox(
+              height: 108,
+              child: Row(
+                children: [
+                  const Spacer(),
+                  // set color
+                  SizedBox(
+                    width: 100,
+                    child: Column(
+                      children: [
+                        _ColorSettingTextField(
+                          controller: hexController,
+                          labelText: 'Hex value',
+                          hintText: '6fc9e7',
+                          onChanged: (_) => updateSelectedColor(),
+                        ),
+                        const VSpace(8),
+                        _ColorSettingTextField(
+                          controller: opacityController,
+                          labelText: 'Opacity',
+                          hintText: '50',
+                          onChanged: (_) => updateSelectedColor(),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const HSpace(8),
+                  // preview color
+                  SizedBox(
+                    width: 100,
+                    child: Center(
+                      child: widget.previewWidgetBuilder(
+                        selectedColorOnDialog,
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                ],
+              ),
+            ),
+            const VSpace(16),
+            ElevatedButton(
+              onPressed: () {
+                if (selectedColorOnDialog != null &&
+                    selectedColorOnDialog != widget.currentColor) {
+                  widget.onApply.call(selectedColorOnDialog!);
+                }
+                Navigator.of(context).pop();
+              },
+              child: const Text('Apply'),
+            ),
+            const Spacer(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ColorSettingTextField extends StatelessWidget {
+  const _ColorSettingTextField({
+    required this.controller,
+    required this.labelText,
+    required this.hintText,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final String labelText;
+  final String hintText;
+
+  final void Function(String) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: labelText,
+        hintText: hintText,
+        border: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        ),
+      ),
+      style: Theme.of(context).textTheme.bodyMedium,
+      onChanged: onChanged,
+    );
+  }
+}
+
+// same convert functions as in appflowy_editor
+String? _extractColorHex(String? colorHex) {
+  if (colorHex == null) return null;
+  return colorHex.substring(4);
+}
+
+String? _convertHexToOpacity(String? colorHex) {
+  if (colorHex == null) return null;
+  final opacityHex = colorHex.substring(2, 4);
+  final opacity = int.parse(opacityHex, radix: 16) / 2.55;
+  return opacity.toStringAsFixed(0);
+}
+
+String _combineColorHexAndOpacity(String colorHex, String opacity) {
+  colorHex = _fixColorHex(colorHex);
+  opacity = _fixOpacity(opacity);
+  final opacityHex = (int.parse(opacity) * 2.55).round().toRadixString(16);
+  return '0x$opacityHex$colorHex';
+}
+
+String _fixColorHex(String colorHex) {
+  if (colorHex.length > 6) {
+    colorHex = colorHex.substring(0, 6);
+  }
+  if (int.tryParse(colorHex, radix: 16) == null) {
+    colorHex = 'FFFFFF';
+  }
+  return colorHex;
+}
+
+String _fixOpacity(String opacity) {
+  final RegExp regex = RegExp('[a-zA-Z]');
+  if (regex.hasMatch(opacity) ||
+      int.parse(opacity) > 100 ||
+      int.parse(opacity) < 0) {
+    return '100';
+  }
+  return opacity;
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart
@@ -1,4 +1,6 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/util/color_to_hex_string.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/dialog/styled_dialogs.dart';
 import 'package:flutter/material.dart';
@@ -120,14 +122,14 @@ class DocumentColorSettingDialogState
                       children: [
                         _ColorSettingTextField(
                           controller: hexController,
-                          labelText: 'Hex value',
+                          labelText: LocaleKeys.editor_hexValue.tr(),
                           hintText: '6fc9e7',
                           onChanged: (_) => updateSelectedColor(),
                         ),
                         const VSpace(8),
                         _ColorSettingTextField(
                           controller: opacityController,
-                          labelText: 'Opacity',
+                          labelText: LocaleKeys.editor_opacity.tr(),
                           hintText: '50',
                           onChanged: (_) => updateSelectedColor(),
                         ),
@@ -157,7 +159,9 @@ class DocumentColorSettingDialogState
                 }
                 Navigator.of(context).pop();
               },
-              child: const Text('Apply'),
+              child: Text(
+                LocaleKeys.settings_appearance_documentSettings_apply.tr(),
+              ),
             ),
             const Spacer(),
           ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -24,26 +24,26 @@ class DocumentCursorColorSetting extends StatelessWidget {
       onResetRequested: () {
         context.read<AppearanceSettingsCubit>().resetDocumentCursorColor();
         context.read<DocumentAppearanceCubit>().syncCursorColor(null);
-        // context.read<DocumentAppearanceCubit>().fetch();
       },
       trailing: [
         DocumentColorSettingButton(
           key: const Key('DocumentCursorColorSettingButton'),
           currentColor: currentCursorColor,
           previewWidgetBuilder: (color) => _CursorColorValueWidget(
-            cursorColor:
-                color ?? DefaultAppearanceSettings.kDefaultDocumentCursorColor,
+            cursorColor: color ??
+                DefaultAppearanceSettings.getDefaultDocumentCursorColor(
+                  context,
+                ),
           ),
           dialogTitle: label,
           onApply: (selectedColorOnDialog) {
             context
                 .read<AppearanceSettingsCubit>()
                 .setDocumentCursorColor(selectedColorOnDialog);
+            // update the state of document appearance cubit with latest cursor color
             context
                 .read<DocumentAppearanceCubit>()
                 .syncCursorColor(selectedColorOnDialog);
-            // update the state of document appearance cubit with latest cursor color
-            // context.read<DocumentAppearanceCubit>().fetch();
           },
         ),
       ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -68,7 +68,11 @@ class _CursorColorValueWidget extends StatelessWidget {
           width: 2,
           height: 16,
         ),
-        const FlowyText('AppFlowy'),
+        FlowyText(
+          'AppFlowy',
+          // To avoid the text color changes when it is hovered in dark mode
+          color: Theme.of(context).colorScheme.onBackground,
+        ),
       ],
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -1,0 +1,66 @@
+import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
+import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class DocumentCursorColorSetting extends StatelessWidget {
+  const DocumentCursorColorSetting({
+    super.key,
+    required this.currentCursorColor,
+  });
+
+  final Color currentCursorColor;
+
+  @override
+  Widget build(BuildContext context) {
+    const label = 'Document Cursor Color';
+    return ThemeSettingEntryTemplateWidget(
+      label: label,
+      onResetRequested: () =>
+          context.read<AppearanceSettingsCubit>().resetDocumentCursorColor(),
+      trailing: [
+        DocumentColorSettingButton(
+          key: const Key('DocumentCursorColorSettingButton'),
+          currentColor: currentCursorColor,
+          previewWidgetBuilder: (color) => _CursorColorValueWidget(
+            cursorColor: color ?? Colors.transparent,
+          ),
+          dialogTitle: label,
+          onApply: (selectedColorOnDialog) {
+            context
+                .read<AppearanceSettingsCubit>()
+                .setDocumentCursorColor(selectedColorOnDialog);
+            // update the state of document appearance cubit with latest cursor color
+            context.read<DocumentAppearanceCubit>().fetch();
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _CursorColorValueWidget extends StatelessWidget {
+  const _CursorColorValueWidget({
+    required this.cursorColor,
+  });
+
+  final Color cursorColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          color: cursorColor,
+          width: 2,
+          height: 16,
+        ),
+        const FlowyText('AppFlowy'),
+      ],
+    );
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
+import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
@@ -19,22 +20,30 @@ class DocumentCursorColorSetting extends StatelessWidget {
     const label = 'Document Cursor Color';
     return ThemeSettingEntryTemplateWidget(
       label: label,
-      onResetRequested: () =>
-          context.read<AppearanceSettingsCubit>().resetDocumentCursorColor(),
+      resetButtonKey: const Key('DocumentCursorColorResetButton'),
+      onResetRequested: () {
+        context.read<AppearanceSettingsCubit>().resetDocumentCursorColor();
+        context.read<DocumentAppearanceCubit>().syncCursorColor(null);
+        // context.read<DocumentAppearanceCubit>().fetch();
+      },
       trailing: [
         DocumentColorSettingButton(
           key: const Key('DocumentCursorColorSettingButton'),
           currentColor: currentCursorColor,
           previewWidgetBuilder: (color) => _CursorColorValueWidget(
-            cursorColor: color ?? Colors.transparent,
+            cursorColor:
+                color ?? DefaultAppearanceSettings.kDefaultDocumentCursorColor,
           ),
           dialogTitle: label,
           onApply: (selectedColorOnDialog) {
             context
                 .read<AppearanceSettingsCubit>()
                 .setDocumentCursorColor(selectedColorOnDialog);
+            context
+                .read<DocumentAppearanceCubit>()
+                .syncCursorColor(selectedColorOnDialog);
             // update the state of document appearance cubit with latest cursor color
-            context.read<DocumentAppearanceCubit>().fetch();
+            // context.read<DocumentAppearanceCubit>().fetch();
           },
         ),
       ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -18,7 +18,7 @@ class DocumentCursorColorSetting extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const label = 'Document Cursor Color';
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: label,
       resetButtonKey: const Key('DocumentCursorColorResetButton'),
       onResetRequested: () {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_cursor_color_setting.dart
@@ -1,8 +1,10 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,7 +19,8 @@ class DocumentCursorColorSetting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const label = 'Document Cursor Color';
+    final label =
+        LocaleKeys.settings_appearance_documentSettings_cursorColor.tr();
     return FlowySettingListTile(
       label: label,
       resetButtonKey: const Key('DocumentCursorColorResetButton'),
@@ -69,7 +72,7 @@ class _CursorColorValueWidget extends StatelessWidget {
           height: 16,
         ),
         FlowyText(
-          'AppFlowy',
+          LocaleKeys.appName.tr(),
           // To avoid the text color changes when it is hovered in dark mode
           color: Theme.of(context).colorScheme.onBackground,
         ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -25,14 +25,15 @@ class DocumentSelectionColorSetting extends StatelessWidget {
       onResetRequested: () {
         context.read<AppearanceSettingsCubit>().resetDocumentSelectionColor();
         context.read<DocumentAppearanceCubit>().syncSelectionColor(null);
-        // context.read<DocumentAppearanceCubit>().fetch();
       },
       trailing: [
         DocumentColorSettingButton(
           currentColor: currentSelectionColor,
-          previewWidgetBuilder: (color) => SelectionColorValueWidget(
+          previewWidgetBuilder: (color) => _SelectionColorValueWidget(
             selectionColor: color ??
-                DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
+                DefaultAppearanceSettings.getDefaultDocumentSelectionColor(
+                  context,
+                ),
           ),
           dialogTitle: label,
           onApply: (selectedColorOnDialog) {
@@ -40,7 +41,6 @@ class DocumentSelectionColorSetting extends StatelessWidget {
                 .read<AppearanceSettingsCubit>()
                 .setDocumentSelectionColor(selectedColorOnDialog);
             // update the state of document appearance cubit with latest selection color
-            // context.read<DocumentAppearanceCubit>().fetch(),
             context
                 .read<DocumentAppearanceCubit>()
                 .syncSelectionColor(selectedColorOnDialog);
@@ -51,8 +51,8 @@ class DocumentSelectionColorSetting extends StatelessWidget {
   }
 }
 
-class SelectionColorValueWidget extends StatelessWidget {
-  const SelectionColorValueWidget({
+class _SelectionColorValueWidget extends StatelessWidget {
+  const _SelectionColorValueWidget({
     required this.selectionColor,
   });
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -60,14 +60,22 @@ class _SelectionColorValueWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // To avoid the text color changes when it is hovered in dark mode
+    final textColor = Theme.of(context).colorScheme.onBackground;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Container(
           color: selectionColor,
-          child: const FlowyText('App'),
+          child: FlowyText(
+            'App',
+            color: textColor,
+          ),
         ),
-        const FlowyText('flowy'),
+        FlowyText(
+          'flowy',
+          color: textColor,
+        ),
       ],
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -19,7 +19,7 @@ class DocumentSelectionColorSetting extends StatelessWidget {
   Widget build(BuildContext context) {
     const label = 'Document Selection Color';
 
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: label,
       resetButtonKey: const Key('DocumentSelectionColorResetButton'),
       onResetRequested: () {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -1,0 +1,66 @@
+import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
+import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class DocumentSelectionColorSetting extends StatelessWidget {
+  const DocumentSelectionColorSetting({
+    super.key,
+    required this.currentSelectionColor,
+  });
+
+  final Color currentSelectionColor;
+
+  @override
+  Widget build(BuildContext context) {
+    const label = 'Document Selection Color';
+
+    return ThemeSettingEntryTemplateWidget(
+      label: label,
+      resetButtonKey: const Key('DocumentSelectionColorResetButton'),
+      onResetRequested: () =>
+          context.read<AppearanceSettingsCubit>().resetDocumentSelectionColor(),
+      trailing: [
+        DocumentColorSettingButton(
+          currentColor: currentSelectionColor,
+          previewWidgetBuilder: (color) => _SelectionColorValueWidget(
+            selectionColor: color ?? Colors.transparent,
+          ),
+          dialogTitle: label,
+          onApply: (selectedColorOnDialog) => {
+            context
+                .read<AppearanceSettingsCubit>()
+                .setDocumentSelectionColor(selectedColorOnDialog),
+            // update the state of document appearance cubit with latest selection color
+            context.read<DocumentAppearanceCubit>().fetch(),
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _SelectionColorValueWidget extends StatelessWidget {
+  const _SelectionColorValueWidget({
+    required this.selectionColor,
+  });
+
+  final Color selectionColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          color: selectionColor,
+          child: const FlowyText('App'),
+        ),
+        const FlowyText('flowy'),
+      ],
+    );
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -1,8 +1,10 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,7 +19,8 @@ class DocumentSelectionColorSetting extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const label = 'Document Selection Color';
+    final label =
+        LocaleKeys.settings_appearance_documentSettings_selectionColor.tr();
 
     return FlowySettingListTile(
       label: label,
@@ -68,12 +71,12 @@ class _SelectionColorValueWidget extends StatelessWidget {
         Container(
           color: selectionColor,
           child: FlowyText(
-            'App',
+            LocaleKeys.settings_appearance_documentSettings_app.tr(),
             color: textColor,
           ),
         ),
         FlowyText(
-          'flowy',
+          LocaleKeys.settings_appearance_documentSettings_flowy.tr(),
           color: textColor,
         ),
       ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/document_selection_color_setting.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
+import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/document_color_setting_button.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart';
@@ -21,21 +22,28 @@ class DocumentSelectionColorSetting extends StatelessWidget {
     return ThemeSettingEntryTemplateWidget(
       label: label,
       resetButtonKey: const Key('DocumentSelectionColorResetButton'),
-      onResetRequested: () =>
-          context.read<AppearanceSettingsCubit>().resetDocumentSelectionColor(),
+      onResetRequested: () {
+        context.read<AppearanceSettingsCubit>().resetDocumentSelectionColor();
+        context.read<DocumentAppearanceCubit>().syncSelectionColor(null);
+        // context.read<DocumentAppearanceCubit>().fetch();
+      },
       trailing: [
         DocumentColorSettingButton(
           currentColor: currentSelectionColor,
-          previewWidgetBuilder: (color) => _SelectionColorValueWidget(
-            selectionColor: color ?? Colors.transparent,
+          previewWidgetBuilder: (color) => SelectionColorValueWidget(
+            selectionColor: color ??
+                DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
           ),
           dialogTitle: label,
-          onApply: (selectedColorOnDialog) => {
+          onApply: (selectedColorOnDialog) {
             context
                 .read<AppearanceSettingsCubit>()
-                .setDocumentSelectionColor(selectedColorOnDialog),
+                .setDocumentSelectionColor(selectedColorOnDialog);
             // update the state of document appearance cubit with latest selection color
-            context.read<DocumentAppearanceCubit>().fetch(),
+            // context.read<DocumentAppearanceCubit>().fetch(),
+            context
+                .read<DocumentAppearanceCubit>()
+                .syncSelectionColor(selectedColorOnDialog);
           },
         ),
       ],
@@ -43,8 +51,8 @@ class DocumentSelectionColorSetting extends StatelessWidget {
   }
 }
 
-class _SelectionColorValueWidget extends StatelessWidget {
-  const _SelectionColorValueWidget({
+class SelectionColorValueWidget extends StatelessWidget {
+  const SelectionColorValueWidget({
     required this.selectionColor,
   });
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/font_family_setting.dart
@@ -33,7 +33,7 @@ class ThemeFontFamilySetting extends StatefulWidget {
 class _ThemeFontFamilySettingState extends State<ThemeFontFamilySetting> {
   @override
   Widget build(BuildContext context) {
-    return ThemeSettingEntryTemplateWidget(
+    return FlowySettingListTile(
       label: LocaleKeys.settings_appearance_fontFamily_label.tr(),
       resetButtonKey: ThemeFontFamilySetting.resetButtonkey,
       onResetRequested: () {
@@ -91,7 +91,7 @@ class _FontFamilyDropDownState extends State<FontFamilyDropDown> {
 
   @override
   Widget build(BuildContext context) {
-    return ThemeValueDropDown(
+    return FlowySettingValueDropDown(
       popoverKey: ThemeFontFamilySetting.popoverKey,
       popoverController: widget.popoverController,
       currentValue: parseFontFamilyName(widget.currentFontFamily),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/settings_appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/settings_appearance.dart
@@ -2,3 +2,5 @@ export 'brightness_setting.dart';
 export 'font_family_setting.dart';
 export 'color_scheme.dart';
 export 'direction_setting.dart';
+export 'document_cursor_color_setting.dart';
+export 'document_selection_color_setting.dart';

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/theme_setting_entry_template.dart
@@ -5,9 +5,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 
-class ThemeSettingEntryTemplateWidget extends StatelessWidget {
-  const ThemeSettingEntryTemplateWidget({
+class FlowySettingListTile extends StatelessWidget {
+  const FlowySettingListTile({
     super.key,
+    this.resetTooltipText,
     this.resetButtonKey,
     required this.label,
     this.hint,
@@ -17,6 +18,7 @@ class ThemeSettingEntryTemplateWidget extends StatelessWidget {
 
   final String label;
   final String? hint;
+  final String? resetTooltipText;
   final Key? resetButtonKey;
   final List<Widget>? trailing;
   final void Function()? onResetRequested;
@@ -57,7 +59,8 @@ class ThemeSettingEntryTemplateWidget extends StatelessWidget {
               color: Theme.of(context).iconTheme.color,
             ),
             iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
-            tooltipText: LocaleKeys.settings_appearance_resetSetting.tr(),
+            tooltipText: resetTooltipText ??
+                LocaleKeys.settings_appearance_resetSetting.tr(),
             onPressed: onResetRequested,
           ),
       ],
@@ -65,8 +68,8 @@ class ThemeSettingEntryTemplateWidget extends StatelessWidget {
   }
 }
 
-class ThemeValueDropDown extends StatefulWidget {
-  const ThemeValueDropDown({
+class FlowySettingValueDropDown extends StatefulWidget {
+  const FlowySettingValueDropDown({
     super.key,
     required this.currentValue,
     required this.popupBuilder,
@@ -86,10 +89,11 @@ class ThemeValueDropDown extends StatefulWidget {
   final Offset? offset;
 
   @override
-  State<ThemeValueDropDown> createState() => _ThemeValueDropDownState();
+  State<FlowySettingValueDropDown> createState() =>
+      _FlowySettingValueDropDownState();
 }
 
-class _ThemeValueDropDownState extends State<ThemeValueDropDown> {
+class _FlowySettingValueDropDownState extends State<FlowySettingValueDropDown> {
   @override
   Widget build(BuildContext context) {
     return AppFlowyPopover(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/time_format_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance/time_format_setting.dart
@@ -18,10 +18,10 @@ class TimeFormatSetting extends StatelessWidget {
   final UserTimeFormatPB currentFormat;
 
   @override
-  Widget build(BuildContext context) => ThemeSettingEntryTemplateWidget(
+  Widget build(BuildContext context) => FlowySettingListTile(
         label: LocaleKeys.settings_appearance_timeFormat_label.tr(),
         trailing: [
-          ThemeValueDropDown(
+          FlowySettingValueDropDown(
             currentValue: _formatLabel(currentFormat),
             popupBuilder: (_) => Column(
               mainAxisSize: MainAxisSize.min,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -1,3 +1,4 @@
+import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/create_file_setting.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/settings_appearance/date_format_setting.dart';
@@ -31,6 +32,15 @@ class SettingsAppearanceView extends StatelessWidget {
                 const Divider(),
                 ThemeFontFamilySetting(
                   currentFontFamily: state.font,
+                ),
+                const Divider(),
+                DocumentCursorColorSetting(
+                  currentCursorColor: state.documentCursorColor ??
+                      DefaultAppearanceSettings.kDefaultDocumentCursorColor,
+                ),
+                DocumentSelectionColorSetting(
+                  currentSelectionColor: state.documentSelectionColor ??
+                      DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
                 ),
                 const Divider(),
                 LayoutDirectionSetting(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_appearance_view.dart
@@ -36,11 +36,16 @@ class SettingsAppearanceView extends StatelessWidget {
                 const Divider(),
                 DocumentCursorColorSetting(
                   currentCursorColor: state.documentCursorColor ??
-                      DefaultAppearanceSettings.kDefaultDocumentCursorColor,
+                      DefaultAppearanceSettings.getDefaultDocumentCursorColor(
+                        context,
+                      ),
                 ),
                 DocumentSelectionColorSetting(
                   currentSelectionColor: state.documentSelectionColor ??
-                      DefaultAppearanceSettings.kDefaultDocumentSelectionColor,
+                      DefaultAppearanceSettings
+                          .getDefaultDocumentSelectionColor(
+                        context,
+                      ),
                 ),
                 const Divider(),
                 LayoutDirectionSetting(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_notifications_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_notifications_view.dart
@@ -17,7 +17,7 @@ class SettingsNotificationsView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              ThemeSettingEntryTemplateWidget(
+              FlowySettingListTile(
                 label: LocaleKeys
                     .settings_notifications_enableNotifications_label
                     .tr(),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/utils/hex_opacity_string_extension.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/utils/hex_opacity_string_extension.dart
@@ -1,0 +1,19 @@
+extension HexOpacityExtension on String {
+  /// Only used in a valid color String like '0xff00bcf0'
+  String extractHex() {
+    return substring(4);
+  }
+
+  /// Only used in a valid color String like '0xff00bcf0'
+  String extractOpacity() {
+    final opacityString = substring(2, 4);
+    final opacityInt = int.parse(opacityString, radix: 16) / 2.55;
+    return opacityInt.toStringAsFixed(0);
+  }
+
+  /// Apply on the hex string like '00bcf0', with opacity like '100'
+  String combineHexWithOpacity(String opacity) {
+    final opacityInt = (int.parse(opacity) * 2.55).round().toRadixString(16);
+    return '0x$opacityInt$this';
+  }
+}

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/default_colorscheme.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/colorscheme/default_colorscheme.dart
@@ -85,7 +85,7 @@ class DefaultColorScheme extends FlowyColorScheme {
           shader1: _darkShader1,
           shader2: _darkShader2,
           shader3: _darkShader3,
-          shader4: const Color(0xff7C8CA5),
+          shader4: const Color(0xff505469),
           shader5: _darkShader5,
           shader6: _darkShader6,
           shader7: _white,

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -308,7 +308,7 @@
       }
     },
     "appearance": {
-      "resetSetting": "Reset this setting",
+      "resetSetting": "Reset",
       "fontFamily": {
         "label": "Font Family",
         "search": "Search"

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -322,6 +322,11 @@
       "documentSettings": {
         "cursorColor": "Document cursor color",
         "selectionColor": "Document selection color",
+        "hexEmptyError": "Hex color cannot be empty",
+        "hexLengthError": "Hex value must be 6 digits long",
+        "hexInvalidError": "Invalid hex value",
+        "opacityEmptyError": "Opacity cannot be empty",
+        "opacityRangeError": "Opacity must be between 1 and 100",
         "app": "App",
         "flowy": "Flowy",
         "apply": "Apply"

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -319,6 +319,13 @@
         "dark": "Dark Mode",
         "system": "Adapt to System"
       },
+      "documentSettings": {
+        "cursorColor": "Document cursor color",
+        "selectionColor": "Document selection color",
+        "app": "App",
+        "flowy": "Flowy",
+        "apply": "Apply"
+      },
       "layoutDirection": {
         "label": "Layout Direction",
         "hint": "Control the flow of content on your screen, from left to right or right to left.",

--- a/frontend/rust-lib/flowy-user/src/entities/user_setting.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/user_setting.rs
@@ -64,6 +64,10 @@ pub struct AppearanceSettingsPB {
   #[pb(index = 11)]
   #[serde(default)]
   pub text_direction: TextDirectionPB,
+
+  #[pb(index = 12)]
+  #[serde(default)]
+  pub document_setting: DocumentSettingsPB,
 }
 
 const DEFAULT_RESET_VALUE: fn() -> bool = || APPEARANCE_RESET_AS_DEFAULT;
@@ -110,6 +114,24 @@ impl std::default::Default for LocaleSettingsPB {
   }
 }
 
+#[derive(ProtoBuf, Serialize, Deserialize, Debug, Clone)]
+pub struct DocumentSettingsPB {
+  #[pb(index = 1, one_of)]
+  pub cursor_color: Option<String>,
+
+  #[pb(index = 2, one_of)]
+  pub selection_color: Option<String>,
+}
+
+impl std::default::Default for DocumentSettingsPB {
+  fn default() -> Self {
+    Self {
+      cursor_color: None,
+      selection_color: None,
+    }
+  }
+}
+
 pub const APPEARANCE_DEFAULT_THEME: &str = "Default";
 pub const APPEARANCE_DEFAULT_FONT: &str = "Poppins";
 pub const APPEARANCE_DEFAULT_MONOSPACE_FONT: &str = "SF Mono";
@@ -131,6 +153,7 @@ impl std::default::Default for AppearanceSettingsPB {
       menu_offset: APPEARANCE_DEFAULT_MENU_OFFSET,
       layout_direction: LayoutDirectionPB::default(),
       text_direction: TextDirectionPB::default(),
+      document_setting: DocumentSettingsPB::default(),
     }
   }
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

**Customized document cursor and selection color**

To close #3972 

- When users enter 'return' on the text field, the preview area will get updated. Thus, users can get a brief preview of how it will look like. If users type an invalid value of color, it will show the error message below the text field.
- When users click 'Apply', it will validate all the values and save the value only if it is validated. 
- When users reset the color, the value will be `null` and the UI will use the corresponding theme color from `DefaultAppearanceSettings. get**Color. `
- The color values are saved both in the backend and shared preference. 

https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/1ce1e188-0b16-4a2b-828a-a819117729c7

https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/d5b2b628-4e9e-4776-b817-90d20b2614b0


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
