### PR TITLE
fix: notify all views of field type option changes

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database2/src/event_handler.rs
@@ -219,12 +219,7 @@ pub(crate) async fn update_field_type_option_handler(
     let field_type = FieldType::from(old_field.field_type);
     let type_option_data = type_option_data_from_pb(params.type_option_data, &field_type)?;
     database_editor
-      .update_field_type_option(
-        &params.view_id,
-        &params.field_id,
-        type_option_data,
-        old_field,
-      )
+      .update_field_type_option(&params.field_id, type_option_data, old_field)
       .await?;
   }
   Ok(())
@@ -262,12 +257,7 @@ pub(crate) async fn switch_to_field_handler(
     match (old_field, new_type_option) {
       (Some(old_field), Some(new_type_option)) => {
         database_editor
-          .update_field_type_option(
-            &params.view_id,
-            &params.field_id,
-            new_type_option,
-            old_field,
-          )
+          .update_field_type_option(&params.field_id, new_type_option, old_field)
           .await?;
       },
       _ => {

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_editor.rs
@@ -363,7 +363,7 @@ impl DatabaseViewEditor {
       if let (Some(type_option_data), Some(payload)) = result {
         self
           .delegate
-          .update_field(&self.view_id, type_option_data, old_field)
+          .update_field(type_option_data, old_field)
           .await?;
 
         let group_changes = GroupChangesPB {
@@ -402,10 +402,7 @@ impl DatabaseViewEditor {
       changes.deleted_rows.extend(deleted_rows);
 
       if let Some(type_option) = type_option_data {
-        self
-          .delegate
-          .update_field(&self.view_id, type_option, field)
-          .await?;
+        self.delegate.update_field(type_option, field).await?;
       }
       let notification = GroupChangesPB {
         view_id: self.view_id.clone(),
@@ -436,7 +433,7 @@ impl DatabaseViewEditor {
       if !type_option_data.is_empty() {
         self
           .delegate
-          .update_field(&self.view_id, type_option_data, old_field)
+          .update_field(type_option_data, old_field)
           .await?;
       }
       let notification = GroupChangesPB {

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_operation.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_operation.rs
@@ -41,7 +41,6 @@ pub trait DatabaseViewOperation: Send + Sync + 'static {
 
   fn update_field(
     &self,
-    view_id: &str,
     type_option_data: TypeOptionData,
     old_field: Field,
   ) -> FutureResult<(), FlowyError>;

--- a/frontend/rust-lib/flowy-database2/src/services/field/field_operation.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/field_operation.rs
@@ -9,7 +9,6 @@ use crate::services::database::DatabaseEditor;
 use crate::services::field::{MultiSelectTypeOption, SingleSelectTypeOption};
 
 pub async fn edit_field_type_option<T: From<TypeOptionData> + Into<TypeOptionData>>(
-  view_id: &str,
   field_id: &str,
   editor: Arc<DatabaseEditor>,
   action: impl FnOnce(&mut T),
@@ -25,7 +24,7 @@ pub async fn edit_field_type_option<T: From<TypeOptionData> + Into<TypeOptionDat
       action(&mut type_option);
       let type_option_data: TypeOptionData = type_option.into();
       editor
-        .update_field_type_option(view_id, field_id, type_option_data, old_field)
+        .update_field_type_option(field_id, type_option_data, old_field)
         .await?;
     }
   }
@@ -34,19 +33,17 @@ pub async fn edit_field_type_option<T: From<TypeOptionData> + Into<TypeOptionDat
 }
 
 pub async fn edit_single_select_type_option(
-  view_id: &str,
   field_id: &str,
   editor: Arc<DatabaseEditor>,
   action: impl FnOnce(&mut SingleSelectTypeOption),
 ) -> FlowyResult<()> {
-  edit_field_type_option(view_id, field_id, editor, action).await
+  edit_field_type_option(field_id, editor, action).await
 }
 
 pub async fn edit_multi_select_type_option(
-  view_id: &str,
   field_id: &str,
   editor: Arc<DatabaseEditor>,
   action: impl FnOnce(&mut MultiSelectTypeOption),
 ) -> FlowyResult<()> {
-  edit_field_type_option(view_id, field_id, editor, action).await
+  edit_field_type_option(field_id, editor, action).await
 }

--- a/frontend/rust-lib/flowy-database2/tests/database/field_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/field_test/script.rs
@@ -99,7 +99,7 @@ impl DatabaseFieldTest {
         let old_field = self.editor.get_field(&field_id).unwrap();
         self
           .editor
-          .update_field_type_option(&self.view_id, &field_id, type_option, old_field)
+          .update_field_type_option(&field_id, type_option, old_field)
           .await
           .unwrap();
       },

--- a/frontend/rust-lib/flowy-database2/tests/database/group_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/group_test/script.rs
@@ -306,14 +306,9 @@ impl DatabaseGroupTest {
     action: impl FnOnce(&mut SingleSelectTypeOption),
   ) {
     let single_select = self.get_single_select_field().await;
-    edit_single_select_type_option(
-      &self.view_id,
-      &single_select.id,
-      self.editor.clone(),
-      action,
-    )
-    .await
-    .unwrap();
+    edit_single_select_type_option(&single_select.id, self.editor.clone(), action)
+      .await
+      .unwrap();
   }
 
   pub async fn get_url_field(&self) -> Field {


### PR DESCRIPTION
This is a hot-fix for a bug where if a new option is inserted in a grid, a relevant stack isn't being created in a linked kanban board.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
