### PR TITLE
feat: support RTL layout on mobile

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/appearance_setting_group.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/appearance_setting_group.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/mobile/presentation/setting/appearance/rtl_setting.dart';
 import 'package:appflowy/mobile/presentation/setting/appearance/theme_setting.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -17,6 +18,7 @@ class AppearanceSettingGroup extends StatelessWidget {
       settingItemList: const [
         ThemeSetting(),
         FontSetting(),
+        RTLSetting(),
       ],
     );
   }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/rtl_setting.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/rtl_setting.dart
@@ -1,0 +1,83 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
+import 'package:appflowy/mobile/presentation/widgets/widgets.dart';
+import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../setting.dart';
+
+class RTLSetting extends StatelessWidget {
+  const RTLSetting({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final layoutDirection =
+        context.watch<AppearanceSettingsCubit>().state.layoutDirection;
+    return MobileSettingItem(
+      name: LocaleKeys.settings_appearance_textDirection_label.tr(),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FlowyText(
+            _textDirectionLabelText(layoutDirection),
+            color: theme.colorScheme.onSurface,
+          ),
+          const Icon(Icons.chevron_right),
+        ],
+      ),
+      onTap: () {
+        showMobileBottomSheet(
+          context,
+          showHeader: true,
+          showDragHandle: true,
+          showDivider: false,
+          showCloseButton: false,
+          title: LocaleKeys.settings_appearance_textDirection_label.tr(),
+          padding: const EdgeInsets.fromLTRB(0, 8, 0, 48),
+          builder: (context) {
+            final layoutDirection =
+                context.watch<AppearanceSettingsCubit>().state.layoutDirection;
+            return Padding(
+              padding: const EdgeInsets.only(top: 10),
+              child: Column(
+                children: [
+                  FlowyOptionTile.checkbox(
+                    text: LocaleKeys.settings_appearance_textDirection_ltr.tr(),
+                    isSelected: layoutDirection == LayoutDirection.ltrLayout,
+                    onTap: () => context
+                        .read<AppearanceSettingsCubit>()
+                        .setLayoutDirection(LayoutDirection.ltrLayout),
+                  ),
+                  FlowyOptionTile.checkbox(
+                    showTopBorder: false,
+                    text: LocaleKeys.settings_appearance_textDirection_rtl.tr(),
+                    isSelected: layoutDirection == LayoutDirection.rtlLayout,
+                    onTap: () => context
+                        .read<AppearanceSettingsCubit>()
+                        .setLayoutDirection(LayoutDirection.rtlLayout),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _textDirectionLabelText(LayoutDirection? textDirection) {
+    switch (textDirection) {
+      case LayoutDirection.rtlLayout:
+        return LocaleKeys.settings_appearance_textDirection_rtl.tr();
+      case LayoutDirection.ltrLayout:
+      default:
+        return LocaleKeys.settings_appearance_textDirection_ltr.tr();
+    }
+  }
+}

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/theme_setting.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/theme_setting.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
+import 'package:appflowy/mobile/presentation/widgets/widgets.dart';
 import 'package:appflowy/util/theme_mode_extension.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -34,60 +35,46 @@ class ThemeSetting extends StatelessWidget {
         showMobileBottomSheet(
           context,
           showHeader: true,
-          showCloseButton: true,
           showDragHandle: true,
+          showDivider: false,
+          showCloseButton: false,
           title: LocaleKeys.settings_appearance_themeMode_label.tr(),
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 32),
-          builder: (_) {
-            return Column(
-              children: [
-                _ThemeModeRadioListTile(
-                  title: LocaleKeys.settings_appearance_themeMode_system.tr(),
-                  value: ThemeMode.system,
-                ),
-                _ThemeModeRadioListTile(
-                  title: LocaleKeys.settings_appearance_themeMode_light.tr(),
-                  value: ThemeMode.light,
-                ),
-                _ThemeModeRadioListTile(
-                  title: LocaleKeys.settings_appearance_themeMode_dark.tr(),
-                  value: ThemeMode.dark,
-                ),
-              ],
+          padding: const EdgeInsets.fromLTRB(0, 8, 0, 48),
+          builder: (context) {
+            final themeMode =
+                context.read<AppearanceSettingsCubit>().state.themeMode;
+            return Padding(
+              padding: const EdgeInsets.only(top: 10),
+              child: Column(
+                children: [
+                  FlowyOptionTile.checkbox(
+                    text: LocaleKeys.settings_appearance_themeMode_system.tr(),
+                    isSelected: themeMode == ThemeMode.system,
+                    onTap: () => context
+                        .read<AppearanceSettingsCubit>()
+                        .setThemeMode(ThemeMode.system),
+                  ),
+                  FlowyOptionTile.checkbox(
+                    showTopBorder: false,
+                    text: LocaleKeys.settings_appearance_themeMode_light.tr(),
+                    isSelected: themeMode == ThemeMode.light,
+                    onTap: () => context
+                        .read<AppearanceSettingsCubit>()
+                        .setThemeMode(ThemeMode.light),
+                  ),
+                  FlowyOptionTile.checkbox(
+                    showTopBorder: false,
+                    text: LocaleKeys.settings_appearance_themeMode_dark.tr(),
+                    isSelected: themeMode == ThemeMode.dark,
+                    onTap: () => context
+                        .read<AppearanceSettingsCubit>()
+                        .setThemeMode(ThemeMode.dark),
+                  ),
+                ],
+              ),
             );
           },
         );
-      },
-    );
-  }
-}
-
-class _ThemeModeRadioListTile extends StatelessWidget {
-  const _ThemeModeRadioListTile({
-    required this.title,
-    required this.value,
-  });
-  final String title;
-  final ThemeMode value;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return RadioListTile<ThemeMode>(
-      dense: true,
-      contentPadding: const EdgeInsets.fromLTRB(0, 0, 4, 0),
-      controlAffinity: ListTileControlAffinity.trailing,
-      title: Text(
-        title,
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.onSurface,
-        ),
-      ),
-      groupValue: context.read<AppearanceSettingsCubit>().state.themeMode,
-      value: value,
-      onChanged: (selectedThemeMode) {
-        if (selectedThemeMode == null) return;
-        context.read<AppearanceSettingsCubit>().setThemeMode(selectedThemeMode);
       },
     );
   }

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -343,7 +343,7 @@
         "rtl": "RTL"
       },
       "textDirection": {
-        "label": "Default text direction",
+        "label": "Default Text Direction",
         "hint": "Specify whether text should start from left or right as the default.",
         "ltr": "LTR",
         "rtl": "RTL",


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/4329

- support RTL mode on mobile
<img width="589" alt="Screenshot 2024-01-08 at 23 12 06" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/34e6f2d2-639e-450d-a726-583b39829f4d">
<img width="597" alt="Screenshot 2024-01-08 at 23 11 59" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/b7efef12-b327-47ff-a9ec-a80bb6bfe1a4">

- revamp the theme mode settings UI
<img width="584" alt="Screenshot 2024-01-08 at 22 33 28" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/755c18fc-5943-427e-a504-a80ce2e717bb">
<img width="579" alt="Screenshot 2024-01-08 at 22 52 37" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/9e7a3b8a-c8b2-4da8-8b08-4d70a8ef40c5">


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
