### PR TITLE
fix: mobile view and field list bottom sheets

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/show_mobile_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/show_mobile_bottom_sheet.dart
@@ -3,6 +3,24 @@ import 'package:appflowy/plugins/base/drag_handler.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart' hide WidgetBuilder;
 import 'package:flutter/material.dart';
 
+extension BottomSheetPaddingExtension on BuildContext {
+  /// Calculates the total amount of space that should be added to the bottom of
+  /// a bottom sheet
+  double bottomSheetPadding({
+    bool ignoreViewPadding = true,
+  }) {
+    final mediaQuery = MediaQuery.of(this);
+    double bottom = 0.0;
+    if (!ignoreViewPadding) {
+      bottom += mediaQuery.viewPadding.bottom;
+    }
+    // for screens with 0 view padding, add some even more space
+    bottom += mediaQuery.viewPadding.bottom == 0 ? 28.0 : 16.0;
+    bottom += mediaQuery.viewInsets.bottom;
+    return bottom;
+  }
+}
+
 Future<T?> showMobileBottomSheet<T>(
   BuildContext context, {
   required WidgetBuilder builder,
@@ -120,12 +138,11 @@ Future<T?> showMobileBottomSheet<T>(
       }
 
       // ----- content area -----
-      // make sure the keyboard won't cover the content
+      // add content padding and extra bottom padding
       children.add(
         Padding(
-          padding: padding.copyWith(
-            bottom: padding.bottom + MediaQuery.of(context).viewInsets.bottom,
-          ),
+          padding:
+              padding + EdgeInsets.only(bottom: context.bottomSheetPadding()),
           child: child,
         ),
       );
@@ -134,13 +151,6 @@ Future<T?> showMobileBottomSheet<T>(
       if (children.length == 1) {
         return children.first;
       }
-
-      // add default padding
-      // for full screen bottom sheet, the padding should be 16.0
-      // for non full screen bottom sheet, the padding should be 28.0
-      children.add(
-        VSpace(MediaQuery.of(context).padding.bottom == 0 ? 28.0 : 16.0),
-      );
 
       return useSafeArea
           ? SafeArea(

--- a/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/show_mobile_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/show_mobile_bottom_sheet.dart
@@ -9,14 +9,15 @@ extension BottomSheetPaddingExtension on BuildContext {
   double bottomSheetPadding({
     bool ignoreViewPadding = true,
   }) {
-    final mediaQuery = MediaQuery.of(this);
+    final viewPadding = MediaQuery.viewPaddingOf(this);
+    final viewInsets = MediaQuery.viewInsetsOf(this);
     double bottom = 0.0;
     if (!ignoreViewPadding) {
-      bottom += mediaQuery.viewPadding.bottom;
+      bottom += viewPadding.bottom;
     }
     // for screens with 0 view padding, add some even more space
-    bottom += mediaQuery.viewPadding.bottom == 0 ? 28.0 : 16.0;
-    bottom += mediaQuery.viewInsets.bottom;
+    bottom += viewPadding.bottom == 0 ? 28.0 : 16.0;
+    bottom += viewInsets.bottom;
     return bottom;
   }
 }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
 import 'package:appflowy/mobile/presentation/widgets/flowy_option_tile.dart';
 import 'package:appflowy/plugins/database/application/database_controller.dart';
 import 'package:appflowy/plugins/database/application/field/field_controller.dart';
@@ -62,9 +63,6 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
             return const SizedBox.shrink();
           }
 
-          final mediaQuery = MediaQuery.of(context);
-          final bottomPadding = mediaQuery.viewPadding.bottom +
-              (mediaQuery.padding.bottom == 0 ? 28.0 : 16.0);
           final fields = [...state.fieldContexts];
           final firstField = fields.removeAt(0);
           final firstCell = DatabaseFieldListTile(
@@ -128,10 +126,16 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
                     children: [
                       _divider(),
                       _NewDatabaseFieldTile(viewId: viewId),
-                      VSpace(bottomPadding),
+                      VSpace(
+                        context.bottomSheetPadding(
+                          ignoreViewPadding: false,
+                        ),
+                      ),
                     ],
                   )
-                : VSpace(bottomPadding),
+                : VSpace(
+                    context.bottomSheetPadding(ignoreViewPadding: false),
+                  ),
             itemCount: cells.length,
             itemBuilder: (context, index) => cells[index],
           );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_field_list.dart
@@ -61,6 +61,10 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
           if (state.fieldContexts.isEmpty) {
             return const SizedBox.shrink();
           }
+
+          final mediaQuery = MediaQuery.of(context);
+          final bottomPadding = mediaQuery.viewPadding.bottom +
+              (mediaQuery.padding.bottom == 0 ? 28.0 : 16.0);
           final fields = [...state.fieldContexts];
           final firstField = fields.removeAt(0);
           final firstCell = DatabaseFieldListTile(
@@ -124,10 +128,10 @@ class _MobileDatabaseFieldListBody extends StatelessWidget {
                     children: [
                       _divider(),
                       _NewDatabaseFieldTile(viewId: viewId),
-                      const VSpace(24),
+                      VSpace(bottomPadding),
                     ],
                   )
-                : const VSpace(24),
+                : VSpace(bottomPadding),
             itemCount: cells.length,
             itemBuilder: (context, index) => cells[index],
           );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_view_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_view_list.dart
@@ -28,7 +28,6 @@ class MobileDatabaseViewList extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ViewBloc, ViewState>(
       builder: (context, state) {
-        final mediaQuery = MediaQuery.of(context);
         final views = [state.view, ...state.view.childViews];
 
         return Column(
@@ -45,8 +44,10 @@ class MobileDatabaseViewList extends StatelessWidget {
               useFilledDoneButton: false,
               onDone: (context) => Navigator.pop(context),
             ),
-            SingleChildScrollView(
-              child: Column(
+            Expanded(
+              child: ListView(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
                 children: [
                   ...views.mapIndexed(
                     (index, view) => MobileDatabaseViewListButton(
@@ -56,8 +57,9 @@ class MobileDatabaseViewList extends StatelessWidget {
                   ),
                   const VSpace(20),
                   const MobileNewDatabaseViewButton(),
-                  VSpace(mediaQuery.viewPadding.bottom),
-                  VSpace(mediaQuery.padding.bottom == 0 ? 28.0 : 16.0),
+                  VSpace(
+                    context.bottomSheetPadding(ignoreViewPadding: false),
+                  ),
                 ],
               ),
             ),

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_view_list.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/view/database_view_list.dart
@@ -28,6 +28,7 @@ class MobileDatabaseViewList extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ViewBloc, ViewState>(
       builder: (context, state) {
+        final mediaQuery = MediaQuery.of(context);
         final views = [state.view, ...state.view.childViews];
 
         return Column(
@@ -55,6 +56,8 @@ class MobileDatabaseViewList extends StatelessWidget {
                   ),
                   const VSpace(20),
                   const MobileNewDatabaseViewButton(),
+                  VSpace(mediaQuery.viewPadding.bottom),
+                  VSpace(mediaQuery.padding.bottom == 0 ? 28.0 : 16.0),
                 ],
               ),
             ),

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/sort/create_sort_list.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/sort/create_sort_list.dart
@@ -4,6 +4,7 @@ import 'package:appflowy/plugins/database/application/field/field_info.dart';
 import 'package:appflowy/plugins/database/grid/application/sort/sort_editor_bloc.dart';
 import 'package:appflowy/plugins/database/grid/presentation/layout/sizes.dart';
 import 'package:appflowy/util/field_type_extension.dart';
+import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/style_widget/button.dart';
@@ -26,9 +27,10 @@ class CreateDatabaseViewSortList extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SortEditorBloc, SortEditorState>(
       builder: (context, state) {
-        final filter = state.filter.toLowerCase();
         final cells = state.creatableFields
-            .where((field) => field.field.name.toLowerCase().contains(filter))
+            .where(
+          (field) => equalsIgnoreAsciiCase(field.field.name, state.filter),
+        )
             .map((fieldInfo) {
           return GridSortPropertyCell(
             fieldInfo: fieldInfo,

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/sort/create_sort_list.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/sort/create_sort_list.dart
@@ -4,7 +4,6 @@ import 'package:appflowy/plugins/database/application/field/field_info.dart';
 import 'package:appflowy/plugins/database/grid/application/sort/sort_editor_bloc.dart';
 import 'package:appflowy/plugins/database/grid/presentation/layout/sizes.dart';
 import 'package:appflowy/util/field_type_extension.dart';
-import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/style_widget/button.dart';
@@ -27,10 +26,9 @@ class CreateDatabaseViewSortList extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SortEditorBloc, SortEditorState>(
       builder: (context, state) {
+        final filter = state.filter.toLowerCase();
         final cells = state.creatableFields
-            .where(
-          (field) => equalsIgnoreAsciiCase(field.field.name, state.filter),
-        )
+            .where((field) => field.field.name.toLowerCase().contains(filter))
             .map((fieldInfo) {
           return GridSortPropertyCell(
             fieldInfo: fieldInfo,

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/mobile_select_option_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/mobile_select_option_editor.dart
@@ -480,7 +480,11 @@ class _MoreOptionsState extends State<_MoreOptions> {
   Widget _buildDeleteButton(BuildContext context) {
     return FlowyOptionTile.text(
       text: LocaleKeys.button_delete.tr(),
-      leftIcon: const FlowySvg(FlowySvgs.m_delete_s),
+      textColor: Theme.of(context).colorScheme.error,
+      leftIcon: FlowySvg(
+        FlowySvgs.m_delete_s,
+        color: Theme.of(context).colorScheme.error,
+      ),
       onTap: widget.onDelete,
     );
   }


### PR DESCRIPTION
bottom overflow
![Screenshot 2024-02-24 at 9 38 27 PM](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/0e9b9aca-47ce-44ea-90e1-a79ce0e351b7)

not enough padding
![Screenshot 2024-02-24 at 9 38 48 PM](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/d00ea806-5f44-4116-bb3f-efc28c94272f)

misc
- change delete text and icon color for select option editor to red
- improve code style in field name filter

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
