### PR TITLE
fix: don't parse unexpected files while generating protobuf

### DIFF
--- a/frontend/rust-lib/build-tool/flowy-codegen/src/protobuf_file/proto_gen.rs
+++ b/frontend/rust-lib/build-tool/flowy-codegen/src/protobuf_file/proto_gen.rs
@@ -138,7 +138,7 @@ fn write_rust_crate_mod_file(crate_contexts: &[ProtobufCrateContext]) {
         mod_file_content.push_str("// Auto-generated, do not edit\n");
         walk_dir(
           context.protobuf_crate.proto_output_path(),
-          |e| !e.file_type().is_dir(),
+          |e| !e.file_type().is_dir() && !e.file_name().to_string_lossy().starts_with('.'),
           |_, name| {
             let c = format!("\nmod {};\npub use {}::*;\n", &name, &name);
             mod_file_content.push_str(c.as_ref());


### PR DESCRIPTION
Fix a bug that sometimes occur during development where a rogue .DS_Store file is parsed while generating protobuf files.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
