### PR TITLE
fix: fix secondary button outline color

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/theme_upload/theme_upload_learn_more_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/theme_upload/theme_upload_learn_more_button.dart
@@ -20,6 +20,7 @@ class ThemeUploadLearnMoreButton extends StatelessWidget {
       height: ThemeUploadWidget.buttonSize.height,
       child: IntrinsicWidth(
         child: SecondaryButton(
+          outlineColor: Theme.of(context).colorScheme.onBackground,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: FlowyText.medium(

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/widget/buttons/secondary_button.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/widget/buttons/secondary_button.dart
@@ -37,21 +37,26 @@ class SecondaryTextButton extends StatelessWidget {
     this.label, {
     super.key,
     this.onPressed,
+    this.textColor,
+    this.outlineColor,
     this.mode = TextButtonMode.normal,
   });
 
   final String label;
   final VoidCallback? onPressed;
   final TextButtonMode mode;
+  final Color? textColor;
+  final Color? outlineColor;
 
   @override
   Widget build(BuildContext context) {
     return SecondaryButton(
       mode: mode,
       onPressed: onPressed,
+      outlineColor: outlineColor,
       child: FlowyText.regular(
         label,
-        color: Theme.of(context).colorScheme.primary,
+        color: textColor ?? Theme.of(context).colorScheme.primary,
       ),
     );
   }
@@ -62,12 +67,14 @@ class SecondaryButton extends StatelessWidget {
     super.key,
     required this.child,
     this.onPressed,
+    this.outlineColor,
     this.mode = TextButtonMode.normal,
   });
 
   final Widget child;
   final VoidCallback? onPressed;
   final TextButtonMode mode;
+  final Color? outlineColor;
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +84,7 @@ class SecondaryButton extends StatelessWidget {
       minHeight: size.height,
       contentPadding: EdgeInsets.zero,
       bgColor: Colors.transparent,
-      outlineColor: Theme.of(context).colorScheme.onBackground,
+      outlineColor: outlineColor ?? Theme.of(context).colorScheme.primary,
       borderRadius: mode.borderRadius,
       onPressed: onPressed,
       child: child,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

- ### Feature Preview
- Restored the outline color for the secondary button prior to #4317.  
- Add an outline color field in the secondary button to build the learn more button in the customized theme dialog. 

<img width="629" alt="Continue with an anonymous session" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/8b77134f-0ec0-469d-97f6-3ff6fc3e2580">
<img width="613" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/1f225808-c019-479b-8b6d-d3c6a000c6a6">

<img width="614" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/14248245/3ac6ddee-155a-44de-998e-cd8b9cc24439">



<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
