### PR TITLE
fix: don't show ungrouped column when the field type is checkbox

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/board/application/board_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/board/application/board_bloc.dart
@@ -303,12 +303,14 @@ class BoardBloc extends Bloc<BoardEvent, BoardState> {
 
     boardController.addGroups(
       groups
-          .where(
-            (group) =>
-                fieldController.getField(group.fieldId) != null &&
-                ((!group.isDefault && group.isVisible) ||
-                    (group.isDefault && !hideUngrouped)),
-          )
+          .where((group) {
+            final field = fieldController.getField(group.fieldId);
+            return field != null &&
+                (!group.isDefault && group.isVisible ||
+                    group.isDefault &&
+                        !hideUngrouped &&
+                        field.fieldType != FieldType.Checkbox);
+          })
           .map((group) => _initializeGroupData(group))
           .toList(),
     );


### PR DESCRIPTION
There's no tri-state.

<img width="911" alt="image" src="https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/dd74a144-5602-4d1f-869b-52ea71637050">


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
