### PR TITLE
refactor: create row workflow

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/application/row/row_service.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/row/row_service.dart
@@ -28,16 +28,10 @@ class RowBackendService {
       ),
     );
 
-    Map<String, String>? cellDataByFieldId;
-
     if (withCells != null) {
       final rowBuilder = RowDataBuilder();
       withCells(rowBuilder);
-      cellDataByFieldId = rowBuilder.build();
-    }
-
-    if (cellDataByFieldId != null) {
-      payload.data = RowDataPB(cellDataByFieldId: cellDataByFieldId);
+      payload.data.addAll(rowBuilder.build());
     }
 
     return DatabaseEventCreateRow(payload).send();

--- a/frontend/appflowy_tauri/src/appflowy_app/application/database/row/row_service.ts
+++ b/frontend/appflowy_tauri/src/appflowy_app/application/database/row/row_service.ts
@@ -30,7 +30,7 @@ export async function createRow(viewId: string, params?: {
       object_id: params?.rowId,
     },
     group_id: params?.groupId,
-    data: params?.data ? { cell_data_by_field_id: params.data } : undefined,
+    data: params?.data,
   });
 
   const result = await DatabaseEventCreateRow(payload);

--- a/frontend/rust-lib/event-integration/src/database_event.rs
+++ b/frontend/rust-lib/event-integration/src/database_event.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use bytes::Bytes;
@@ -200,7 +201,7 @@ impl EventIntegrationTest {
     &self,
     view_id: &str,
     row_position: OrderObjectPositionPB,
-    data: Option<RowDataPB>,
+    data: Option<HashMap<String, String>>,
   ) -> RowMetaPB {
     EventBuilder::new(self.clone())
       .event(DatabaseEvent::CreateRow)
@@ -208,7 +209,7 @@ impl EventIntegrationTest {
         view_id: view_id.to_string(),
         row_position,
         group_id: None,
-        data,
+        data: data.unwrap_or_default(),
       })
       .async_send()
       .await

--- a/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
 use collab_database::rows::{Row, RowDetail, RowId};
-use collab_database::views::{OrderObjectPosition, RowOrder};
+use collab_database::views::RowOrder;
 
 use flowy_derive::ProtoBuf;
 use flowy_error::ErrorCode;
+use lib_infra::validator_fn::required_not_empty_str;
+use validator::Validate;
 
 use crate::entities::parser::NotEmptyStr;
 use crate::entities::position_entities::OrderObjectPositionPB;
@@ -335,46 +337,25 @@ impl TryInto<RowIdParams> for RowIdPB {
   }
 }
 
-#[derive(ProtoBuf, Default)]
+#[derive(ProtoBuf, Default, Validate)]
 pub struct CreateRowPayloadPB {
   #[pb(index = 1)]
+  #[validate(custom = "required_not_empty_str")]
   pub view_id: String,
 
   #[pb(index = 2)]
   pub row_position: OrderObjectPositionPB,
 
   #[pb(index = 3, one_of)]
+  #[validate(custom = "required_not_empty_str")]
   pub group_id: Option<String>,
 
-  #[pb(index = 4, one_of)]
-  pub data: Option<RowDataPB>,
-}
-
-#[derive(ProtoBuf, Default)]
-pub struct RowDataPB {
-  #[pb(index = 1)]
-  pub cell_data_by_field_id: HashMap<String, String>,
+  #[pb(index = 4)]
+  pub data: HashMap<String, String>,
 }
 
 #[derive(Default)]
 pub struct CreateRowParams {
-  pub view_id: String,
-  pub row_position: OrderObjectPosition,
-  pub group_id: Option<String>,
-  pub cell_data_by_field_id: Option<HashMap<String, String>>,
-}
-
-impl TryInto<CreateRowParams> for CreateRowPayloadPB {
-  type Error = ErrorCode;
-
-  fn try_into(self) -> Result<CreateRowParams, Self::Error> {
-    let view_id = NotEmptyStr::parse(self.view_id).map_err(|_| ErrorCode::ViewIdIsInvalid)?;
-    let position = self.row_position.try_into()?;
-    Ok(CreateRowParams {
-      view_id: view_id.0,
-      row_position: position,
-      group_id: self.group_id,
-      cell_data_by_field_id: self.data.map(|data| data.cell_data_by_field_id),
-    })
-  }
+  pub collab_params: collab_database::rows::CreateRowParams,
+  pub open_after_create: bool,
 }

