### PR TITLE
fix: bottom sheet updates apply immediately

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_bottom_sheets.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_bottom_sheets.dart
@@ -1,7 +1,6 @@
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_controller.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_info.dart';
-import 'package:appflowy/plugins/database_view/application/field/field_service.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -57,32 +56,9 @@ Future<FieldOptionValues?> showEditFieldScreen(
     MobileEditPropertyScreen.routeName,
     extra: {
       MobileEditPropertyScreen.argViewId: viewId,
-      MobileEditPropertyScreen.argField: field.field,
+      MobileEditPropertyScreen.argField: field,
     },
   );
-  if (optionValues != null) {
-    final service = FieldBackendService(
-      viewId: viewId,
-      fieldId: field.id,
-    );
-
-    if (optionValues.name != field.name) {
-      await service.updateField(name: optionValues.name);
-    }
-
-    if (optionValues.type != field.fieldType) {
-      await service.updateFieldType(fieldType: optionValues.type);
-    }
-
-    final data = optionValues.toTypeOptionBuffer();
-    if (data != null) {
-      await FieldBackendService.updateFieldTypeOption(
-        viewId: viewId,
-        fieldId: field.id,
-        typeOptionData: data,
-      );
-    }
-  }
 
   return optionValues;
 }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_bottom_sheets.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_bottom_sheets.dart
@@ -1,6 +1,7 @@
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_controller.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_info.dart';
+import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -11,7 +12,11 @@ import 'mobile_field_type_grid.dart';
 import 'mobile_field_type_option_editor.dart';
 import 'mobile_quick_field_editor.dart';
 
