### PR TITLE
fix: edit column sheet uniform ui

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/board/widgets/group_card_header.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/board/widgets/group_card_header.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
+import 'package:appflowy/mobile/presentation/widgets/flowy_mobile_quick_action_button.dart';
 import 'package:appflowy/plugins/database/board/application/board_bloc.dart';
 import 'package:appflowy/plugins/database/grid/presentation/widgets/header/field_type_extension.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/field_entities.pbenum.dart';
@@ -8,7 +11,6 @@ import 'package:appflowy_backend/protobuf/flowy-database2/group.pb.dart';
 import 'package:appflowy_board/appflowy_board.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
@@ -107,46 +109,43 @@ class _GroupCardHeaderState extends State<GroupCardHeader> {
                   splashRadius: 5,
                   onPressed: () => showMobileBottomSheet(
                     context,
-                    title: LocaleKeys.board_column_groupActions.tr(),
-                    showHeader: true,
-                    showCloseButton: true,
-                    builder: (_) {
-                      return Row(
-                        children: [
-                          Expanded(
-                            child: BottomSheetActionWidget(
-                              svg: FlowySvgs.edit_s,
-                              text: LocaleKeys.board_column_renameColumn.tr(),
-                              onTap: () {
-                                context.read<BoardBloc>().add(
-                                      BoardEvent.startEditingHeader(
-                                        widget.groupData.id,
-                                      ),
-                                    );
-                                context.pop();
-                              },
-                            ),
-                          ),
-                          const HSpace(8),
-                          Expanded(
-                            child: BottomSheetActionWidget(
-                              svg: FlowySvgs.hide_s,
-                              text: LocaleKeys.board_column_hideColumn.tr(),
-                              onTap: () {
-                                context.read<BoardBloc>().add(
-                                      BoardEvent.toggleGroupVisibility(
-                                        widget.groupData.customData.group
-                                            as GroupPB,
-                                        false,
-                                      ),
-                                    );
-                                context.pop();
-                              },
-                            ),
-                          ),
-                        ],
-                      );
-                    },
+                    showDragHandle: true,
+                    backgroundColor: Theme.of(context).colorScheme.surface,
+                    builder: (_) => SeparatedColumn(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      separatorBuilder: () => const Divider(
+                        height: 8.5,
+                        thickness: 0.5,
+                      ),
+                      children: [
+                        MobileQuickActionButton(
+                          text: LocaleKeys.board_column_renameColumn.tr(),
+                          icon: FlowySvgs.edit_s,
+                          onTap: () {
+                            context.read<BoardBloc>().add(
+                                  BoardEvent.startEditingHeader(
+                                    widget.groupData.id,
+                                  ),
+                                );
+                            context.pop();
+                          },
+                        ),
+                        MobileQuickActionButton(
+                          text: LocaleKeys.board_column_hideColumn.tr(),
+                          icon: FlowySvgs.hide_s,
+                          onTap: () {
+                            context.read<BoardBloc>().add(
+                                  BoardEvent.toggleGroupVisibility(
+                                    widget.groupData.customData.group
+                                        as GroupPB,
+                                    false,
+                                  ),
+                                );
+                            context.pop();
+                          },
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 IconButton(

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -940,7 +940,6 @@
       "addToColumnBottomTooltip": "Add a new card at the bottom",
       "renameColumn": "Rename",
       "hideColumn": "Hide",
-      "groupActions": "Group Actions",
       "newGroup": "New Group",
       "deleteColumn": "Delete",
       "deleteColumnConfirmation": "This will delete this group and all the cards in it.\nAre you sure you want to continue?"


### PR DESCRIPTION
Closes: #4770 

We have a lot of different sheets on Mobile, but I've made it uniform to the database options sheet.

### Feature Preview

<img width="559" alt="Screenshot 2024-02-28 at 12 10 36" src="https://github.com/AppFlowy-IO/AppFlowy/assets/42929161/4f487930-f7e6-424b-89a0-96fd1ca2cc0b">

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
