### PR TITLE
feat: Implement outline block component depth control

### DIFF
--- a/frontend/appflowy_flutter/integration_test/document/document_with_outline_block_test.dart
+++ b/frontend/appflowy_flutter/integration_test/document/document_with_outline_block_test.dart
@@ -9,12 +9,12 @@ import 'package:integration_test/integration_test.dart';
 
 import '../util/util.dart';
 
+const String heading1 = "Heading 1";
+const String heading2 = "Heading 2";
+const String heading3 = "Heading 3";
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-
-  const String heading1 = "Heading 1";
-  const String heading2 = "Heading 2";
-  const String heading3 = "Heading 3";
 
   group('outline block test', () {
     testWidgets('insert an outline block', (tester) async {
@@ -40,12 +40,8 @@ void main() {
       await tester.createNewPageWithNameUnderParent(
         name: 'outline_test',
       );
-      await tester.editor.tapLineOfEditorAt(0);
 
-      await tester.ime.insertText('# $heading1\n');
-      await tester.ime.insertText('## $heading2\n');
-      await tester.ime.insertText('### $heading3\n');
-
+      await insertHeadingComponent(tester);
       /* Results in:
       * # Heading 1
       * ## Heading 2
@@ -100,12 +96,8 @@ void main() {
       await tester.createNewPageWithNameUnderParent(
         name: 'outline_test',
       );
-      await tester.editor.tapLineOfEditorAt(0);
 
-      await tester.ime.insertText('# $heading1\n');
-      await tester.ime.insertText('## $heading2\n');
-      await tester.ime.insertText('### $heading3\n');
-
+      await insertHeadingComponent(tester);
       /* Results in:
         * # Heading 1
         * ## Heading 2
@@ -133,7 +125,7 @@ void main() {
       );
       //////
 
-      /// expect to find only the 'heading1` and `heading2` under the [OutlineBlockWidget]
+      /// expect to find only the 'heading1' and 'heading2' under the [OutlineBlockWidget]
       await hoverAndClickDepthOptionAction(tester, [3], 2);
       expect(
         find.descendant(
@@ -197,4 +189,11 @@ Future<void> hoverAndClickDepthOptionAction(
   // in addition to 3 HoverButtons under the [DepthOptionAction] - (child of BlockOptionButton)
   await tester.tap(find.byType(HoverButton).hitTestable().at(3 + level));
   await tester.pumpAndSettle();
+}
+
+Future<void> insertHeadingComponent(WidgetTester tester) async {
+  await tester.editor.tapLineOfEditorAt(0);
+  await tester.ime.insertText('# $heading1\n');
+  await tester.ime.insertText('## $heading2\n');
+  await tester.ime.insertText('### $heading3\n');
 }

--- a/frontend/appflowy_flutter/integration_test/document/document_with_outline_block_test.dart
+++ b/frontend/appflowy_flutter/integration_test/document/document_with_outline_block_test.dart
@@ -1,6 +1,9 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
+import 'package:appflowy/workspace/presentation/widgets/pop_up_action.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -8,6 +11,10 @@ import '../util/util.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const String heading1 = "Heading 1";
+  const String heading2 = "Heading 2";
+  const String heading3 = "Heading 3";
 
   group('outline block test', () {
     testWidgets('insert an outline block', (tester) async {
@@ -35,9 +42,9 @@ void main() {
       );
       await tester.editor.tapLineOfEditorAt(0);
 
-      await tester.ime.insertText('# Heading 1\n');
-      await tester.ime.insertText('## Heading 2\n');
-      await tester.ime.insertText('### Heading 3\n');
+      await tester.ime.insertText('# $heading1\n');
+      await tester.ime.insertText('## $heading2\n');
+      await tester.ime.insertText('### $heading3\n');
 
       /* Results in:
       * # Heading 1
@@ -51,7 +58,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(OutlineBlockWidget),
-          matching: find.text('Heading 1'),
+          matching: find.text(heading1),
         ),
         findsOneWidget,
       );
@@ -60,7 +67,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(OutlineBlockWidget),
-          matching: find.text('Heading 2'),
+          matching: find.text(heading2),
         ),
         findsOneWidget,
       );
@@ -69,7 +76,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(OutlineBlockWidget),
-          matching: find.text('Heading 3'),
+          matching: find.text(heading3),
         ),
         findsOneWidget,
       );
@@ -80,10 +87,89 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(OutlineBlockWidget),
-          matching: find.text('Heading 1Hello world'),
+          matching: find.text('${heading1}Hello world'),
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets("control the depth of outline block", (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapGoButton();
+
+      await tester.createNewPageWithNameUnderParent(
+        name: 'outline_test',
+      );
+      await tester.editor.tapLineOfEditorAt(0);
+
+      await tester.ime.insertText('# $heading1\n');
+      await tester.ime.insertText('## $heading2\n');
+      await tester.ime.insertText('### $heading3\n');
+
+      /* Results in:
+        * # Heading 1
+        * ## Heading 2
+        * ### Heading 3
+      */
+
+      await tester.editor.tapLineOfEditorAt(3);
+      await insertOutlineInDocument(tester);
+
+      // expect to find only the `heading1` widget under the [OutlineBlockWidget]
+      await hoverAndClickDepthOptionAction(tester, [3], 1);
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading2),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading3),
+        ),
+        findsNothing,
+      );
+      //////
+
+      /// expect to find only the 'heading1` and `heading2` under the [OutlineBlockWidget]
+      await hoverAndClickDepthOptionAction(tester, [3], 2);
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading3),
+        ),
+        findsNothing,
+      );
+      //////
+
+      // expect to find all the headings under the [OutlineBlockWidget]
+      await hoverAndClickDepthOptionAction(tester, [3], 3);
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading1),
+        ),
+        findsOneWidget,
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading2),
+        ),
+        findsOneWidget,
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(OutlineBlockWidget),
+          matching: find.text(heading3),
+        ),
+        findsOneWidget,
+      );
+      //////
     });
   });
 }
