### PR TITLE
fix: android navigation bar color

### DIFF
--- a/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
@@ -204,11 +204,14 @@ class _ApplicationWidgetState extends State<ApplicationWidget> {
   void _setSystemOverlayStyle(AppearanceSettingsState state) {
     if (Platform.isAndroid) {
       SystemUiOverlayStyle style = SystemUiOverlayStyle.dark;
+      Color systemNavigationBarColor = Colors.transparent;
       final themeMode = state.themeMode;
       if (themeMode == ThemeMode.dark) {
         style = SystemUiOverlayStyle.light;
+        systemNavigationBarColor = state.darkTheme.colorScheme.surface;
       } else if (themeMode == ThemeMode.light) {
         style = SystemUiOverlayStyle.dark;
+        systemNavigationBarColor = state.lightTheme.colorScheme.surface;
       } else {
         final brightness = Theme.of(context).brightness;
         // reverse the brightness of the system status bar.
@@ -220,7 +223,7 @@ class _ApplicationWidgetState extends State<ApplicationWidget> {
       SystemChrome.setSystemUIOverlayStyle(
         style.copyWith(
           statusBarColor: Colors.transparent,
-          systemNavigationBarColor: Colors.transparent,
+          systemNavigationBarColor: systemNavigationBarColor,
         ),
       );
     }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

Notes: SystemChrome.setSystemUIOverlayStyle doesn't work when triggered a second time.


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
