### PR TITLE
fix: font shown in AA has _r as a suffix & copy & paste menu did not dismiss when navigating to the font page

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/_font_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/_font_item.dart
@@ -2,6 +2,7 @@ import 'package:appflowy/mobile/presentation/setting/font/font_picker_screen.dar
 import 'package:appflowy/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/_toolbar_theme.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy/plugins/document/presentation/more/cubit/document_appearance_cubit.dart';
+import 'package:appflowy/util/google_font_family_extension.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -27,8 +28,16 @@ class FontFamilyItem extends StatelessWidget {
     return MobileToolbarMenuItemWrapper(
       size: const Size(144, 52),
       onTap: () async {
-        keepEditorFocusNotifier.increase();
         final selection = editorState.selection;
+        // disable the floating toolbar
+        editorState.updateSelectionWithReason(
+          selection,
+          extraInfo: {
+            selectionExtraInfoDisableFloatingToolbar: true,
+            selectionExtraInfoDisableMobileToolbarKey: true,
+          },
+        );
+
         final newFont = await context
             .read<GoRouter>()
             .push<String>(FontPickerScreen.routeName);
@@ -45,11 +54,12 @@ class FontFamilyItem extends StatelessWidget {
             selection,
             extraInfo: {
               selectionExtraInfoDisableFloatingToolbar: true,
+              selectionExtraInfoDisableMobileToolbarKey: false,
             },
           );
         });
       },
-      text: fontFamily ?? systemFonFamily,
+      text: (fontFamily ?? systemFonFamily).parseFontFamilyName(),
       fontFamily: fontFamily ?? systemFonFamily,
       backgroundColor: theme.toolbarMenuItemBackgroundColor,
       isSelected: false,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/4477
closes https://github.com/AppFlowy-IO/AppFlowy/issues/4476

https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/ec590cd9-246e-4f32-8a60-1f6e7da1921e

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
