### PR TITLE
feat: checklist UX improvement

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/application/cell/bloc/checklist_cell_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/cell/bloc/checklist_cell_bloc.dart
@@ -11,7 +11,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'checklist_cell_bloc.freezed.dart';
 
 class ChecklistSelectOption {
-  ChecklistSelectOption(this.isSelected, this.data);
+  ChecklistSelectOption({required this.isSelected, required this.data});
 
   final bool isSelected;
   final SelectOptionPB data;
@@ -26,6 +26,7 @@ class ChecklistCellBloc extends Bloc<ChecklistCellEvent, ChecklistCellState> {
         ),
         super(ChecklistCellState.initial(cellController)) {
     _dispatch();
+    _startListening();
   }
 
   final ChecklistCellController cellController;
@@ -46,9 +47,6 @@ class ChecklistCellBloc extends Bloc<ChecklistCellEvent, ChecklistCellState> {
     on<ChecklistCellEvent>(
       (event, emit) async {
         await event.when(
-          initial: () {
-            _startListening();
-          },
           didReceiveOptions: (data) {
             if (data == null) {
               emit(
@@ -71,8 +69,8 @@ class ChecklistCellBloc extends Bloc<ChecklistCellEvent, ChecklistCellState> {
           updateTaskName: (option, name) {
             _updateOption(option, name);
           },
-          selectTask: (option) async {
-            await _checklistCellService.select(optionId: option.id);
+          selectTask: (id) async {
+            await _checklistCellService.select(optionId: id);
           },
           createNewTask: (name) async {
             final result = await _checklistCellService.create(name: name);
@@ -81,8 +79,8 @@ class ChecklistCellBloc extends Bloc<ChecklistCellEvent, ChecklistCellState> {
               (err) => Log.error(err),
             );
           },
-          deleteTask: (option) async {
-            await _deleteOption([option]);
+          deleteTask: (id) async {
+            await _deleteOption([id]);
           },
         );
       },
@@ -102,21 +100,17 @@ class ChecklistCellBloc extends Bloc<ChecklistCellEvent, ChecklistCellState> {
   void _updateOption(SelectOptionPB option, String name) async {
     final result =
         await _checklistCellService.updateName(option: option, name: name);
-
     result.fold((l) => null, (err) => Log.error(err));
   }
 
-  Future<void> _deleteOption(List<SelectOptionPB> options) async {
-    final result = await _checklistCellService.delete(
-      optionIds: options.map((e) => e.id).toList(),
-    );
+  Future<void> _deleteOption(List<String> options) async {
+    final result = await _checklistCellService.delete(optionIds: options);
     result.fold((l) => null, (err) => Log.error(err));
   }
 }
 
 @freezed
 class ChecklistCellEvent with _$ChecklistCellEvent {
-  const factory ChecklistCellEvent.initial() = _InitialCell;
   const factory ChecklistCellEvent.didReceiveOptions(
     ChecklistCellDataPB? data,
   ) = _DidReceiveCellUpdate;
@@ -124,12 +118,10 @@ class ChecklistCellEvent with _$ChecklistCellEvent {
     SelectOptionPB option,
     String name,
   ) = _UpdateTaskName;
-  const factory ChecklistCellEvent.selectTask(SelectOptionPB task) =
-      _SelectTask;
+  const factory ChecklistCellEvent.selectTask(String taskId) = _SelectTask;
   const factory ChecklistCellEvent.createNewTask(String description) =
       _CreateNewTask;
-  const factory ChecklistCellEvent.deleteTask(SelectOptionPB option) =
-      _DeleteTask;
+  const factory ChecklistCellEvent.deleteTask(String taskId) = _DeleteTask;
 }
 
 @freezed
@@ -157,16 +149,14 @@ List<ChecklistSelectOption> _makeChecklistSelectOptions(
   if (data == null) {
     return [];
   }
-
-  final List<ChecklistSelectOption> options = [];
-  final List<SelectOptionPB> allOptions = List.from(data.options);
-  final selectedOptionIds = data.selectedOptions.map((e) => e.id).toList();
-
-  for (final option in allOptions) {
-    options.add(
-      ChecklistSelectOption(selectedOptionIds.contains(option.id), option),
-    );
-  }
-
-  return options;
+  return data.options
+      .map(
+        (option) => ChecklistSelectOption(
+          isSelected: data.selectedOptions.any(
+            (selected) => selected.id == option.id,
+          ),
+          data: option,
+        ),
+      )
+      .toList();
 }

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/card_cell_skeleton/checklist_card_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/card_cell_skeleton/checklist_card_cell.dart
@@ -42,7 +42,7 @@ class _ChecklistCellState extends State<ChecklistCardCell> {
             widget.databaseController,
             widget.cellContext,
           ).as(),
-        )..add(const ChecklistCellEvent.initial());
+        );
       },
       child: BlocBuilder<ChecklistCellBloc, ChecklistCellState>(
         builder: (context, state) {

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_checklist_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_checklist_cell.dart
@@ -64,14 +64,17 @@ class _ChecklistItemsState extends State<ChecklistItems> {
     }
     final children = tasks
         .mapIndexed(
-          (index, task) => ChecklistItem(
-            task: task,
-            autofocus: widget.state.newTask && index == tasks.length - 1,
-            onSubmitted: () {
-              if (index == tasks.length - 1) {
-                widget.bloc.add(const ChecklistCellEvent.createNewTask(""));
-              }
-            },
+          (index, task) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2.0),
+            child: ChecklistItem(
+              task: task,
+              autofocus: widget.state.newTask && index == tasks.length - 1,
+              onSubmitted: () {
+                if (index == tasks.length - 1) {
+                  widget.bloc.add(const ChecklistCellEvent.createNewTask(""));
+                }
+              },
+            ),
           ),
         )
         .toList();
@@ -111,7 +114,7 @@ class _ChecklistItemsState extends State<ChecklistItems> {
               ],
             ),
           ),
-          const VSpace(4),
+          const VSpace(2.0),
           ...children,
           ChecklistItemControl(cellNotifer: widget.cellContainerNotifier),
         ],
@@ -136,7 +139,7 @@ class ChecklistItemControl extends StatelessWidget {
               .read<ChecklistCellBloc>()
               .add(const ChecklistCellEvent.createNewTask("")),
           child: Container(
-            margin: const EdgeInsets.fromLTRB(8.0, 4.0, 8.0, 0),
+            margin: const EdgeInsets.fromLTRB(8.0, 2.0, 8.0, 0),
             height: 12,
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 150),

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/checklist.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/checklist.dart
@@ -58,7 +58,7 @@ class GridChecklistCellState extends GridCellState<EditableChecklistCell> {
       widget.databaseController,
       widget.cellContext,
     ).as(),
-  )..add(const ChecklistCellEvent.initial());
+  );
 
   @override
   void dispose() {

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/mobile_checklist_cell_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/mobile_checklist_cell_editor.dart
@@ -159,7 +159,7 @@ class _ChecklistItemState extends State<_ChecklistItem> {
             borderRadius: BorderRadius.circular(22),
             onTap: () => context
                 .read<ChecklistCellBloc>()
-                .add(ChecklistCellEvent.selectTask(widget.task.data)),
+                .add(ChecklistCellEvent.selectTask(widget.task.data.id)),
             child: SizedBox.square(
               dimension: 44,
               child: Center(
@@ -239,7 +239,7 @@ class _ChecklistItemState extends State<_ChecklistItem> {
             child: InkWell(
               onTap: () {
                 context.read<ChecklistCellBloc>().add(
-                      ChecklistCellEvent.deleteTask(widget.task.data),
+                      ChecklistCellEvent.deleteTask(widget.task.data.id),
                     );
                 context.pop();
               },

--- a/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
@@ -161,15 +161,16 @@ class PopoverState extends State<Popover> {
         ),
       );
 
-      return FocusScope(
-        onKey: (node, event) {
-          if (event.logicalKey == LogicalKeyboardKey.escape) {
-            _removeRootOverlay();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
+      return CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.escape): () =>
+              _removeRootOverlay(),
         },
-        child: Stack(children: children),
+        child: FocusScope(
+          child: Stack(
+            children: children,
+          ),
+        ),
       );
     });
     _rootEntry.addEntry(context, this, newEntry, widget.asBarrier);


### PR DESCRIPTION
Add keyboard navigation to checklist cell editor. `text field` refers to the place where the name of the task is changed. `item` refers to the entire checklist task, comprised of the checkbox, text field and delete button.

- Space when item is focused to select/unselect
- Delete when item is focused to delete
- Enter when item is focused to start editing (give focus to the text field)
- Cmd/Ctrl + Enter when item is focused OR text field is focused to select/unselect
- Esc when text field is focused to stop editing

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
