### PR TITLE
fix: renamed duplicate shortcut commands

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_copy_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_copy_command.dart
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 ///   - mobile
 ///
 final CommandShortcutEvent customCopyCommand = CommandShortcutEvent(
-  key: 'copy the selected content',
+  key: 'copy the selected content (with formatting)',
   command: 'ctrl+c',
   macOSCommand: 'cmd+c',
   handler: _copyCommandHandler,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_cut_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_cut_command.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 ///   - mobile
 ///
 final CommandShortcutEvent customCutCommand = CommandShortcutEvent(
-  key: 'cut the selected content',
+  key: 'cut the selected content (with formatting)',
   command: 'ctrl+x',
   macOSCommand: 'cmd+x',
   handler: _cutCommandHandler,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
@@ -18,7 +18,7 @@ import 'package:string_validator/string_validator.dart';
 ///   - mobile
 ///
 final CommandShortcutEvent customPasteCommand = CommandShortcutEvent(
-  key: 'paste the content',
+  key: 'paste the content (with formatting)',
   command: 'ctrl+v',
   macOSCommand: 'cmd+v',
   handler: _pasteCommandHandler,


### PR DESCRIPTION
### Feature Preview

renamed the duplicated 
Copy, Paste, and Cut commands

![image](https://github.com/AppFlowy-IO/AppFlowy/assets/85027826/e3424aa7-d1e4-4c9c-9d66-91804bd990b4)
![image](https://github.com/AppFlowy-IO/AppFlowy/assets/85027826/496872d5-6e9c-4dad-b773-fd4234722e9c)
![image](https://github.com/AppFlowy-IO/AppFlowy/assets/85027826/bf9182a1-29cf-4599-b44a-4618c1613fe8)


this PR closes #4193 
<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
