### PR TITLE
feat: support aligning the text block using shortcuts

### DIFF
--- a/frontend/appflowy_flutter/integration_test/document/document_alignment_test.dart
+++ b/frontend/appflowy_flutter/integration_test/document/document_alignment_test.dart
@@ -1,8 +1,10 @@
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import '../util/keyboard.dart';
 import '../util/util.dart';
 
 void main() {
@@ -40,6 +42,52 @@ void main() {
       // click the align left
       await tester.tapButtonWithFlowySvgData(FlowySvgs.toolbar_align_right_s);
       await tester.tapButtonWithFlowySvgData(FlowySvgs.toolbar_align_left_s);
+      expect(first.attributes[blockComponentAlign], 'left');
+    });
+
+    testWidgets('edit alignment using shortcut', (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapGoButton();
+
+      // click the first line of the readme
+      await tester.editor.tapLineOfEditorAt(0);
+
+      await tester.pumpAndSettle();
+
+      final editorState = tester.editor.getCurrentEditorState();
+      final first = editorState.getNodeAtPath([0])!;
+      
+      // expect to see text aligned to the right
+      await FlowyTestKeyboard.simulateKeyDownEvent(
+        [
+          LogicalKeyboardKey.control,
+          LogicalKeyboardKey.shift,
+          LogicalKeyboardKey.keyR,
+        ],
+        tester: tester,
+      );
+      expect(first.attributes[blockComponentAlign], 'right');
+
+      // expect to see text aligned to the center
+      await FlowyTestKeyboard.simulateKeyDownEvent(
+        [
+          LogicalKeyboardKey.control,
+          LogicalKeyboardKey.shift,
+          LogicalKeyboardKey.keyE,
+        ],
+        tester: tester,
+      );
+      expect(first.attributes[blockComponentAlign], 'center');
+
+      // expect to see text aligned to the left
+      await FlowyTestKeyboard.simulateKeyDownEvent(
+        [
+          LogicalKeyboardKey.control,
+          LogicalKeyboardKey.shift,
+          LogicalKeyboardKey.keyL,
+        ],
+        tester: tester,
+      );
       expect(first.attributes[blockComponentAlign], 'left');
     });
   });

--- a/frontend/appflowy_flutter/integration_test/document/document_alignment_test.dart
+++ b/frontend/appflowy_flutter/integration_test/document/document_alignment_test.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/generated/flowy_svgs.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -66,7 +67,7 @@ void main() {
         ],
         tester: tester,
       );
-      expect(first.attributes[blockComponentAlign], 'right');
+      expect(first.attributes[blockComponentAlign], rightAlignmentKey);
 
       // expect to see text aligned to the center
       await FlowyTestKeyboard.simulateKeyDownEvent(
@@ -77,7 +78,7 @@ void main() {
         ],
         tester: tester,
       );
-      expect(first.attributes[blockComponentAlign], 'center');
+      expect(first.attributes[blockComponentAlign], centerAlignmentKey);
 
       // expect to see text aligned to the left
       await FlowyTestKeyboard.simulateKeyDownEvent(
@@ -88,7 +89,7 @@ void main() {
         ],
         tester: tester,
       );
-      expect(first.attributes[blockComponentAlign], 'left');
+      expect(first.attributes[blockComponentAlign], leftAlignmentKey);
     });
   });
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy/plugins/document/application/doc_bloc.dart';
 import 'package:appflowy/plugins/document/presentation/editor_configuration.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/background_color/theme_background_color.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/base/page_reference_commands.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/i18n/editor_i18n.dart';
@@ -31,6 +32,7 @@ final List<CommandShortcutEvent> commandShortcutEvents = [
   customCopyCommand,
   customPasteCommand,
   customCutCommand,
+  ...customTextAlignCommands,
   ...standardCommandShortcutEvents,
 ];
 
@@ -86,6 +88,7 @@ class _AppFlowyEditorPageState extends State<AppFlowyEditorPage> {
     customCopyCommand,
     customPasteCommand,
     customCutCommand,
+    ...customTextAlignCommands,
     ...standardCommandShortcutEvents,
     ..._buildFindAndReplaceCommands(),
   ];

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/align_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/align_toolbar_item.dart
@@ -7,6 +7,10 @@ import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/flowy_tooltip.dart';
 import 'package:flutter/material.dart';
 
