### PR TITLE
feat: optimize cloud settings on mobile

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/_restart_app_button.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/_restart_app_button.dart
@@ -1,0 +1,43 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/user/presentation/screens/sign_in_screen/widgets/sign_in_or_logout_button.dart';
+import 'package:appflowy_editor/appflowy_editor.dart' show PlatformExtension;
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+
+class RestartButton extends StatelessWidget {
+  const RestartButton({
+    super.key,
+    required this.onClick,
+  });
+
+  final VoidCallback onClick;
+
+  @override
+  Widget build(BuildContext context) {
+    if (PlatformExtension.isDesktopOrWeb) {
+      return Row(
+        children: [
+          FlowyButton(
+            isSelected: true,
+            useIntrinsicWidth: true,
+            margin: const EdgeInsets.symmetric(
+              horizontal: 30,
+              vertical: 10,
+            ),
+            text: FlowyText(
+              LocaleKeys.settings_menu_restartApp.tr(),
+            ),
+            onTap: onClick,
+          ),
+          const Spacer(),
+        ],
+      );
+    } else {
+      return MobileSignInOrLogoutButton(
+        labelText: LocaleKeys.settings_menu_restartApp.tr(),
+        onPressed: onClick,
+      );
+    }
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
@@ -3,6 +3,7 @@ import 'package:appflowy/env/env.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/application/settings/appflowy_cloud_setting_bloc.dart';
 import 'package:appflowy/workspace/application/settings/appflowy_cloud_urls_bloc.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/_restart_app_button.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_backend/dispatch/dispatch.dart';
 import 'package:appflowy_backend/log.dart';
@@ -59,7 +60,7 @@ class AppFlowyCloudViewSetting extends StatelessWidget {
       child: Column(
         children: [
           const AppFlowyCloudEnableSync(),
-          const VSpace(40),
+          const VSpace(12),
           RestartButton(
             onClick: () async {
               NavigatorAlertDialog(
@@ -173,7 +174,7 @@ class AppFlowyCloudURLs extends StatelessWidget {
                         );
                   },
                 ),
-                const VSpace(20),
+                const VSpace(8),
                 RestartButton(
                   onClick: () async {
                     NavigatorAlertDialog(
@@ -317,38 +318,18 @@ class AppFlowyCloudEnableSync extends StatelessWidget {
           children: [
             FlowyText.medium(LocaleKeys.settings_menu_enableSync.tr()),
             const Spacer(),
-            Switch(
+            Switch.adaptive(
               onChanged: (bool value) {
                 context.read<AppFlowyCloudSettingBloc>().add(
                       AppFlowyCloudSettingEvent.enableSync(value),
                     );
               },
+              activeColor: Theme.of(context).colorScheme.primary,
               value: state.setting.enableSync,
             ),
           ],
         );
       },
-    );
-  }
-}
-
-class RestartButton extends StatelessWidget {
-  final VoidCallback onClick;
-  const RestartButton({required this.onClick, super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return FlowyButton(
-      isSelected: true,
-      useIntrinsicWidth: true,
-      margin: const EdgeInsets.symmetric(
-        horizontal: 30,
-        vertical: 10,
-      ),
-      text: FlowyText(
-        LocaleKeys.settings_menu_restartApp.tr(),
-      ),
-      onTap: onClick,
     );
   }
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_local_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_local_cloud.dart
@@ -1,9 +1,8 @@
 import 'package:appflowy/env/cloud_env.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/_restart_app_button.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flowy_infra_ui/style_widget/button.dart';
-import 'package:flowy_infra_ui/style_widget/text.dart';
 import 'package:flutter/material.dart';
 
 class SettingLocalCloud extends StatelessWidget {
@@ -15,32 +14,20 @@ class SettingLocalCloud extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        FlowyButton(
-          isSelected: true,
-          useIntrinsicWidth: true,
-          margin: const EdgeInsets.symmetric(
-            horizontal: 30,
-            vertical: 10,
-          ),
-          text: FlowyText(
-            LocaleKeys.settings_menu_restartApp.tr(),
-          ),
-          onTap: () {
-            NavigatorAlertDialog(
-              title: LocaleKeys.settings_menu_restartAppTip.tr(),
-              confirm: () async {
-                await setAuthenticatorType(
-                  AuthenticatorType.local,
-                );
-                didResetServerUrl();
-              },
-            ).show(context);
-          },
-        ),
-        const Spacer(),
-      ],
+    return RestartButton(
+      onClick: () => onPressed(context),
     );
+  }
+
+  void onPressed(BuildContext context) {
+    NavigatorAlertDialog(
+      title: LocaleKeys.settings_menu_restartAppTip.tr(),
+      confirm: () async {
+        await setAuthenticatorType(
+          AuthenticatorType.local,
+        );
+        didResetServerUrl();
+      },
+    ).show(context);
   }
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_supabase_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_supabase_cloud.dart
@@ -3,6 +3,7 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/application/settings/supabase_cloud_setting_bloc.dart';
 import 'package:appflowy/workspace/application/settings/supabase_cloud_urls_bloc.dart';
 import 'package:appflowy/workspace/presentation/home/toast.dart';
+import 'package:appflowy/workspace/presentation/settings/widgets/_restart_app_button.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_backend/dispatch/dispatch.dart';
 import 'package:appflowy_backend/log.dart';
@@ -118,24 +119,8 @@ class SupabaseCloudURLs extends StatelessWidget {
                   error: state.anonKeyError.fold(() => null, (a) => a),
                 ),
                 const VSpace(20),
-                FlowyButton(
-                  isSelected: true,
-                  useIntrinsicWidth: true,
-                  margin: const EdgeInsets.symmetric(
-                    horizontal: 30,
-                    vertical: 10,
-                  ),
-                  text: FlowyText(
-                    LocaleKeys.settings_menu_restartApp.tr(),
-                  ),
-                  onTap: () {
-                    NavigatorAlertDialog(
-                      title: LocaleKeys.settings_menu_restartAppTip.tr(),
-                      confirm: () => context
-                          .read<SupabaseCloudURLsBloc>()
-                          .add(const SupabaseCloudURLsEvent.confirmUpdate()),
-                    ).show(context);
-                  },
+                RestartButton(
+                  onClick: () => _restartApp,
                 ),
               ],
             );
@@ -143,6 +128,15 @@ class SupabaseCloudURLs extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  void _restartApp(BuildContext context) {
+    NavigatorAlertDialog(
+      title: LocaleKeys.settings_menu_restartAppTip.tr(),
+      confirm: () => context
+          .read<SupabaseCloudURLsBloc>()
+          .add(const SupabaseCloudURLsEvent.confirmUpdate()),
+    ).show(context);
   }
 }
 
@@ -167,7 +161,8 @@ class EnableEncrypt extends StatelessWidget {
                 const Spacer(),
                 indicator,
                 const HSpace(3),
-                Switch(
+                Switch.adaptive(
+                  activeColor: Theme.of(context).colorScheme.primary,
                   onChanged: state.setting.enableEncrypt
                       ? null
                       : (bool value) {
@@ -235,7 +230,8 @@ class SupabaseEnableSync extends StatelessWidget {
           children: [
             FlowyText.medium(LocaleKeys.settings_menu_enableSync.tr()),
             const Spacer(),
-            Switch(
+            Switch.adaptive(
+              activeColor: Theme.of(context).colorScheme.primary,
               onChanged: (bool value) {
                 context.read<SupabaseCloudSettingBloc>().add(
                       SupabaseCloudSettingEvent.enableSync(value),


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

**Before**
<img width="519" alt="Screenshot 2024-01-22 at 23 16 08" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/881c04a4-0959-407e-8fd0-1e88f4bedf20">
<img width="519" alt="Screenshot 2024-01-22 at 23 20 50" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/ea9e620b-79a0-403f-b05f-172b5da0440b">
<img width="563" alt="Screenshot 2024-01-22 at 23 25 01" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/5b4d2265-464c-4f53-ba4a-058bb34dbb54">

**after**
<img width="563" alt="Screenshot 2024-01-22 at 23 47 01" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/b330e09b-5a0d-4e15-9860-4b8a79b51d61">
<img width="563" alt="Screenshot 2024-01-22 at 23 48 22" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/a5818a58-6d55-4fa8-8ec4-38234d279be7">


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