@@ -95,5 +181,20 @@ Future<void> insertOutlineInDocument(WidgetTester tester) async {
   await tester.editor.tapSlashMenuItemWithName(
     LocaleKeys.document_selectionMenu_outline.tr(),
   );
+  await tester.pumpAndSettle();
+}
+
+Future<void> hoverAndClickDepthOptionAction(
+  WidgetTester tester,
+  List<int> path,
+  int level,
+) async {
+  await tester.editor.hoverAndClickOptionMenuButton([3]);
+  await tester.tap(find.byType(AppFlowyPopover).hitTestable().last);
+  await tester.pumpAndSettle();
+
+  // Find a total of 4 HoverButtons under the [BlockOptionButton],
+  // in addition to 3 HoverButtons under the [DepthOptionAction] - (child of BlockOptionButton)
+  await tester.tap(find.byType(HoverButton).hitTestable().at(3 + level));
   await tester.pumpAndSettle();
 }

--- a/frontend/appflowy_flutter/integration_test/util/editor_test_operations.dart
+++ b/frontend/appflowy_flutter/integration_test/util/editor_test_operations.dart
@@ -6,6 +6,7 @@ import 'package:appflowy/plugins/base/emoji/emoji_picker.dart';
 import 'package:appflowy/plugins/base/emoji/emoji_skin_tone.dart';
 import 'package:appflowy/plugins/base/icon/icon_picker.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/actions/block_action_add_button.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/header/cover_editor.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart';
