### PR TITLE
fix: deleting a sorting field doesn't delete existing sorts

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/sort/entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/sort/entities.rs
@@ -121,7 +121,7 @@ pub struct ReorderSingleRowResult {
   pub new_index: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SortChangeset {
   pub(crate) insert_sort: Option<Sort>,
   pub(crate) update_sort: Option<Sort>,
@@ -133,36 +133,28 @@ impl SortChangeset {
   pub fn from_insert(sort: Sort) -> Self {
     Self {
       insert_sort: Some(sort),
-      update_sort: None,
-      delete_sort: None,
-      reorder_sort: None,
+      ..Default::default()
     }
   }
 
   pub fn from_update(sort: Sort) -> Self {
     Self {
-      insert_sort: None,
       update_sort: Some(sort),
-      delete_sort: None,
-      reorder_sort: None,
+      ..Default::default()
     }
   }
 
   pub fn from_delete(sort_id: String) -> Self {
     Self {
-      insert_sort: None,
-      update_sort: None,
       delete_sort: Some(sort_id),
-      reorder_sort: None,
+      ..Default::default()
     }
   }
 
   pub fn from_reorder(from_sort_id: String, to_sort_id: String) -> Self {
     Self {
-      insert_sort: None,
-      update_sort: None,
-      delete_sort: None,
       reorder_sort: Some((from_sort_id, to_sort_id)),
+      ..Default::default()
     }
   }
 }


### PR DESCRIPTION
resovles #4520


<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
