### PR TITLE
chore: bump client api

### DIFF
--- a/frontend/appflowy_flutter/lib/startup/startup.dart
+++ b/frontend/appflowy_flutter/lib/startup/startup.dart
@@ -89,7 +89,6 @@ class FlowyRunner {
       config.rustEnvs["APP_VERSION"] =
           await PackageInfo.fromPlatform().then((value) => value.version);
     }
-
     // Specify the env
     await initGetIt(getIt, mode, f, config);
     await didInitGetItCallback?.call();

--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1256,7 +1256,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1602,7 +1602,7 @@ dependencies = [
  "console",
  "fancy-regex 0.10.0",
  "flowy-ast",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "phf 0.8.0",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -2962,15 +2962,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -4283,7 +4274,7 @@ checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -4304,7 +4295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.47",
@@ -4589,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "realtime-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4611,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "realtime-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "bincode",
@@ -5258,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "shared_entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -7041,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "workspace-template"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -57,7 +57,7 @@ custom-protocol = ["tauri/custom-protocol"]
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "05d9297dc55886237f8c9feb367d632bec8ade8c" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "2159c68688a69af83e1c8d07cf17c40f0c315566" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1025,7 +1025,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.8.0",
  "smallvec",
 ]
 
@@ -1153,7 +1153,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1554,7 +1554,7 @@ dependencies = [
  "console",
  "fancy-regex 0.10.0",
  "flowy-ast",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "phf 0.8.0",
@@ -2300,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2316,7 +2316,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -2701,15 +2701,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -3383,7 +3374,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
- "phf_macros 0.8.0",
+ "phf_macros",
  "phf_shared 0.8.0",
  "proc-macro-hack",
 ]
@@ -3403,7 +3394,6 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros 0.11.2",
  "phf_shared 0.11.2",
 ]
 
@@ -3469,19 +3459,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
- "proc-macro2",
- "quote",
- "syn 2.0.47",
 ]
 
 [[package]]
@@ -3687,7 +3664,7 @@ checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -3708,7 +3685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.47",
@@ -4037,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "realtime-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4059,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "realtime-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4637,7 +4614,7 @@ dependencies = [
 [[package]]
 name = "shared_entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "app-error",
@@ -5935,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "workspace-template"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=05d9297dc55886237f8c9feb367d632bec8ade8c#05d9297dc55886237f8c9feb367d632bec8ade8c"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=2159c68688a69af83e1c8d07cf17c40f0c315566#2159c68688a69af83e1c8d07cf17c40f0c315566"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -107,7 +107,7 @@ incremental = false
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "05d9297dc55886237f8c9feb367d632bec8ade8c" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "2159c68688a69af83e1c8d07cf17c40f0c315566" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #


### PR DESCRIPTION
Every request to AppFlowy cloud will carry the client api version