--- a/frontend/rust-lib/flowy-database2/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database2/src/event_handler.rs
@@ -1,17 +1,14 @@
 use std::sync::{Arc, Weak};
 
-use collab_database::database::gen_row_id;
 use collab_database::rows::RowId;
 use lib_infra::box_any::BoxAny;
 use tokio::sync::oneshot;
 
 use flowy_error::{FlowyError, FlowyResult};
 use lib_dispatch::prelude::{af_spawn, data_result_ok, AFPluginData, AFPluginState, DataResult};
-use lib_infra::util::timestamp;
 
 use crate::entities::*;
 use crate::manager::DatabaseManager;
-use crate::services::cell::CellBuilder;
 use crate::services::field::{
   type_option_data_from_pb, ChecklistCellChangeset, DateCellChangeset, RelationCellChangeset,
   SelectOptionCellChangeset,
@@ -393,7 +390,7 @@ pub(crate) async fn duplicate_row_handler(
   let database_editor = manager.get_database_with_view_id(&params.view_id).await?;
   database_editor
     .duplicate_row(&params.view_id, &params.row_id)
-    .await;
+    .await?;
   Ok(())
 }
 
@@ -417,27 +414,12 @@ pub(crate) async fn create_row_handler(
   manager: AFPluginState<Weak<DatabaseManager>>,
 ) -> DataResult<RowMetaPB, FlowyError> {
   let manager = upgrade_manager(manager)?;
-  let params: CreateRowParams = data.into_inner().try_into()?;
+  let params = data.try_into_inner()?;
   let database_editor = manager.get_database_with_view_id(&params.view_id).await?;
-  let fields = database_editor.get_fields(&params.view_id, None);
-  let cells =
-    CellBuilder::with_cells(params.cell_data_by_field_id.unwrap_or_default(), &fields).build();
-  let view_id = params.view_id;
-  let group_id = params.group_id;
-  let params = collab_database::rows::CreateRowParams {
-    id: gen_row_id(),
-    cells,
-    height: 60,
-    visibility: true,
-    row_position: params.row_position,
-    timestamp: timestamp(),
-  };
-  match database_editor
-    .create_row(&view_id, group_id, params)
-    .await?
-  {
-    None => Err(FlowyError::internal().with_context("Create row fail")),
+
+  match database_editor.create_row(params).await? {
     Some(row) => data_result_ok(RowMetaPB::from(row)),
+    None => Err(FlowyError::internal().with_context("Error creating row")),
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_filter.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_filter.rs
@@ -50,7 +50,7 @@ impl FilterDelegate for DatabaseViewFilterDelegateImpl {
     self.0.get_field(field_id)
   }
 
-  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Arc<Field>>> {
+  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Field>> {
     self.0.get_fields(view_id, field_ids)
   }
 

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_group.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_group.rs
@@ -18,7 +18,7 @@ use crate::services::group::{
 pub async fn new_group_controller_with_field(
   view_id: String,
   delegate: Arc<dyn DatabaseViewOperation>,
-  grouping_field: Arc<Field>,
+  grouping_field: Field,
 ) -> FlowyResult<Box<dyn GroupController>> {
   let setting_reader = GroupSettingReaderImpl(delegate.clone());
   let rows = delegate.get_rows(&view_id).await;

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_operation.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_operation.rs
@@ -27,7 +27,7 @@ pub trait DatabaseViewOperation: Send + Sync + 'static {
   /// Get the view of the database with the view_id
   fn get_view(&self, view_id: &str) -> Fut<Option<DatabaseView>>;
   /// If the field_ids is None, then it will return all the field revisions
-  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Arc<Field>>>;
+  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Field>>;
 
   /// Returns the field with the field_id
   fn get_field(&self, field_id: &str) -> Option<Field>;

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_sort.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_sort.rs
@@ -74,7 +74,7 @@ impl SortDelegate for DatabaseViewSortDelegateImpl {
     self.delegate.get_field(field_id)
   }
 
-  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Arc<Field>>> {
+  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Field>> {
     self.delegate.get_fields(view_id, field_ids)
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/services/group/configuration.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/group/configuration.rs
@@ -71,7 +71,7 @@ pub struct GroupContext<C> {
   configuration_phantom: PhantomData<C>,
 
   /// The grouping field
-  field: Arc<Field>,
+  field: Field,
 
   /// Cache all the groups. Cache the group by its id.
   /// We use the id of the [Field] as the [No Status] group id.
@@ -94,7 +94,7 @@ where
   #[tracing::instrument(level = "trace", skip_all, err)]
   pub async fn new(
     view_id: String,
-    field: Arc<Field>,
+    field: Field,
     reader: Arc<dyn GroupSettingReader>,
     writer: Arc<dyn GroupSettingWriter>,
   ) -> FlowyResult<Self> {

--- a/frontend/rust-lib/flowy-database2/src/services/group/controller.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/group/controller.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use collab_database::fields::{Field, TypeOptionData};
@@ -75,7 +74,7 @@ where
   I: GroupOperationInterceptor<GroupTypeOption = T> + Send + Sync,
 {
   pub async fn new(
-    grouping_field: &Arc<Field>,
+    grouping_field: &Field,
     mut configuration: GroupContext<C>,
     operation_interceptor: I,
   ) -> FlowyResult<Self> {

--- a/frontend/rust-lib/flowy-database2/src/services/group/controller_impls/default_controller.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/group/controller_impls/default_controller.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use collab_database::fields::{Field, TypeOptionData};
 use collab_database::rows::{Cells, Row, RowDetail, RowId};
@@ -26,7 +24,7 @@ pub struct DefaultGroupController {
 const DEFAULT_GROUP_CONTROLLER: &str = "DefaultGroupController";
 
 impl DefaultGroupController {
-  pub fn new(field: &Arc<Field>) -> Self {
+  pub fn new(field: &Field) -> Self {
     let group = GroupData::new(
       DEFAULT_GROUP_CONTROLLER.to_owned(),
       field.id.clone(),

--- a/frontend/rust-lib/flowy-database2/src/services/group/group_builder.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/group/group_builder.rs
@@ -96,7 +96,7 @@ impl RowChangeset {
 )]
 pub async fn make_group_controller<R, W, TW>(
   view_id: String,
-  grouping_field: Arc<Field>,
+  grouping_field: Field,
   row_details: Vec<Arc<RowDetail>>,
   setting_reader: R,
   setting_writer: W,
@@ -200,10 +200,7 @@ where
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
-pub fn find_new_grouping_field(
-  fields: &[Arc<Field>],
-  _layout: &DatabaseLayout,
-) -> Option<Arc<Field>> {
+pub fn find_new_grouping_field(fields: &[Field], _layout: &DatabaseLayout) -> Option<Field> {
   let mut groupable_field_revs = fields
     .iter()
     .flat_map(|field_rev| {
@@ -213,7 +210,7 @@ pub fn find_new_grouping_field(
         false => None,
       }
     })
-    .collect::<Vec<Arc<Field>>>();
+    .collect::<Vec<Field>>();
 
   if groupable_field_revs.is_empty() {
     // If there is not groupable fields then we use the primary field.

--- a/frontend/rust-lib/flowy-database2/src/services/sort/controller.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/sort/controller.rs
@@ -30,7 +30,7 @@ pub trait SortDelegate: Send + Sync {
   /// Returns all the rows after applying grid's filter
   fn get_rows(&self, view_id: &str) -> Fut<Vec<Arc<RowDetail>>>;
   fn get_field(&self, field_id: &str) -> Option<Field>;
-  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Arc<Field>>>;
+  fn get_fields(&self, view_id: &str, field_ids: Option<Vec<String>>) -> Fut<Vec<Field>>;
 }
 
 pub struct SortController {
@@ -290,7 +290,7 @@ fn cmp_row(
   left: &Row,
   right: &Row,
   sort: &Arc<Sort>,
-  fields: &[Arc<Field>],
+  fields: &[Field],
   cell_data_cache: &CellCache,
 ) -> Ordering {
   match fields
@@ -335,18 +335,16 @@ fn cmp_row(
 fn cmp_cell(
   left_cell: Option<&Cell>,
   right_cell: Option<&Cell>,
-  field: &Arc<Field>,
+  field: &Field,
   field_type: FieldType,
   cell_data_cache: &CellCache,
   sort_condition: SortCondition,
 ) -> Ordering {
-  match TypeOptionCellExt::new(field.as_ref(), Some(cell_data_cache.clone()))
+  match TypeOptionCellExt::new(field, Some(cell_data_cache.clone()))
     .get_type_option_cell_data_handler(&field_type)
   {
     None => default_order(),
-    Some(handler) => {
-      handler.handle_cell_compare(left_cell, right_cell, field.as_ref(), sort_condition)
-    },
+    Some(handler) => handler.handle_cell_compare(left_cell, right_cell, field, sort_condition),
   }
 }
 

--- a/frontend/rust-lib/flowy-database2/tests/database/block_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/block_test/script.rs
@@ -1,7 +1,6 @@
-use collab_database::database::gen_row_id;
 use collab_database::rows::RowId;
 
-use lib_infra::util::timestamp;
+use flowy_database2::entities::CreateRowPayloadPB;
 
 use crate::database::database_editor::DatabaseEditorTest;
 
@@ -30,17 +29,11 @@ impl DatabaseRowTest {
   pub async fn run_script(&mut self, script: RowScript) {
     match script {
       RowScript::CreateEmptyRow => {
-        let params = collab_database::rows::CreateRowParams {
-          id: gen_row_id(),
-          timestamp: timestamp(),
+        let params = CreateRowPayloadPB {
+          view_id: self.view_id.clone(),
           ..Default::default()
         };
-        let row_detail = self
-          .editor
-          .create_row(&self.view_id, None, params)
-          .await
-          .unwrap()
-          .unwrap();
+        let row_detail = self.editor.create_row(params).await.unwrap().unwrap();
         self
           .row_by_row_id
           .insert(row_detail.row.id.to_string(), row_detail.into());

--- a/frontend/rust-lib/flowy-database2/tests/database/group_test/date_group_test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/group_test/date_group_test.rs
@@ -3,12 +3,8 @@ use std::vec;
 
 use chrono::NaiveDateTime;
 use chrono::{offset, Duration};
-use collab_database::database::gen_row_id;
-use collab_database::rows::CreateRowParams;
 
-use collab_database::views::OrderObjectPosition;
-use flowy_database2::entities::FieldType;
-use flowy_database2::services::cell::CellBuilder;
+use flowy_database2::entities::{CreateRowPayloadPB, FieldType};
 use flowy_database2::services::field::DateCellData;
 
 use crate::database::group_test::script::DatabaseGroupTest;
@@ -26,19 +22,17 @@ async fn group_by_date_test() {
       .unwrap()
       .timestamp()
       .to_string();
+
     let mut cells = HashMap::new();
     cells.insert(date_field.id.clone(), timestamp);
-    let cells = CellBuilder::with_cells(cells, &[date_field.clone()]).build();
 
-    let params = CreateRowParams {
-      id: gen_row_id(),
-      cells,
-      height: 60,
-      visibility: true,
-      row_position: OrderObjectPosition::default(),
-      timestamp: 0,
+    let params = CreateRowPayloadPB {
+      view_id: test.view_id.clone(),
+      data: cells,
+      ..Default::default()
     };
-    let res = test.editor.create_row(&test.view_id, None, params).await;
+
+    let res = test.editor.create_row(params).await;
     assert!(res.is_ok());
   }
 

--- a/frontend/rust-lib/flowy-database2/tests/database/group_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/group_test/script.rs
@@ -1,8 +1,7 @@
-use collab_database::database::gen_row_id;
 use collab_database::fields::Field;
-use collab_database::rows::{CreateRowParams, RowId};
+use collab_database::rows::RowId;
 
-use flowy_database2::entities::{FieldType, GroupPB, RowMetaPB};
+use flowy_database2::entities::{CreateRowPayloadPB, FieldType, GroupPB, RowMetaPB};
 use flowy_database2::services::cell::{
   delete_select_option_cell, insert_date_cell, insert_select_option_cell, insert_url_cell,
 };
@@ -10,7 +9,6 @@ use flowy_database2::services::field::{
   edit_single_select_type_option, SelectOption, SelectTypeOptionSharedAction,
   SingleSelectTypeOption,
 };
-use lib_infra::util::timestamp;
 
 use crate::database::database_editor::DatabaseEditorTest;
 
@@ -138,16 +136,13 @@ impl DatabaseGroupTest {
       },
       GroupScript::CreateRow { group_index } => {
         let group = self.group_at_index(group_index).await;
-        let params = CreateRowParams {
-          id: gen_row_id(),
-          timestamp: timestamp(),
-          ..Default::default()
+        let params = CreateRowPayloadPB {
+          view_id: self.view_id.clone(),
+          row_position: Default::default(),
+          group_id: Some(group.group_id),
+          data: Default::default(),
         };
-        let _ = self
-          .editor
-          .create_row(&self.view_id, Some(group.group_id.clone()), params)
-          .await
-          .unwrap();
+        let _ = self.editor.create_row(params).await.unwrap();
       },
       GroupScript::DeleteRow {
         group_index,

--- a/frontend/rust-lib/flowy-database2/tests/database/sort_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/sort_test/script.rs
@@ -8,7 +8,7 @@ use futures::stream::StreamExt;
 use tokio::sync::broadcast::Receiver;
 
 use flowy_database2::entities::{
-  DeleteSortPayloadPB, FieldType, ReorderSortPayloadPB, UpdateSortPayloadPB,
+  CreateRowPayloadPB, DeleteSortPayloadPB, FieldType, ReorderSortPayloadPB, UpdateSortPayloadPB,
 };
 use flowy_database2::services::cell::stringify_cell_data;
 use flowy_database2::services::database_view::DatabaseViewChanged;
@@ -155,15 +155,10 @@ impl DatabaseSortTest {
         );
         self
           .editor
-          .create_row(
-            &self.view_id,
-            None,
-            collab_database::rows::CreateRowParams {
-              id: collab_database::database::gen_row_id(),
-              timestamp: collab_database::database::timestamp(),
-              ..Default::default()
-            },
-          )
+          .create_row(CreateRowPayloadPB {
+            view_id: self.view_id.clone(),
+            ..Default::default()
+          })
           .await
           .unwrap();
       },


### PR DESCRIPTION
requires https://github.com/AppFlowy-IO/AppFlowy/pull/4688

- Move some fragmented create row logic from event handler to database editor
- Streamline row duplication logic
- Remove unnecessary Arc\<Field>. The filter, sort and group controllers already are Arcs, and in the instances where we use the struct field, we are just referencing it. So we probably don't need to put it in an Arc.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
