### PR TITLE
fix: the text and icon in + menu are not aligned in the same baseline

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/add_block_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/add_block_toolbar_item.dart
@@ -274,6 +274,7 @@ class _AddBlockMenuItem extends StatelessWidget {
     return GestureDetector(
       onTap: data.onTap,
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Container(
             height: 68.0 * context.scale,
@@ -291,9 +292,15 @@ class _AddBlockMenuItem extends StatelessWidget {
             ),
           ),
           const VSpace(4),
-          FlowyText(
-            data.text,
-            fontSize: 12.0,
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: 68.0 * context.scale,
+            ),
+            child: FlowyText(
+              data.text,
+              fontSize: 12.0,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<img width="451" alt="Screenshot 2024-01-25 at 23 28 43" src="https://github.com/AppFlowy-IO/AppFlowy/assets/11863087/8448930e-d12c-4159-ad9e-c2b90a969aa3">

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
