### PR TITLE
chore: type option cell data trait cleanup

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/entities/filter_entities/select_option_filter.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/filter_entities/select_option_filter.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use flowy_derive::{ProtoBuf, ProtoBuf_Enum};
 use flowy_error::ErrorCode;
 
@@ -48,7 +50,7 @@ impl FromFilterString for SelectOptionFilterPB {
   where
     Self: Sized,
   {
-    let ids = SelectOptionIds::from(filter.content.clone());
+    let ids = SelectOptionIds::from_str(&filter.content).unwrap_or_default();
     SelectOptionFilterPB {
       condition: SelectOptionConditionPB::try_from(filter.condition as u8)
         .unwrap_or(SelectOptionConditionPB::OptionIs),
@@ -59,7 +61,7 @@ impl FromFilterString for SelectOptionFilterPB {
 
 impl std::convert::From<&Filter> for SelectOptionFilterPB {
   fn from(filter: &Filter) -> Self {
-    let ids = SelectOptionIds::from(filter.content.clone());
+    let ids = SelectOptionIds::from_str(&filter.content).unwrap_or_default();
     SelectOptionFilterPB {
       condition: SelectOptionConditionPB::try_from(filter.condition as u8)
         .unwrap_or(SelectOptionConditionPB::OptionIs),

--- a/frontend/rust-lib/flowy-database2/src/services/cell/cell_operation.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/cell/cell_operation.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use collab_database::fields::Field;
 use collab_database::rows::{get_field_type_from_cell, Cell, Cells};
@@ -245,13 +246,6 @@ pub fn delete_select_option_cell(option_ids: Vec<String>, field: &Field) -> Cell
   apply_cell_changeset(BoxAny::new(changeset), None, field, None).unwrap()
 }
 
-/// Deserialize the String into cell specific data type.
-pub trait FromCellString {
-  fn from_cell_str(s: &str) -> FlowyResult<Self>
-  where
-    Self: Sized;
-}
-
 pub struct CellBuilder<'a> {
   cells: Cells,
   field_maps: HashMap<String, &'a Field>,
@@ -290,12 +284,12 @@ impl<'a> CellBuilder<'a> {
             tracing::warn!("Shouldn't insert cell data to cell whose field type is LastEditedTime or CreatedTime");
           },
           FieldType::SingleSelect | FieldType::MultiSelect => {
-            if let Ok(ids) = SelectOptionIds::from_cell_str(&cell_str) {
+            if let Ok(ids) = SelectOptionIds::from_str(&cell_str) {
               cells.insert(field_id, insert_select_option_cell(ids.into_inner(), field));
             }
           },
           FieldType::Checkbox => {
-            if let Ok(value) = CheckboxCellDataPB::from_cell_str(&cell_str) {
+            if let Ok(value) = CheckboxCellDataPB::from_str(&cell_str) {
               cells.insert(field_id, insert_checkbox_cell(value.is_checked, field));
             }
           },
@@ -303,7 +297,7 @@ impl<'a> CellBuilder<'a> {
             cells.insert(field_id, insert_url_cell(cell_str, field));
           },
           FieldType::Checklist => {
-            if let Ok(ids) = SelectOptionIds::from_cell_str(&cell_str) {
+            if let Ok(ids) = SelectOptionIds::from_str(&cell_str) {
               cells.insert(field_id, insert_select_option_cell(ids.into_inner(), field));
             }
           },

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_tests.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_tests.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
+
   use collab_database::fields::Field;
 
   use crate::entities::CheckboxCellDataPB;
   use crate::entities::FieldType;
   use crate::services::cell::CellDataDecoder;
-  use crate::services::cell::FromCellString;
   use crate::services::field::type_options::checkbox_type_option::*;
   use crate::services::field::FieldBuilder;
 
@@ -43,7 +44,7 @@ mod tests {
     assert_eq!(
       type_option
         .decode_cell(
-          &CheckboxCellDataPB::from_cell_str(input_str).unwrap().into(),
+          &CheckboxCellDataPB::from_str(input_str).unwrap().into(),
           field_type,
           field
         )

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_type_option_entities.rs
@@ -7,7 +7,7 @@ use collab_database::rows::{new_cell_builder, Cell};
 use flowy_error::{FlowyError, FlowyResult};
 
 use crate::entities::{CheckboxCellDataPB, FieldType};
-use crate::services::cell::{CellProtobufBlobParser, DecodedCellData, FromCellString};
+use crate::services::cell::{CellProtobufBlobParser, FromCellString};
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 pub const CHECK: &str = "Yes";
@@ -65,14 +65,6 @@ impl ToString for CheckboxCellDataPB {
     } else {
       UNCHECK.to_string()
     }
-  }
-}
-
-impl DecodedCellData for CheckboxCellDataPB {
-  type Object = CheckboxCellDataPB;
-
-  fn is_empty(&self) -> bool {
-    false
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/checkbox_type_option/checkbox_type_option_entities.rs
@@ -7,7 +7,7 @@ use collab_database::rows::{new_cell_builder, Cell};
 use flowy_error::{FlowyError, FlowyResult};
 
 use crate::entities::{CheckboxCellDataPB, FieldType};
-use crate::services::cell::{CellProtobufBlobParser, FromCellString};
+use crate::services::cell::CellProtobufBlobParser;
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 pub const CHECK: &str = "Yes";
@@ -22,7 +22,7 @@ impl TypeOptionCellData for CheckboxCellDataPB {
 impl From<&Cell> for CheckboxCellDataPB {
   fn from(cell: &Cell) -> Self {
     let value = cell.get_str_value(CELL_DATA).unwrap_or_default();
-    CheckboxCellDataPB::from_cell_str(&value).unwrap_or_default()
+    CheckboxCellDataPB::from_str(&value).unwrap_or_default()
   }
 }
 
@@ -46,15 +46,6 @@ impl FromStr for CheckboxCellDataPB {
     };
 
     Ok(Self::new(is_checked))
-  }
-}
-
-impl FromCellString for CheckboxCellDataPB {
-  fn from_cell_str(s: &str) -> FlowyResult<Self>
-  where
-    Self: Sized,
-  {
-    Self::from_str(s)
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
@@ -11,7 +11,7 @@ use strum_macros::EnumIter;
 use flowy_error::{internal_error, FlowyResult};
 
 use crate::entities::{DateCellDataPB, FieldType};
-use crate::services::cell::{CellProtobufBlobParser, DecodedCellData, FromCellString};
+use crate::services::cell::{CellProtobufBlobParser, FromCellString};
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 #[derive(Clone, Debug, Default)]
@@ -285,14 +285,6 @@ impl TimeFormat {
       TimeFormat::TwelveHour => "%I:%M %p",
       TimeFormat::TwentyFourHour => "%R",
     }
-  }
-}
-
-impl DecodedCellData for DateCellDataPB {
-  type Object = DateCellDataPB;
-
-  fn is_empty(&self) -> bool {
-    self.date.is_empty()
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/date_type_option/date_type_option_entities.rs
@@ -11,7 +11,7 @@ use strum_macros::EnumIter;
 use flowy_error::{internal_error, FlowyResult};
 
 use crate::entities::{DateCellDataPB, FieldType};
-use crate::services::cell::{CellProtobufBlobParser, FromCellString};
+use crate::services::cell::CellProtobufBlobParser;
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 #[derive(Clone, Debug, Default)]
@@ -193,16 +193,6 @@ impl<'de> serde::Deserialize<'de> for DateCellData {
     }
 
     deserializer.deserialize_any(DateCellVisitor())
-  }
-}
-
-impl FromCellString for DateCellData {
-  fn from_cell_str(s: &str) -> FlowyResult<Self>
-  where
-    Self: Sized,
-  {
-    let result: DateCellData = serde_json::from_str(s).unwrap();
-    Ok(result)
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/number_type_option/number_type_option_entities.rs
@@ -1,4 +1,4 @@
-use crate::services::cell::{CellBytesCustomParser, CellProtobufBlobParser, DecodedCellData};
+use crate::services::cell::{CellBytesCustomParser, CellProtobufBlobParser};
 use crate::services::field::number_currency::Currency;
 use crate::services::field::{NumberFormat, EXTRACT_NUM_REGEX, START_WITH_DOT_NUM_REGEX};
 use bytes::Bytes;
@@ -105,14 +105,6 @@ impl ToString for NumberCellFormat {
       },
       Some(money) => money.to_string(),
     }
-  }
-}
-
-impl DecodedCellData for NumberCellFormat {
-  type Object = NumberCellFormat;
-
-  fn is_empty(&self) -> bool {
-    self.decimal.is_none()
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/multi_select_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/multi_select_type_option.rs
@@ -216,8 +216,6 @@ mod tests {
     debug_assert_eq!(multi_select.options.len(), 2);
   }
 
-  // #[test]
-
   #[test]
   fn multi_select_insert_multi_option_test() {
     let google = SelectOption::new("Google");

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_ids.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_ids.rs
@@ -4,7 +4,7 @@ use collab_database::rows::{new_cell_builder, Cell};
 use flowy_error::FlowyResult;
 
 use crate::entities::FieldType;
-use crate::services::cell::{DecodedCellData, FromCellString};
+use crate::services::cell::FromCellString;
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 pub const SELECTION_IDS_SEPARATOR: &str = ",";
@@ -105,13 +105,5 @@ impl std::ops::Deref for SelectOptionIds {
 impl std::ops::DerefMut for SelectOptionIds {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
-  }
-}
-
-impl DecodedCellData for SelectOptionIds {
-  type Object = SelectOptionIds;
-
-  fn is_empty(&self) -> bool {
-    self.0.is_empty()
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_ids.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_ids.rs
@@ -1,10 +1,11 @@
+use std::str::FromStr;
+
 use collab::core::any_map::AnyMapExtension;
 use collab_database::rows::{new_cell_builder, Cell};
 
-use flowy_error::FlowyResult;
+use flowy_error::FlowyError;
 
 use crate::entities::FieldType;
-use crate::services::cell::FromCellString;
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 pub const SELECTION_IDS_SEPARATOR: &str = ",";
@@ -37,33 +38,25 @@ impl TypeOptionCellData for SelectOptionIds {
   }
 }
 
-impl FromCellString for SelectOptionIds {
-  fn from_cell_str(s: &str) -> FlowyResult<Self>
-  where
-    Self: Sized,
-  {
-    Ok(Self::from(s.to_owned()))
-  }
-}
-
 impl From<&Cell> for SelectOptionIds {
   fn from(cell: &Cell) -> Self {
     let value = cell.get_str_value(CELL_DATA).unwrap_or_default();
-    Self::from(value)
+    Self::from_str(&value).unwrap_or_default()
   }
 }
 
-impl std::convert::From<String> for SelectOptionIds {
-  fn from(s: String) -> Self {
-    if s.is_empty() {
-      return Self(vec![]);
-    }
+impl FromStr for SelectOptionIds {
+  type Err = FlowyError;
 
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    if s.is_empty() {
+      return Ok(Self(vec![]));
+    }
     let ids = s
       .split(SELECTION_IDS_SEPARATOR)
       .map(|id| id.to_string())
       .collect::<Vec<String>>();
-    Self(ids)
+    Ok(Self(ids))
   }
 }
 
@@ -89,7 +82,7 @@ impl std::convert::From<Option<String>> for SelectOptionIds {
   fn from(s: Option<String>) -> Self {
     match s {
       None => Self(vec![]),
-      Some(s) => Self::from(s),
+      Some(s) => Self::from_str(&s).unwrap_or_default(),
     }
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_type_option.rs
@@ -5,7 +5,7 @@ use collab_database::rows::Cell;
 use flowy_error::{internal_error, ErrorCode, FlowyResult};
 
 use crate::entities::{CheckboxCellDataPB, FieldType, SelectOptionCellDataPB};
-use crate::services::cell::{CellDataDecoder, CellProtobufBlobParser, DecodedCellData};
+use crate::services::cell::{CellDataDecoder, CellProtobufBlobParser};
 use crate::services::field::selection_type_option::type_option_transform::SelectOptionTypeOptionTransformHelper;
 use crate::services::field::{
   make_selected_options, MultiSelectTypeOption, SelectOption, SelectOptionCellData,
@@ -208,14 +208,6 @@ impl CellProtobufBlobParser for SelectOptionIdsParser {
       Ok(s) => Ok(SelectOptionIds::from(s)),
       Err(_) => Ok(SelectOptionIds::from("".to_owned())),
     }
-  }
-}
-
-impl DecodedCellData for SelectOptionCellDataPB {
-  type Object = SelectOptionCellDataPB;
-
-  fn is_empty(&self) -> bool {
-    self.select_options.is_empty()
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/selection_type_option/select_type_option.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use bytes::Bytes;
 use collab_database::fields::{Field, TypeOptionData};
 use collab_database::rows::Cell;
@@ -205,8 +207,8 @@ impl CellProtobufBlobParser for SelectOptionIdsParser {
   type Object = SelectOptionIds;
   fn parser(bytes: &Bytes) -> FlowyResult<Self::Object> {
     match String::from_utf8(bytes.to_vec()) {
-      Ok(s) => Ok(SelectOptionIds::from(s)),
-      Err(_) => Ok(SelectOptionIds::from("".to_owned())),
+      Ok(s) => SelectOptionIds::from_str(&s),
+      Err(_) => Ok(SelectOptionIds::default()),
     }
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_type_option.rs
@@ -10,8 +10,7 @@ use flowy_error::{FlowyError, FlowyResult};
 
 use crate::entities::{FieldType, TextFilterPB};
 use crate::services::cell::{
-  stringify_cell_data, CellDataChangeset, CellDataDecoder, CellProtobufBlobParser, DecodedCellData,
-  FromCellString,
+  stringify_cell_data, CellDataChangeset, CellDataDecoder, CellProtobufBlobParser, FromCellString,
 };
 use crate::services::field::type_options::util::ProtobufStr;
 use crate::services::field::{
@@ -203,14 +202,6 @@ impl FromCellString for TextCellData {
 impl ToString for TextCellData {
   fn to_string(&self) -> String {
     self.0.clone()
-  }
-}
-
-impl DecodedCellData for TextCellData {
-  type Object = TextCellData;
-
-  fn is_empty(&self) -> bool {
-    self.0.is_empty()
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_type_option.rs
@@ -10,7 +10,7 @@ use flowy_error::{FlowyError, FlowyResult};
 
 use crate::entities::{FieldType, TextFilterPB};
 use crate::services::cell::{
-  stringify_cell_data, CellDataChangeset, CellDataDecoder, CellProtobufBlobParser, FromCellString,
+  stringify_cell_data, CellDataChangeset, CellDataDecoder, CellProtobufBlobParser,
 };
 use crate::services::field::type_options::util::ProtobufStr;
 use crate::services::field::{
@@ -190,15 +190,6 @@ impl std::ops::Deref for TextCellData {
   }
 }
 
-impl FromCellString for TextCellData {
-  fn from_cell_str(s: &str) -> FlowyResult<Self>
-  where
-    Self: Sized,
-  {
-    Ok(TextCellData(s.to_owned()))
-  }
-}
-
 impl ToString for TextCellData {
   fn to_string(&self) -> String {
     self.0.clone()
@@ -249,12 +240,6 @@ impl From<StrCellData> for Cell {
 impl std::ops::DerefMut for StrCellData {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
-  }
-}
-
-impl FromCellString for StrCellData {
-  fn from_cell_str(s: &str) -> FlowyResult<Self> {
-    Ok(Self(s.to_owned()))
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/type_option.rs
@@ -23,16 +23,15 @@ use crate::services::filter::FromFilterString;
 use crate::services::sort::SortCondition;
 
 pub trait TypeOption {
-  /// `CellData` represents as the decoded model for current type option. Each of them impl the
-  /// `FromCellString` and `Default` trait. If the cell string can not be decoded into the specified
-  /// cell data type then the default value will be returned.
-  /// For example:
+  /// `CellData` represents the decoded model for the current type option. Each of them must
+  /// implement the From<&Cell> trait. If the `Cell` cannot be decoded into this type, the default
+  /// value will be returned.
+  ///
+  /// Note: Use `StrCellData` for any `TypeOption` whose cell data is simply `String`.
   ///
   /// - FieldType::Checkbox => CheckboxCellData
   /// - FieldType::Date => DateCellData
   /// - FieldType::URL => URLCellData
-  ///
-  /// Uses `StrCellData` for any `TypeOption` if their cell data is pure `String`.
   ///
   type CellData: for<'a> From<&'a Cell>
     + TypeOptionCellData

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/url_type_option/url_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/url_type_option/url_type_option_entities.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use flowy_error::{internal_error, FlowyResult};
 
 use crate::entities::{FieldType, URLCellDataPB};
-use crate::services::cell::{CellProtobufBlobParser, FromCellString};
+use crate::services::cell::CellProtobufBlobParser;
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -81,12 +81,6 @@ impl CellProtobufBlobParser for URLCellDataParser {
 
   fn parser(bytes: &Bytes) -> FlowyResult<Self::Object> {
     URLCellDataPB::try_from(bytes.as_ref()).map_err(internal_error)
-  }
-}
-
-impl FromCellString for URLCellData {
-  fn from_cell_str(s: &str) -> FlowyResult<Self> {
-    serde_json::from_str::<URLCellData>(s).map_err(internal_error)
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/url_type_option/url_type_option_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/url_type_option/url_type_option_entities.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use flowy_error::{internal_error, FlowyResult};
 
 use crate::entities::{FieldType, URLCellDataPB};
-use crate::services::cell::{CellProtobufBlobParser, DecodedCellData, FromCellString};
+use crate::services::cell::{CellProtobufBlobParser, FromCellString};
 use crate::services::field::{TypeOptionCellData, CELL_DATA};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -60,14 +60,6 @@ impl From<URLCellData> for URLCellDataPB {
   }
 }
 
-impl DecodedCellData for URLCellDataPB {
-  type Object = URLCellDataPB;
-
-  fn is_empty(&self) -> bool {
-    self.content.is_empty()
-  }
-}
-
 impl From<URLCellDataPB> for URLCellData {
   fn from(data: URLCellDataPB) -> Self {
     Self {
@@ -80,14 +72,6 @@ impl From<URLCellDataPB> for URLCellData {
 impl AsRef<str> for URLCellData {
   fn as_ref(&self) -> &str {
     &self.url
-  }
-}
-
-impl DecodedCellData for URLCellData {
-  type Object = URLCellData;
-
-  fn is_empty(&self) -> bool {
-    self.data.is_empty()
   }
 }
 


### PR DESCRIPTION
- `TypeCellData` is dead code. We use `AnyMap`s for serialization and deserialization when dealing with data storage and `BoxAny`s for generic in-memory storage instead now. 
- The `DecodedCellData` trait has been replaced with `TypeOptionCellData` whose contents are the same but is more thoroughly implemented (and actively used, in `TypeOptionCellDataCompare`)
- `FromCellString` isn't required for the `TypeOption::CellData` type. We have replaced it with `for<'a> From<&'a Cell>`. As such, I've decided to remove this trait completely and let the individual cell data types that need this functionality implement the `FromStr` trait

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