@@ -238,6 +239,27 @@ class EditorOperations {
         if (withModifiedKey) {
           await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
         }
+      },
+    );
+  }
+
+  /// hover and click on the option menu button beside the block component.
+  Future<void> hoverAndClickOptionMenuButton(Path path) async {
+    final optionMenuButton = find.byWidgetPredicate(
+      (widget) =>
+          widget is BlockComponentActionWrapper &&
+          widget.node.path.equals(path),
+    );
+    await tester.hoverOnWidget(
+      optionMenuButton,
+      onHover: () async {
+        await tester.tapButton(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is BlockOptionButton &&
+                widget.blockComponentContext.node.path.equals(path),
+          ),
+        );
       },
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
@@ -229,6 +229,10 @@ Map<String, BlockComponentBuilder> getEditorBuilderMap({
         ImageBlockKeys.type,
       ];
 
+      final supportDepthBuilderType = [
+        OutlineBlockKeys.type,
+      ];
+
       final colorAction = [
         OptionAction.divider,
         OptionAction.color,
@@ -239,10 +243,15 @@ Map<String, BlockComponentBuilder> getEditorBuilderMap({
         OptionAction.align,
       ];
 
+      final depthAction = [
+        OptionAction.depth,
+      ];
+
       final List<OptionAction> actions = [
         ...standardActions,
         if (supportColorBuilderTypes.contains(entry.key)) ...colorAction,
         if (supportAlignBuilderType.contains(entry.key)) ...alignAction,
+        if (supportDepthBuilderType.contains(entry.key)) ...depthAction,
       ];
 
       if (PlatformExtension.isDesktop) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_button.dart
@@ -34,12 +34,15 @@ class BlockOptionButton extends StatelessWidget {
           return ColorOptionAction(editorState: editorState);
         case OptionAction.align:
           return AlignOptionAction(editorState: editorState);
+        case OptionAction.depth:
+          return DepthOptionAction(editorState: editorState);
         default:
           return OptionActionWrapper(e);
       }
     }).toList();
 
     return PopoverActionList<PopoverAction>(
+      popoverMutex: PopoverMutex(),
       direction:
           context.read<AppearanceSettingsCubit>().state.layoutDirection ==
                   LayoutDirection.rtlLayout
@@ -136,6 +139,7 @@ class BlockOptionButton extends StatelessWidget {
       case OptionAction.align:
       case OptionAction.color:
       case OptionAction.divider:
+      case OptionAction.depth:
         throw UnimplementedError();
     }
     editorState.apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action.dart
@@ -42,9 +42,9 @@ enum OptionAction {
       case OptionAction.divider:
         return const FlowySvgData('editor/divider');
       case OptionAction.align:
-      // TODO: depth action icon required
-      case OptionAction.depth:
         return FlowySvgs.m_aa_bulleted_list_s;
+      case OptionAction.depth:
+        return FlowySvgs.tag_s;
     }
   }
 
@@ -114,33 +114,14 @@ enum OptionAlignType {
 }
 
 enum OptionDepthType {
-  h1,
-  h2,
-  h3;
+  h1(1, "H1"),
+  h2(2, "H2"),
+  h3(3, "H3");
 
-  String get description {
-    switch (this) {
-      case OptionDepthType.h1:
-        return 'H1';
-      case OptionDepthType.h2:
-        return 'H2';
-      case OptionDepthType.h3:
-      default:
-        return 'H3';
-    }
-  }
+  const OptionDepthType(this.level, this.description);
 
-  int get level {
-    switch (this) {
-      case OptionDepthType.h1:
-        return 1;
-      case OptionDepthType.h2:
-        return 2;
-      case OptionDepthType.h3:
-      default:
-        return 3;
-    }
-  }
+  final String description;
+  final int level;
 
   static OptionDepthType fromLevel(int? level) {
     switch (level) {
@@ -339,9 +320,9 @@ class DepthOptionAction extends PopoverActionCell {
 
   @override
   Widget? leftIcon(Color iconColor) {
-    return const FlowySvg(
-      FlowySvgs.m_aa_bulleted_list_s,
-      size: Size.square(12),
+    return FlowySvg(
+      OptionAction.depth.svg,
+      size: const Size.square(12),
     ).padding(all: 2.0);
   }
 
@@ -368,7 +349,7 @@ class DepthOptionAction extends PopoverActionCell {
 
   List<Widget> buildDepthOptions(
     BuildContext context,
-    void Function(OptionDepthType) onTap,
+    Future<void> Function(OptionDepthType) onTap,
   ) {
     return OptionDepthType.values
         .map((e) => OptionDepthWrapper(e))
@@ -402,7 +383,6 @@ class DepthOptionAction extends PopoverActionCell {
       node,
       {OutlineBlockKeys.depth: depth.level},
     );
-
     await editorState.apply(transaction);
   }
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option_action_button.dart
@@ -29,12 +29,17 @@ class OptionActionList extends StatelessWidget {
         return ColorOptionAction(
           editorState: editorState,
         );
+      } else if (e == OptionAction.depth) {
+        return DepthOptionAction(
+          editorState: editorState,
+        );
       } else {
         return OptionActionWrapper(e);
       }
     }).toList();
 
     return PopoverActionList<PopoverAction>(
+      popoverMutex: PopoverMutex(),
       direction: PopoverDirection.leftWithCenterAligned,
       actions: popoverActions,
       onPopupBuilder: () => blockComponentState.alwaysShowActions = true,
@@ -105,6 +110,7 @@ class OptionActionList extends StatelessWidget {
       case OptionAction.align:
       case OptionAction.color:
       case OptionAction.divider:
+      case OptionAction.depth:
         throw UnimplementedError();
     }
     editorState.apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -14,6 +14,7 @@ class OutlineBlockKeys {
 
   static const String type = 'outline';
   static const String backgroundColor = blockComponentBackgroundColor;
+  static const String depth = 'depth';
 }
 
 // defining the callout block menu item for selection
@@ -166,6 +167,17 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
 
   Iterable<Node> getHeadingNodes() {
     final children = editorState.document.root.children;
+
+    if (node.attributes.containsKey(OutlineBlockKeys.depth)) {
+      final int level = node.attributes[OutlineBlockKeys.depth];
+      return children.where(
+        (element) =>
+            element.type == HeadingBlockKeys.type &&
+            element.attributes[HeadingBlockKeys.level] <= level &&
+            element.delta?.isNotEmpty == true,
+      );
+    }
+
     return children.where(
       (element) =>
           element.type == HeadingBlockKeys.type &&

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -15,6 +15,8 @@ class OutlineBlockKeys {
   static const String type = 'outline';
   static const String backgroundColor = blockComponentBackgroundColor;
   static const String depth = 'depth';
+  // Change the value if the heading block type supports heading levels greater than '3'
+  static const int finalHeadingLevel = 3;
 }
 
 // defining the callout block menu item for selection
@@ -183,21 +185,14 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
 
   Iterable<Node> getHeadingNodes() {
     final children = editorState.document.root.children;
-
-    if (node.attributes.containsKey(OutlineBlockKeys.depth)) {
-      final int level = node.attributes[OutlineBlockKeys.depth];
-      return children.where(
-        (element) =>
-            element.type == HeadingBlockKeys.type &&
-            element.attributes[HeadingBlockKeys.level] <= level &&
-            element.delta?.isNotEmpty == true,
-      );
-    }
+    final int level = node.attributes[OutlineBlockKeys.depth] ??
+        OutlineBlockKeys.finalHeadingLevel;
 
     return children.where(
       (element) =>
           element.type == HeadingBlockKeys.type &&
-          element.delta?.isNotEmpty == true,
+          element.delta?.isNotEmpty == true &&
+          element.attributes[HeadingBlockKeys.level] <= level,
     );
   }
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -15,8 +15,6 @@ class OutlineBlockKeys {
   static const String type = 'outline';
   static const String backgroundColor = blockComponentBackgroundColor;
   static const String depth = 'depth';
-  // Change the value if the heading block type supports heading levels greater than '3'
-  static const int finalHeadingLevel = 3;
 }
 
 // defining the callout block menu item for selection
@@ -76,6 +74,9 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
         BlockComponentConfigurable,
         BlockComponentTextDirectionMixin,
         BlockComponentBackgroundColorMixin {
+  // Change the value if the heading block type supports heading levels greater than '3'
+  static const finalHeadingLevel = 3;
+
   @override
   BlockComponentConfiguration get configuration => widget.configuration;
 
@@ -185,8 +186,8 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
 
   Iterable<Node> getHeadingNodes() {
     final children = editorState.document.root.children;
-    final int level = node.attributes[OutlineBlockKeys.depth] ??
-        OutlineBlockKeys.finalHeadingLevel;
+    final int level =
+        node.attributes[OutlineBlockKeys.depth] ?? finalHeadingLevel;
 
     return children.where(
       (element) =>

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -142,7 +142,11 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
               style: configuration.placeholderTextStyle(node),
             ),
           )
-        : DecoratedBox(
+        : Container(
+            padding: const EdgeInsets.symmetric(
+              vertical: 2.0,
+              horizontal: 5.0,
+            ),
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(Radius.circular(8.0)),
               color: backgroundColor,
@@ -152,7 +156,19 @@ class _OutlineBlockWidgetState extends State<OutlineBlockWidget>
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               textDirection: textDirection,
-              children: children,
+              children: [
+                Text(
+                  LocaleKeys.document_outlineBlock_placeholder.tr(),
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const VSpace(8.0),
+                Padding(
+                  padding: const EdgeInsets.only(left: 15.0),
+                  child: Column(
+                    children: children,
+                  ),
+                ),
+              ],
             ),
           );
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/emoji_picker/emoji_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/emoji_picker/emoji_shortcut_event.dart
@@ -8,6 +8,7 @@ final CommandShortcutEvent emojiShortcutEvent = CommandShortcutEvent(
   macOSCommand: 'cmd+alt+e',
   getDescription: () => 'Show an emoji picker',
   handler: _emojiShortcutHandler,
+  getDescription: () => "",
 );
 
 CommandShortcutEventHandler _emojiShortcutHandler = (editorState) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/emoji_picker/emoji_shortcut_event.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/emoji_picker/emoji_shortcut_event.dart
@@ -8,7 +8,6 @@ final CommandShortcutEvent emojiShortcutEvent = CommandShortcutEvent(
   macOSCommand: 'cmd+alt+e',
   getDescription: () => 'Show an emoji picker',
   handler: _emojiShortcutHandler,
-  getDescription: () => "",
 );
 
 CommandShortcutEventHandler _emojiShortcutHandler = (editorState) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/pop_up_action.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/pop_up_action.dart
@@ -7,6 +7,7 @@ import 'package:styled_widget/styled_widget.dart';
 class PopoverActionList<T extends PopoverAction> extends StatefulWidget {
   const PopoverActionList({
     super.key,
+    this.popoverMutex,
     required this.actions,
     required this.buildChild,
     required this.onSelected,
@@ -23,6 +24,7 @@ class PopoverActionList<T extends PopoverAction> extends StatefulWidget {
     ),
   });
 
+  final PopoverMutex? popoverMutex;
   final List<T> actions;
   final Widget Function(PopoverController) buildChild;
   final Function(T, PopoverController) onSelected;
@@ -74,6 +76,7 @@ class _PopoverActionListState<T extends PopoverAction>
             );
           } else if (action is PopoverActionCell) {
             return PopoverActionCellWidget<T>(
+              popoverMutex: widget.popoverMutex,
               popoverController: popoverController,
               action: action,
               itemHeight: ActionListSizes.itemHeight,
@@ -164,11 +167,13 @@ class ActionCellWidget<T extends PopoverAction> extends StatelessWidget {
 class PopoverActionCellWidget<T extends PopoverAction> extends StatefulWidget {
   const PopoverActionCellWidget({
     super.key,
+    this.popoverMutex,
     required this.popoverController,
     required this.action,
     required this.itemHeight,
   });
 
+  final PopoverMutex? popoverMutex;
   final T action;
   final double itemHeight;
 
@@ -190,6 +195,7 @@ class _PopoverActionCellWidgetState<T extends PopoverAction>
     final rightIcon =
         actionCell.rightIcon(Theme.of(context).colorScheme.onSurface);
     return AppFlowyPopover(
+      mutex: widget.popoverMutex,
       controller: popoverController,
       asBarrier: true,
       popupBuilder: (context) => actionCell.builder(

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/language.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/language.dart
@@ -72,9 +72,7 @@ String languageFromLocale(Locale locale) {
       return "اردو";
     case "hin":
       return "हिन्दी";
-
-    // If not found then the language code will be displayed
-    default:
-      return locale.languageCode;
   }
+  // If not found then the language code will be displayed
+  return locale.languageCode;
 }

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -817,6 +817,9 @@
       "date": "Date",
       "emoji": "Emoji"
     },
+    "outlineBlock": {
+      "placeholder": "Table of Contents"
+    },
     "textBlock": {
       "placeholder": "Type '/' for commands"
     },

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -779,7 +779,8 @@
         "left": "Left",
         "center": "Center",
         "right": "Right",
-        "defaultColor": "Default"
+        "defaultColor": "Default",
+        "depth": "Depth"
       },
       "image": {
         "copiedToPasteBoard": "The image link has been copied to the clipboard",


### PR DESCRIPTION
**Closes:** #4355 

**Changes Made:**
Added dynamic depth control to the `OutlineBlockWidget` component.
When a depth **H1** is selected, the app now displays headings up to level 1.
For depth **H2**, it shows headings up to level 2, extending upto subsequent **H3** headings.

**Demo:**


https://github.com/AppFlowy-IO/AppFlowy/assets/68953739/948a6e88-89d8-49c7-b58c-7ef3f5f899af
