### PR TITLE
fix: deleting a sort doesn't allow creating a new sort on that field

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/field_controller.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/field_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:appflowy/plugins/database/application/database_view_service.dart';
 import 'package:appflowy/plugins/database/application/field_settings/field_settings_listener.dart';
 import 'package:appflowy/plugins/database/application/field_settings/field_settings_service.dart';
@@ -333,6 +335,32 @@ class FieldController {
       }
     }
 
+    void updateFieldInfos(
+      List<SortInfo> newSortInfos,
+      SortChangesetNotificationPB changeset,
+    ) {
+      final changedFieldIds = HashSet<String>.from([
+        ...changeset.insertSorts.map((sort) => sort.sort.fieldId),
+        ...changeset.updateSorts.map((sort) => sort.fieldId),
+        ...changeset.deleteSorts.map((sort) => sort.fieldId),
+      ]);
+
+      final newFieldInfos = [...fieldInfos];
+
+      for (final fieldId in changedFieldIds) {
+        final index =
+            newFieldInfos.indexWhere((fieldInfo) => fieldInfo.id == fieldId);
+        if (index == -1) {
+          continue;
+        }
+        newFieldInfos[index] = newFieldInfos[index].copyWith(
+          hasSort: newSortInfos.any((sort) => sort.fieldId == fieldId),
+        );
+      }
+
+      _fieldNotifier.fieldInfos = newFieldInfos;
+    }
+
     _sortsListener.start(
       onSortChanged: (result) {
         if (_isDisposed) {
@@ -346,6 +374,7 @@ class FieldController {
             updateSortFromChangeset(newSortInfos, changeset);
 
             _sortNotifier?.sorts = newSortInfos;
+            updateFieldInfos(newSortInfos, changeset);
           },
           (err) => Log.error(err),
         );


### PR DESCRIPTION
resolves #3444

Steps to reproduce:

1. Create a sort on a field
2. Switch to a different document/database and come back
3. Delete that sort
4. Attempt to create a sort on that same field.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
