### PR TITLE
feat: support dynamic depth control in outline block component

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
@@ -229,6 +229,10 @@ Map<String, BlockComponentBuilder> getEditorBuilderMap({
         ImageBlockKeys.type,
       ];
 
+      final supportDepthBuilderType = [
+        OutlineBlockKeys.type,
+      ];
+
       final colorAction = [
         OptionAction.divider,
         OptionAction.color,
@@ -239,10 +243,15 @@ Map<String, BlockComponentBuilder> getEditorBuilderMap({
         OptionAction.align,
       ];
 
+      final depthAction = [
+        OptionAction.depth,
+      ];
+
       final List<OptionAction> actions = [
         ...standardActions,
         if (supportColorBuilderTypes.contains(entry.key)) ...colorAction,
         if (supportAlignBuilderType.contains(entry.key)) ...alignAction,
+        if (supportDepthBuilderType.contains(entry.key)) ...depthAction,
       ];
 
       if (PlatformExtension.isDesktop) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
@@ -34,6 +34,8 @@ class BlockOptionButton extends StatelessWidget {
           return ColorOptionAction(editorState: editorState);
         case OptionAction.align:
           return AlignOptionAction(editorState: editorState);
+        case OptionAction.depth:
+          return DepthOptionAction(editorState: editorState);
         default:
           return OptionActionWrapper(e);
       }
@@ -136,6 +138,7 @@ class BlockOptionButton extends StatelessWidget {
       case OptionAction.align:
       case OptionAction.color:
       case OptionAction.divider:
+      case OptionAction.depth:
         throw UnimplementedError();
     }
     editorState.apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
@@ -42,6 +42,7 @@ class BlockOptionButton extends StatelessWidget {
     }).toList();
 
     return PopoverActionList<PopoverAction>(
+      actionsMutex: PopoverMutex(),
       direction:
           context.read<AppearanceSettingsCubit>().state.layoutDirection ==
                   LayoutDirection.rtlLayout

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
@@ -375,7 +375,7 @@ class DepthOptionAction extends PopoverActionCell {
   }
 
   OptionDepthType depth(Node node) {
-    final level = node.attributes['depth'];
+    final level = node.attributes[OutlineBlockKeys.depth];
     return OptionDepthType.fromLevel(level);
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
@@ -350,11 +350,11 @@ class DepthOptionAction extends PopoverActionCell {
           parentController.close();
         });
 
-        return IntrinsicHeight(
-          child: IntrinsicWidth(
-            child: Column(
-              children: children,
-            ),
+        return SizedBox(
+          width: 60,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: children,
           ),
         );
       };
@@ -391,7 +391,7 @@ class DepthOptionAction extends PopoverActionCell {
     final transaction = editorState.transaction;
     transaction.updateNode(
       node,
-      {'depth': depth.level},
+      {OutlineBlockKeys.depth: depth.level},
     );
 
     await editorState.apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
@@ -339,6 +339,14 @@ class DepthOptionAction extends PopoverActionCell {
   final EditorState editorState;
 
   @override
+  Widget? leftIcon(Color iconColor) {
+    return const FlowySvg(
+      FlowySvgs.m_aa_bulleted_list_s,
+      size: Size.square(12),
+    ).padding(all: 2.0);
+  }
+
+  @override
   String get name => LocaleKeys.document_plugins_optionAction_depth.tr();
 
   @override

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
@@ -39,6 +39,7 @@ class OptionActionList extends StatelessWidget {
     }).toList();
 
     return PopoverActionList<PopoverAction>(
+      actionsMutex: PopoverMutex(),
       direction: PopoverDirection.leftWithCenterAligned,
       actions: popoverActions,
       onPopupBuilder: () => blockComponentState.alwaysShowActions = true,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
@@ -29,6 +29,10 @@ class OptionActionList extends StatelessWidget {
         return ColorOptionAction(
           editorState: editorState,
         );
+      } else if (e == OptionAction.depth) {
+        return DepthOptionAction(
+          editorState: editorState,
+        );
       } else {
         return OptionActionWrapper(e);
       }
@@ -105,6 +109,7 @@ class OptionActionList extends StatelessWidget {
       case OptionAction.align:
       case OptionAction.color:
       case OptionAction.divider:
+      case OptionAction.depth:
         throw UnimplementedError();
     }
     editorState.apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -166,6 +166,17 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
 
   Iterable<Node> getHeadingNodes() {
     final children = editorState.document.root.children;
+
+    if (node.attributes.containsKey('depth')) {
+      final int level = node.attributes['depth'];
+      return children.where(
+        (element) =>
+            element.type == HeadingBlockKeys.type &&
+            element.attributes['level'] <= level &&
+            element.delta?.isNotEmpty == true,
+      );
+    }
+
     return children.where(
       (element) =>
           element.type == HeadingBlockKeys.type &&

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -168,8 +168,8 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
   Iterable<Node> getHeadingNodes() {
     final children = editorState.document.root.children;
 
-    if (node.attributes.containsKey('depth')) {
-      final int level = node.attributes['depth'];
+    if (node.attributes.containsKey(OutlineBlockKeys.depth)) {
+      final int level = node.attributes[OutlineBlockKeys.depth];
       return children.where(
         (element) =>
             element.type == HeadingBlockKeys.type &&

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -14,6 +14,7 @@ class OutlineBlockKeys {
 
   static const String type = 'outline';
   static const String backgroundColor = blockComponentBackgroundColor;
+  static const String depth = 'depth';
 }
 
 // defining the callout block menu item for selection
@@ -172,7 +173,7 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
       return children.where(
         (element) =>
             element.type == HeadingBlockKeys.type &&
-            element.attributes['level'] <= level &&
+            element.attributes[HeadingBlockKeys.level] <= level &&
             element.delta?.isNotEmpty == true,
       );
     }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/pop_up_action.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/pop_up_action.dart
@@ -11,6 +11,7 @@ class PopoverActionList<T extends PopoverAction> extends StatefulWidget {
     required this.buildChild,
     required this.onSelected,
     this.mutex,
+    this.actionsMutex,
     this.onClosed,
     this.onPopupBuilder,
     this.direction = PopoverDirection.rightWithTopAligned,
@@ -24,15 +25,16 @@ class PopoverActionList<T extends PopoverAction> extends StatefulWidget {
   });
 
   final List<T> actions;
-  final Widget Function(PopoverController) buildChild;
-  final Function(T, PopoverController) onSelected;
   final PopoverMutex? mutex;
-  final VoidCallback? onClosed;
-  final VoidCallback? onPopupBuilder;
+  final PopoverMutex? actionsMutex;
+  final Function(T, PopoverController) onSelected;
+  final BoxConstraints constraints;
   final PopoverDirection direction;
+  final Widget Function(PopoverController) buildChild;
+  final VoidCallback? onPopupBuilder;
+  final VoidCallback? onClosed;
   final bool asBarrier;
   final Offset offset;
-  final BoxConstraints constraints;
 
   @override
   State<PopoverActionList<T>> createState() => _PopoverActionListState<T>();
@@ -74,6 +76,7 @@ class _PopoverActionListState<T extends PopoverAction>
             );
           } else if (action is PopoverActionCell) {
             return PopoverActionCellWidget<T>(
+              mutex: widget.actionsMutex,
               popoverController: popoverController,
               action: action,
               itemHeight: ActionListSizes.itemHeight,
@@ -167,11 +170,13 @@ class PopoverActionCellWidget<T extends PopoverAction> extends StatefulWidget {
     required this.popoverController,
     required this.action,
     required this.itemHeight,
+    this.mutex,
   });
 
   final T action;
   final double itemHeight;
 
+  final PopoverMutex? mutex;
   final PopoverController popoverController;
 
   @override
@@ -190,6 +195,7 @@ class _PopoverActionCellWidgetState<T extends PopoverAction>
     final rightIcon =
         actionCell.rightIcon(Theme.of(context).colorScheme.onSurface);
     return AppFlowyPopover(
+      mutex: widget.mutex,
       controller: popoverController,
       asBarrier: true,
       popupBuilder: (context) => actionCell.builder(

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -751,7 +751,8 @@
         "left": "Left",
         "center": "Center",
         "right": "Right",
-        "defaultColor": "Default"
+        "defaultColor": "Default",
+        "depth": "Depth"
       },
       "image": {
         "copiedToPasteBoard": "The image link has been copied to the clipboard",


### PR DESCRIPTION
This PR is related to the feature request:

> [FR] Variable depth of '/outline' #4355

**Description**:
This PR addresses the implementation of a feature that enhances the `OutlineBlockComponent` functionality by introducing dynamic depth control. The depth control allows users to customise the visibility of headings based on their selected depth.

**Changes Made:**
Added dynamic depth control to the outline block.
When a depth H1 is selected, the app now displays headings up to level 1.
For depth H2, it shows headings up to level 2, extending upto subsequent H3 headings.


https://github.com/AppFlowy-IO/AppFlowy/assets/68953739/879fa002-7e5a-48b7-9025-a866a48ef40a