### PR TITLE
chore: remove misleading vscode launch task

### DIFF
--- a/frontend/.vscode/launch.json
+++ b/frontend/.vscode/launch.json
@@ -70,16 +70,6 @@
             "cwd": "${workspaceRoot}/appflowy_flutter"
         },
         {
-            "name": "AF-iOS-Simulator: Build Dart only",
-            "request": "launch",
-            "program": "./lib/main.dart",
-            "type": "dart",
-            "env": {
-                "RUST_LOG": "trace"
-            },
-            "cwd": "${workspaceRoot}/appflowy_flutter"
-        },
-        {
             "name": "AF-iOS-Simulator: Build All",
             "request": "launch",
             "program": "./lib/main.dart",


### PR DESCRIPTION
The `Build Dart Only` config caters to desktop, ios, ios-simulator android and android-simulator. If you have ios-simulator selected as active device, it will launch AppFlowy on the simulator.

Actually, most of the launch configs are kind of misleading. The `<platform>: Build All` and `<platform>: Clean and Rebuild All` builds the libraries for the specific platform. But which platform AppFlowy will open still depends on which device you have as active at the bottom right.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