-void showCreateFieldBottomSheet(BuildContext context, String viewId) {
+void showCreateFieldBottomSheet(
+  BuildContext context,
+  String viewId, {
+  OrderObjectPositionPB? position,
+}) {
   showMobileBottomSheet(
     context,
     padding: EdgeInsets.zero,
@@ -35,7 +40,7 @@ void showCreateFieldBottomSheet(BuildContext context, String viewId) {
               ).toString(),
             );
             if (optionValues != null) {
-              await optionValues.create(viewId: viewId);
+              await optionValues.create(viewId: viewId, position: position);
               if (context.mounted) {
                 context.pop();
               }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_picker_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_picker_list.dart
@@ -101,7 +101,7 @@ class _Header extends StatelessWidget {
                 ),
                 onPressed: () => context.pop(newFieldId),
                 child: FlowyText.medium(
-                  LocaleKeys.button_save.tr(),
+                  LocaleKeys.button_done.tr(),
                   fontSize: 16,
                   color: Theme.of(context).colorScheme.onPrimary,
                   overflow: TextOverflow.ellipsis,

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_type_option_editor.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_field_type_option_editor.dart
@@ -55,12 +55,14 @@ class FieldOptionValues {
 
   Future<void> create({
     required String viewId,
+    OrderObjectPositionPB? position,
   }) async {
     await FieldBackendService.createField(
       viewId: viewId,
       fieldType: type,
       fieldName: name,
       typeOptionData: getTypeOptionData(),
+      position: position,
     );
   }
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
@@ -114,7 +114,14 @@ class _QuickEditFieldState extends State<QuickEditField> {
             leftIcon: const FlowySvg(FlowySvgs.insert_left_s),
             onTap: () async {
               context.pop();
-              await service.insertLeft();
+              showCreateFieldBottomSheet(
+                context,
+                widget.viewId,
+                position: OrderObjectPositionPB(
+                  position: OrderObjectPositionTypePB.Before,
+                  objectId: widget.fieldInfo.id,
+                ),
+              );
             },
           ),
         FlowyOptionTile.text(
@@ -123,7 +130,14 @@ class _QuickEditFieldState extends State<QuickEditField> {
           leftIcon: const FlowySvg(FlowySvgs.insert_right_s),
           onTap: () async {
             context.pop();
-            await service.insertRight();
+            showCreateFieldBottomSheet(
+              context,
+              widget.viewId,
+              position: OrderObjectPositionPB(
+                position: OrderObjectPositionTypePB.After,
+                objectId: widget.fieldInfo.id,
+              ),
+            );
           },
         ),
         if (!widget.fieldInfo.isPrimary) ...[

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
@@ -6,11 +6,13 @@ import 'package:appflowy/mobile/presentation/database/field/mobile_field_bottom_
 import 'package:appflowy/mobile/presentation/widgets/widgets.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_backend_service.dart';
 import 'package:appflowy/plugins/database_view/application/field/field_info.dart';
+import 'package:appflowy/plugins/database_view/widgets/setting/field_visibility_extension.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:protobuf/protobuf.dart' hide FieldInfo;
 
 class QuickEditField extends StatefulWidget {
   const QuickEditField({
@@ -35,12 +37,15 @@ class _QuickEditFieldState extends State<QuickEditField> {
   );
 
   late FieldType fieldType;
+  late FieldVisibility fieldVisibility;
 
   @override
   void initState() {
     super.initState();
 
     fieldType = widget.fieldInfo.fieldType;
+    fieldVisibility = widget.fieldInfo.fieldSettings?.visibility ??
+        FieldVisibility.AlwaysShown;
     controller.text = widget.fieldInfo.field.name;
   }
 
@@ -69,10 +74,14 @@ class _QuickEditFieldState extends State<QuickEditField> {
           text: LocaleKeys.grid_field_editProperty.tr(),
           leftIcon: const FlowySvg(FlowySvgs.edit_s),
           onTap: () async {
+            widget.fieldInfo.field.freeze();
+            final field = widget.fieldInfo.field.rebuild((field) {
+              field.name = controller.text;
+            });
             final optionValues = await showEditFieldScreen(
               context,
               widget.viewId,
-              widget.fieldInfo,
+              widget.fieldInfo.copyWith(field: field),
             );
             if (optionValues != null) {
               setState(() {
@@ -85,11 +94,17 @@ class _QuickEditFieldState extends State<QuickEditField> {
         if (!widget.fieldInfo.isPrimary)
           FlowyOptionTile.text(
             showTopBorder: false,
-            text: LocaleKeys.grid_field_hide.tr(),
+            text: fieldVisibility.isVisibleState()
+                ? LocaleKeys.grid_field_hide.tr()
+                : LocaleKeys.grid_field_show.tr(),
             leftIcon: const FlowySvg(FlowySvgs.hide_s),
             onTap: () async {
               context.pop();
-              await service.hide();
+              if (fieldVisibility.isVisibleState()) {
+                await service.hide();
+              } else {
+                await service.hide();
+              }
             },
           ),
         if (!widget.fieldInfo.isPrimary)

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
@@ -110,7 +110,19 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
       )..add(const DatabasePropertyEvent.initial()),
       child: BlocBuilder<DatabasePropertyBloc, DatabasePropertyState>(
         builder: (context, state) {
-          final cells = state.fieldContexts
+          if (state.fieldContexts.isEmpty) {
+            return const SizedBox.shrink();
+          }
+          final fields = [...state.fieldContexts];
+          final firstField = fields.removeAt(0);
+          final firstCell = DatabaseFieldListTile(
+            key: ValueKey(firstField.id),
+            viewId: view.id,
+            fieldController: databaseController.fieldController,
+            fieldInfo: firstField,
+            showTopBorder: true,
+          );
+          final cells = fields
               .mapIndexed(
                 (index, field) => DatabaseFieldListTile(
                   key: ValueKey(field.id),
@@ -118,14 +130,14 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
                   fieldController: databaseController.fieldController,
                   fieldInfo: field,
                   index: index,
-                  showTopBorder: index == 0,
+                  showTopBorder: false,
                 ),
               )
               .toList();
 
           return ReorderableListView.builder(
             proxyDecorator: (_, index, anim) {
-              final field = state.fieldContexts[index];
+              final field = fields[index];
               return AnimatedBuilder(
                 animation: anim,
                 builder: (BuildContext context, Widget? child) {
@@ -151,10 +163,13 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
             buildDefaultDragHandles: true,
             shrinkWrap: true,
             onReorder: (from, to) {
+              from++;
+              to++;
               context
                   .read<DatabasePropertyBloc>()
                   .add(DatabasePropertyEvent.moveField(from, to));
             },
+            header: firstCell,
             footer: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -176,14 +191,14 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
 class DatabaseFieldListTile extends StatelessWidget {
   const DatabaseFieldListTile({
     super.key,
-    required this.index,
+    this.index,
     required this.fieldInfo,
     required this.viewId,
     required this.fieldController,
     required this.showTopBorder,
   });
 
-  final int index;
+  final int? index;
   final FieldInfo fieldInfo;
   final String viewId;
   final FieldController fieldController;

--- a/frontend/appflowy_flutter/lib/plugins/database_view/application/field/field_backend_service.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/application/field/field_backend_service.dart
@@ -36,6 +36,13 @@ class FieldServices {
     );
   }
 
+  Future<void> show() async {
+    await fieldSettingsService.updateFieldSettings(
+      fieldId: fieldId,
+      fieldVisibility: FieldVisibility.AlwaysShown,
+    );
+  }
+
   Future<void> delete() async {
     await fieldBackendService.delete();
   }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/application/grid_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/application/grid_bloc.dart
@@ -27,15 +27,20 @@ class GridBloc extends Bloc<GridEvent, GridState> {
             _startListening();
             await _openGrid(emit);
           },
-          createRow: () async {
+          createRow: (openRowDetail) async {
             final result = await RowBackendService.createRow(viewId: viewId);
             result.fold(
-              (createdRow) => emit(state.copyWith(createdRow: createdRow)),
+              (createdRow) => emit(
+                state.copyWith(
+                  createdRow: createdRow,
+                  openRowDetail: openRowDetail ?? false,
+                ),
+              ),
               (err) => Log.error(err),
             );
           },
           resetCreatedRow: () {
-            emit(state.copyWith(createdRow: null));
+            emit(state.copyWith(createdRow: null, openRowDetail: false));
           },
           deleteRow: (rowInfo) async {
             await RowBackendService.deleteRow(rowInfo.viewId, rowInfo.rowId);
@@ -151,7 +156,7 @@ class GridBloc extends Bloc<GridEvent, GridState> {
 @freezed
 class GridEvent with _$GridEvent {
   const factory GridEvent.initial() = InitialGrid;
-  const factory GridEvent.createRow() = _CreateRow;
+  const factory GridEvent.createRow({bool? openRowDetail}) = _CreateRow;
   const factory GridEvent.resetCreatedRow() = _ResetCreatedRow;
   const factory GridEvent.deleteRow(RowInfo rowInfo) = _DeleteRow;
   const factory GridEvent.moveRow(int from, int to) = _MoveRow;
@@ -187,6 +192,7 @@ class GridState with _$GridState {
     required ChangedReason reason,
     required List<SortInfo> sorts,
     required List<FilterInfo> filters,
+    required bool openRowDetail,
   }) = _GridState;
 
   factory GridState.initial(String viewId) => GridState(
@@ -201,5 +207,6 @@ class GridState with _$GridState {
         reason: const InitialListState(),
         filters: [],
         sorts: [],
+        openRowDetail: false,
       );
 }

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/mobile_grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/mobile_grid_page.dart
@@ -139,7 +139,7 @@ class _GridPageContentState extends State<GridPageContent> {
       listenWhen: (previous, current) =>
           previous.createdRow != current.createdRow,
       listener: (context, state) {
-        if (state.createdRow == null) {
+        if (state.createdRow == null || !state.openRowDetail) {
           return;
         }
         final bloc = context.read<GridBloc>();

--- a/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/mobile_fab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_view/grid/presentation/widgets/mobile_fab.dart
@@ -39,7 +39,9 @@ Widget getGridFabs(BuildContext context) {
         backgroundColor: Theme.of(context).primaryColor,
         foregroundColor: Colors.white,
         onTap: () {
-          context.read<GridBloc>().add(const GridEvent.createRow());
+          context
+              .read<GridBloc>()
+              .add(const GridEvent.createRow(openRowDetail: true));
         },
         overlayColor: const MaterialStatePropertyAll<Color>(Color(0xFF009FD1)),
         boxShadow: const BoxShadow(

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -620,7 +620,7 @@
       "aquaColor": "Aqua",
       "blueColor": "Blue",
       "deleteTag": "Delete tag",
-      "colorPanelTitle": "Colors",
+      "colorPanelTitle": "Color",
       "panelTitle": "Select an option or create one",
       "searchOption": "Search for an option",
       "searchOrCreateOption": "Search or create an option...",
@@ -778,7 +778,6 @@
     "textBlock": {
       "placeholder": "Type '/' for commands"
     },
-
     "title": {
       "placeholder": "Untitled"
     },


### PR DESCRIPTION
Whereas before lots of user flows require clicking on a Done or Save button to apply changes, now changes are updated instantaneously.

Also fixes a bug where field editor for hidden fields still show the hide option rather than show.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
