### PR TITLE
Trash prompt 4165

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/trash/application/trash_prompt.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/application/trash_prompt.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+void showConfirmationDialog({
+  required BuildContext context,
+  required String title,
+  required String message,
+  required VoidCallback onConfirm,
+}) {
+  showDialog(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          TextButton(
+            child: const Text('Yes'),
+            onPressed: () {
+              onConfirm();
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
@@ -97,19 +97,37 @@ class _TrashPageState extends State<TrashPage> {
             child: FlowyButton(
               text: FlowyText.medium(LocaleKeys.trash_restoreAll.tr()),
               leftIcon: const FlowySvg(FlowySvgs.restore_s),
-              onTap: () => context.read<TrashBloc>().add(
-                    const TrashEvent.restoreAll(),
-                  ),
+              onTap: () {
+                showConfirmationDialog(
+                  context: context,
+                  title: "Confirm Restore All",
+                  message: "Are you sure you want to restore all the files ?",
+                  onConfirm: () {
+                    context.read<TrashBloc>().add(
+                          const TrashEvent.restoreAll(),
+                        );
+                  },
+                );
+              },
             ),
           ),
           const HSpace(6),
           IntrinsicWidth(
             child: FlowyButton(
-              text: FlowyText.medium(LocaleKeys.trash_deleteAll.tr()),
-              leftIcon: const FlowySvg(FlowySvgs.delete_s),
-              onTap: () =>
-                  context.read<TrashBloc>().add(const TrashEvent.deleteAll()),
-            ),
+                text: FlowyText.medium(LocaleKeys.trash_deleteAll.tr()),
+                leftIcon: const FlowySvg(FlowySvgs.delete_s),
+                onTap: () {
+                  showConfirmationDialog(
+                    context: context,
+                    title: "Confirm Delete All",
+                    message: "Are you sure you want to delete all the files ?",
+                    onConfirm: () {
+                      context
+                          .read<TrashBloc>()
+                          .add(const TrashEvent.deleteAll());
+                    },
+                  );
+                }),
           ),
         ],
       ),

--- a/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
@@ -114,20 +114,19 @@ class _TrashPageState extends State<TrashPage> {
           const HSpace(6),
           IntrinsicWidth(
             child: FlowyButton(
-                text: FlowyText.medium(LocaleKeys.trash_deleteAll.tr()),
-                leftIcon: const FlowySvg(FlowySvgs.delete_s),
-                onTap: () {
-                  showConfirmationDialog(
-                    context: context,
-                    title: "Confirm Delete All",
-                    message: "Are you sure you want to delete all the files ?",
-                    onConfirm: () {
-                      context
-                          .read<TrashBloc>()
-                          .add(const TrashEvent.deleteAll());
-                    },
-                  );
-                }),
+              text: FlowyText.medium(LocaleKeys.trash_deleteAll.tr()),
+              leftIcon: const FlowySvg(FlowySvgs.delete_s),
+              onTap: () {
+                showConfirmationDialog(
+                  context: context,
+                  title: "Confirm Delete All",
+                  message: "Are you sure you want to delete all the files ?",
+                  onConfirm: () {
+                    context.read<TrashBloc>().add(const TrashEvent.deleteAll());
+                  },
+                );
+              },
+            ),
           ),
         ],
       ),

--- a/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/trash_page.dart
@@ -2,6 +2,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/trash/src/sizes.dart';
 import 'package:appflowy/plugins/trash/src/trash_header.dart';
+import 'package:appflowy/plugins/trash/application/trash_prompt.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/size.dart';
@@ -133,10 +134,27 @@ class _TrashPageState extends State<TrashPage> {
             child: TrashCell(
               object: object,
               onRestore: () {
-                context.read<TrashBloc>().add(TrashEvent.putback(object.id));
+                showConfirmationDialog(
+                  context: context,
+                  title: "Confirm Restore",
+                  message: "Are you sure you want to restore this item?",
+                  onConfirm: () {
+                    context
+                        .read<TrashBloc>()
+                        .add(TrashEvent.putback(object.id));
+                  },
+                );
               },
-              onDelete: () =>
-                  context.read<TrashBloc>().add(TrashEvent.delete(object)),
+              onDelete: () {
+                showConfirmationDialog(
+                  context: context,
+                  title: "Confirm Delete",
+                  message: "Are you sure you want to delete this item?",
+                  onConfirm: () {
+                    context.read<TrashBloc>().add(TrashEvent.delete(object));
+                  },
+                );
+              },
             ),
           );
         },


### PR DESCRIPTION
### Feature Preview

Added prompt that asks for confirmation before "deleting" or "restoring" the files from the trash

This PR closes #4165 

---
![image](https://github.com/AppFlowy-IO/AppFlowy/assets/85027826/0ae310e3-c229-4bac-8468-c2326bf02314)

<!---
Before you mark this PR ready for review, run through this checklist!
-->

Tasks left : 

- [ ] Convert the hardcoded strings to localizable
- [ ] Adapt the prompt to have Theme of general NavigationAlert Class

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
