### PR TITLE
fix: size of hitbox in app bar button

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/app_bar_actions.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/app_bar_actions.dart
@@ -144,8 +144,6 @@ class AppBarButton extends StatelessWidget {
     required this.child,
   });
 
-  static const defaultWidth = 40.0;
-
   final VoidCallback onTap;
   final Widget child;
   final bool isActionButton;
@@ -153,6 +151,7 @@ class AppBarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: Padding(
         padding: EdgeInsets.only(


### PR DESCRIPTION
clicking on the white space around the `FlowySvg` doesn't register.

Affects back button, close button, cancel button and more buttons.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