+const String leftAlignmentKey = 'left';
+const String centerAlignmentKey = 'center';
+const String rightAlignmentKey = 'right'; 
+
 final alignToolbarItem = ToolbarItem(
   id: 'editor.align',
   group: 4,
@@ -23,13 +27,13 @@ final alignToolbarItem = ToolbarItem(
 
     bool isHighlight = false;
     FlowySvgData data = FlowySvgs.toolbar_align_left_s;
-    if (isSatisfyCondition((value) => value == 'left')) {
+    if (isSatisfyCondition((value) => value == leftAlignmentKey)) {
       isHighlight = true;
       data = FlowySvgs.toolbar_align_left_s;
-    } else if (isSatisfyCondition((value) => value == 'center')) {
+    } else if (isSatisfyCondition((value) => value == centerAlignmentKey)) {
       isHighlight = true;
       data = FlowySvgs.toolbar_align_center_s;
-    } else if (isSatisfyCondition((value) => value == 'right')) {
+    } else if (isSatisfyCondition((value) => value == rightAlignmentKey)) {
       isHighlight = true;
       data = FlowySvgs.toolbar_align_right_s;
     }
@@ -121,19 +125,19 @@ class _AlignButtons extends StatelessWidget {
           _AlignButton(
             icon: FlowySvgs.toolbar_align_left_s,
             tooltips: LocaleKeys.document_plugins_optionAction_left.tr(),
-            onTap: () => onAlignChanged('left'),
+            onTap: () => onAlignChanged(leftAlignmentKey),
           ),
           const _Divider(),
           _AlignButton(
             icon: FlowySvgs.toolbar_align_center_s,
             tooltips: LocaleKeys.document_plugins_optionAction_center.tr(),
-            onTap: () => onAlignChanged('center'),
+            onTap: () => onAlignChanged(centerAlignmentKey),
           ),
           const _Divider(),
           _AlignButton(
             icon: FlowySvgs.toolbar_align_right_s,
             tooltips: LocaleKeys.document_plugins_optionAction_right.tr(),
-            onTap: () => onAlignChanged('right'),
+            onTap: () => onAlignChanged(rightAlignmentKey),
           ),
           const HSpace(4),
         ],

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
@@ -1,0 +1,104 @@
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+
+final List<CommandShortcutEvent> customTextAlignCommands = [
+  customTextLeftAlignCommand,
+  customTextCenterAlignCommand,
+  customTextRighttAlignCommand,
+];
+
+/// Windows / Linux : ctrl + shift + l
+/// Mac Os          : ctrl + shift + l
+/// Allows the user to align text to the left
+///
+/// - support
+///   - desktop
+///   - web
+///
+final CommandShortcutEvent customTextLeftAlignCommand = CommandShortcutEvent(
+  key: 'Align text to the left',
+  command: 'ctrl+shift+l',
+  macOSCommand: 'ctrl+shift+l',
+  handler: _textLeftAlignCommandHandler,
+);
+
+/// Windows / Linux : ctrl + shift + e
+/// Mac Os          : ctrl + shift + e
+/// Allows the user to align text to the center
+///
+/// - support
+///   - desktop
+///   - web
+///
+final CommandShortcutEvent customTextCenterAlignCommand = CommandShortcutEvent(
+  key: 'Align text to the center',
+  command: 'ctrl+shift+e',
+  macOSCommand: 'ctrl+shift+e',
+  handler: _textCenterAlignCommandHandler,
+);
+
+/// Windows / Linux : ctrl + shift + r
+/// Mac Os          : ctrl + shift + r
+/// Allows the user to align text to the right
+///
+/// - support
+///   - desktop
+///   - web
+///
+final CommandShortcutEvent customTextRighttAlignCommand = CommandShortcutEvent(
+  key: 'Align text to the right',
+  command: 'ctrl+shift+r',
+  macOSCommand: 'ctrl+shift+r',
+  handler: _textRightAlignCommandHandler,
+);
+
+CommandShortcutEventHandler _textLeftAlignCommandHandler = (editorState) {
+  if (editorState.selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  // because the event handler is not async, so we need to use wrap the async function here
+  () async {
+    await _textAlignHandler(editorState, 'left');
+  }();
+
+  return KeyEventResult.handled;
+};
+
+CommandShortcutEventHandler _textCenterAlignCommandHandler = (editorState) {
+  if (editorState.selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  // because the event handler is not async, so we need to use wrap the async function here
+  () async {
+    await _textAlignHandler(editorState, 'center');
+  }();
+
+  return KeyEventResult.handled;
+};
+
+CommandShortcutEventHandler _textRightAlignCommandHandler = (editorState) {
+  if (editorState.selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  // because the event handler is not async, so we need to use wrap the async function here
+  () async {
+    await _textAlignHandler(editorState, 'right');
+  }();
+
+  return KeyEventResult.handled;
+};
+
+Future<void> _textAlignHandler(EditorState editorState, String align) async {
+  await editorState.updateNode(
+    editorState.selection!,
+    (node) => node.copyWith(
+      attributes: {
+        ...node.attributes,
+        blockComponentAlign: align,
+      },
+    ),
+  );
+}

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
@@ -56,19 +56,16 @@ KeyEventResult _textAlignHandler(EditorState editorState, String align) {
   if (selection == null) {
     return KeyEventResult.ignored;
   }
-
-  // because the event handler is not async, so we need to use wrap the async function here
-  () async {
-    await editorState.updateNode(
-      selection,
-      (node) => node.copyWith(
-        attributes: {
-          ...node.attributes,
-          blockComponentAlign: align,
-        },
-      ),
-    );
-  }();
+  
+  editorState.updateNode(
+    selection,
+    (node) => node.copyWith(
+      attributes: {
+        ...node.attributes,
+        blockComponentAlign: align,
+      },
+    ),
+  );
 
   return KeyEventResult.handled;
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
@@ -5,11 +5,11 @@ import 'package:flutter/material.dart';
 final List<CommandShortcutEvent> customTextAlignCommands = [
   customTextLeftAlignCommand,
   customTextCenterAlignCommand,
-  customTextRighttAlignCommand,
+  customTextRightAlignCommand,
 ];
 
 /// Windows / Linux : ctrl + shift + l
-/// Mac Os          : ctrl + shift + l
+/// macOs           : ctrl + shift + l
 /// Allows the user to align text to the left
 ///
 /// - support
@@ -19,12 +19,11 @@ final List<CommandShortcutEvent> customTextAlignCommands = [
 final CommandShortcutEvent customTextLeftAlignCommand = CommandShortcutEvent(
   key: 'Align text to the left',
   command: 'ctrl+shift+l',
-  macOSCommand: 'ctrl+shift+l',
-  handler: _textLeftAlignCommandHandler,
+  handler: (editorState) => _textAlignHandler(editorState, leftAlignmentKey),
 );
 
 /// Windows / Linux : ctrl + shift + e
-/// Mac Os          : ctrl + shift + e
+/// macOs           : ctrl + shift + e
 /// Allows the user to align text to the center
 ///
 /// - support
@@ -34,72 +33,42 @@ final CommandShortcutEvent customTextLeftAlignCommand = CommandShortcutEvent(
 final CommandShortcutEvent customTextCenterAlignCommand = CommandShortcutEvent(
   key: 'Align text to the center',
   command: 'ctrl+shift+e',
-  macOSCommand: 'ctrl+shift+e',
-  handler: _textCenterAlignCommandHandler,
+  handler: (editorState) => _textAlignHandler(editorState, centerAlignmentKey),
 );
 
 /// Windows / Linux : ctrl + shift + r
-/// Mac Os          : ctrl + shift + r
+/// macOs           : ctrl + shift + r
 /// Allows the user to align text to the right
 ///
 /// - support
 ///   - desktop
 ///   - web
 ///
-final CommandShortcutEvent customTextRighttAlignCommand = CommandShortcutEvent(
+final CommandShortcutEvent customTextRightAlignCommand = CommandShortcutEvent(
   key: 'Align text to the right',
   command: 'ctrl+shift+r',
-  macOSCommand: 'ctrl+shift+r',
-  handler: _textRightAlignCommandHandler,
+  handler: (editorState) => _textAlignHandler(editorState, rightAlignmentKey),
 );
 
-CommandShortcutEventHandler _textLeftAlignCommandHandler = (editorState) {
-  if (editorState.selection == null) {
+KeyEventResult _textAlignHandler(EditorState editorState, String align) {
+  final Selection? selection = editorState.selection;
+
+  if (selection == null) {
     return KeyEventResult.ignored;
   }
 
   // because the event handler is not async, so we need to use wrap the async function here
   () async {
-    await _textAlignHandler(editorState, leftAlignmentKey);
+    await editorState.updateNode(
+      selection,
+      (node) => node.copyWith(
+        attributes: {
+          ...node.attributes,
+          blockComponentAlign: align,
+        },
+      ),
+    );
   }();
 
   return KeyEventResult.handled;
-};
-
-CommandShortcutEventHandler _textCenterAlignCommandHandler = (editorState) {
-  if (editorState.selection == null) {
-    return KeyEventResult.ignored;
-  }
-
-  // because the event handler is not async, so we need to use wrap the async function here
-  () async {
-    await _textAlignHandler(editorState, centerAlignmentKey);
-  }();
-
-  return KeyEventResult.handled;
-};
-
-CommandShortcutEventHandler _textRightAlignCommandHandler = (editorState) {
-  if (editorState.selection == null) {
-    return KeyEventResult.ignored;
-  }
-
-  // because the event handler is not async, so we need to use wrap the async function here
-  () async {
-    await _textAlignHandler(editorState, rightAlignmentKey);
-  }();
-
-  return KeyEventResult.handled;
-};
-
-Future<void> _textAlignHandler(EditorState editorState, String align) async {
-  await editorState.updateNode(
-    editorState.selection!,
-    (node) => node.copyWith(
-      attributes: {
-        ...node.attributes,
-        blockComponentAlign: align,
-      },
-    ),
-  );
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
@@ -1,3 +1,4 @@
+import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 
@@ -59,7 +60,7 @@ CommandShortcutEventHandler _textLeftAlignCommandHandler = (editorState) {
 
   // because the event handler is not async, so we need to use wrap the async function here
   () async {
-    await _textAlignHandler(editorState, 'left');
+    await _textAlignHandler(editorState, leftAlignmentKey);
   }();
 
   return KeyEventResult.handled;
@@ -72,7 +73,7 @@ CommandShortcutEventHandler _textCenterAlignCommandHandler = (editorState) {
 
   // because the event handler is not async, so we need to use wrap the async function here
   () async {
-    await _textAlignHandler(editorState, 'center');
+    await _textAlignHandler(editorState, centerAlignmentKey);
   }();
 
   return KeyEventResult.handled;
@@ -85,7 +86,7 @@ CommandShortcutEventHandler _textRightAlignCommandHandler = (editorState) {
 
   // because the event handler is not async, so we need to use wrap the async function here
   () async {
-    await _textAlignHandler(editorState, 'right');
+    await _textAlignHandler(editorState, rightAlignmentKey);
   }();
 
   return KeyEventResult.handled;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/align_toolbar_item/custom_text_align_command.dart
@@ -9,7 +9,7 @@ final List<CommandShortcutEvent> customTextAlignCommands = [
 ];
 
 /// Windows / Linux : ctrl + shift + l
-/// macOs           : ctrl + shift + l
+/// macOS           : ctrl + shift + l
 /// Allows the user to align text to the left
 ///
 /// - support
@@ -23,7 +23,7 @@ final CommandShortcutEvent customTextLeftAlignCommand = CommandShortcutEvent(
 );
 
 /// Windows / Linux : ctrl + shift + e
-/// macOs           : ctrl + shift + e
+/// macOS           : ctrl + shift + e
 /// Allows the user to align text to the center
 ///
 /// - support
@@ -37,7 +37,7 @@ final CommandShortcutEvent customTextCenterAlignCommand = CommandShortcutEvent(
 );
 
 /// Windows / Linux : ctrl + shift + r
-/// macOs           : ctrl + shift + r
+/// macOS           : ctrl + shift + r
 /// Allows the user to align text to the right
 ///
 /// - support


### PR DESCRIPTION
This fix is related to the feature request issue:
> [FR] have a shortcut for text alignment: #3351

Added a feature that addresses the requirements of the issue, allowing users to align text in the document using shortcut keys. The implemented keyboard shortcuts are:

- `Ctrl+Shift+L`: Align left
- `Ctrl+Shift+E`: Align center
- `Ctrl+Shift+R`: Align  right

Additionally, included tests to ensure the functionality works as expected.
<img width="1257" alt="Screenshot 2024-01-06 at 9 24 00 PM" src="https://github.com/AppFlowy-IO/AppFlowy/assets/68953739/1553f399-30a8-43e8-8092-53836be5bda1">

https://github.com/AppFlowy-IO/AppFlowy/assets/68953739/2de99899-5e58-4f9d-915a-c30efe73ca53