### PR TITLE
fix: focus traversal in checklist popover

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_grid/desktop_grid_checklist_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_grid/desktop_grid_checklist_cell.dart
@@ -1,11 +1,12 @@
-import 'package:appflowy/plugins/database/grid/presentation/layout/sizes.dart';
-import 'package:appflowy/plugins/database/widgets/row/cells/cell_container.dart';
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/plugins/database/application/cell/bloc/checklist_cell_bloc.dart';
+import 'package:appflowy/plugins/database/grid/presentation/layout/sizes.dart';
 import 'package:appflowy/plugins/database/widgets/cell_editor/checklist_cell_editor.dart';
 import 'package:appflowy/plugins/database/widgets/cell_editor/checklist_progress_bar.dart';
+import 'package:appflowy/plugins/database/widgets/row/cells/cell_container.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../editable_cell_skeleton/checklist.dart';
@@ -25,6 +26,7 @@ class DesktopGridChecklistCellSkin extends IEditableChecklistCellSkin {
       constraints: BoxConstraints.loose(const Size(360, 400)),
       direction: PopoverDirection.bottomWithLeftAligned,
       triggerActions: PopoverTriggerFlags.none,
+      skipTraversal: true,
       popupBuilder: (BuildContext popoverContext) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           cellContainerNotifier.isFocus = true;

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
@@ -392,12 +392,10 @@ class _NewTaskItemState extends State<NewTaskItem> {
                 hintText: LocaleKeys.grid_checklist_addNew.tr(),
               ),
               onSubmitted: (taskDescription) {
-                if (taskDescription.trim().isNotEmpty) {
-                  context.read<ChecklistCellBloc>().add(
-                        ChecklistCellEvent.createNewTask(
-                          taskDescription.trim(),
-                        ),
-                      );
+                if (taskDescription.isNotEmpty) {
+                  context
+                      .read<ChecklistCellBloc>()
+                      .add(ChecklistCellEvent.createNewTask(taskDescription));
                   _textEditingController.clear();
                 }
                 widget.focusNode.requestFocus();
@@ -408,15 +406,15 @@ class _NewTaskItemState extends State<NewTaskItem> {
           FlowyTextButton(
             LocaleKeys.grid_checklist_submitNewTask.tr(),
             fontSize: 11,
-            fillColor: text.trim().isEmpty
+            fillColor: text.isEmpty
                 ? Theme.of(context).disabledColor
                 : Theme.of(context).colorScheme.primary,
-            hoverColor: text.trim().isEmpty
+            hoverColor: text.isEmpty
                 ? Theme.of(context).disabledColor
                 : Theme.of(context).colorScheme.primaryContainer,
             fontColor: Theme.of(context).colorScheme.onPrimary,
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-            onPressed: text.trim().isEmpty
+            onPressed: text.isEmpty
                 ? null
                 : () {
                     context

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
@@ -347,14 +347,11 @@ class NewTaskItem extends StatefulWidget {
 }
 
 class _NewTaskItemState extends State<NewTaskItem> {
-  late final TextEditingController _textEditingController;
-  String text = "";
+  late final _textEditingController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
-    _textEditingController = TextEditingController();
-    _textEditingController.addListener(_onChange);
     if (widget.focusNode.canRequestFocus) {
       widget.focusNode.requestFocus();
     }
@@ -362,12 +359,9 @@ class _NewTaskItemState extends State<NewTaskItem> {
 
   @override
   void dispose() {
-    _textEditingController.removeListener(_onChange);
     _textEditingController.dispose();
     super.dispose();
   }
-
-  void _onChange() => setState(() => text = _textEditingController.text);
 
   @override
   Widget build(BuildContext context) {
@@ -406,20 +400,22 @@ class _NewTaskItemState extends State<NewTaskItem> {
           FlowyTextButton(
             LocaleKeys.grid_checklist_submitNewTask.tr(),
             fontSize: 11,
-            fillColor: text.isEmpty
+            fillColor: _textEditingController.text.isEmpty
                 ? Theme.of(context).disabledColor
                 : Theme.of(context).colorScheme.primary,
-            hoverColor: text.isEmpty
+            hoverColor: _textEditingController.text.isEmpty
                 ? Theme.of(context).disabledColor
                 : Theme.of(context).colorScheme.primaryContainer,
             fontColor: Theme.of(context).colorScheme.onPrimary,
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-            onPressed: text.isEmpty
+            onPressed: _textEditingController.text.isEmpty
                 ? null
                 : () {
-                    context
-                        .read<ChecklistCellBloc>()
-                        .add(ChecklistCellEvent.createNewTask(text));
+                    context.read<ChecklistCellBloc>().add(
+                          ChecklistCellEvent.createNewTask(
+                            _textEditingController.text,
+                          ),
+                        );
                     widget.focusNode.requestFocus();
                     _textEditingController.clear();
                   },

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell_editor/checklist_cell_editor.dart
@@ -347,7 +347,7 @@ class NewTaskItem extends StatefulWidget {
 }
 
 class _NewTaskItemState extends State<NewTaskItem> {
-  late final _textEditingController = TextEditingController();
+  final _textEditingController = TextEditingController();
 
   @override
   void initState() {

--- a/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_popover/lib/src/popover.dart
@@ -1,6 +1,7 @@
-import 'package:appflowy_popover/src/layout.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'package:appflowy_popover/src/layout.dart';
 
 import 'mask.dart';
 import 'mutex.dart';
@@ -90,6 +91,8 @@ class Popover extends StatefulWidget {
   ///  the conflict won't be resolve by using Listener, we want these two gestures exclusive.
   final PopoverClickHandler clickHandler;
 
+  final bool skipTraversal;
+
   /// The content area of the popover.
   final Widget child;
 
@@ -110,6 +113,7 @@ class Popover extends StatefulWidget {
     this.canClose,
     this.asBarrier = false,
     this.clickHandler = PopoverClickHandler.listener,
+    this.skipTraversal = false,
   });
 
   @override
@@ -158,6 +162,7 @@ class PopoverState extends State<Popover> {
           popupBuilder: widget.popupBuilder,
           onClose: () => close(),
           onCloseAll: () => _removeRootOverlay(),
+          skipTraversal: widget.skipTraversal,
         ),
       );
 
@@ -263,6 +268,7 @@ class PopoverContainer extends StatefulWidget {
   final EdgeInsets windowPadding;
   final void Function() onClose;
   final void Function() onCloseAll;
+  final bool skipTraversal;
 
   const PopoverContainer({
     super.key,
@@ -273,6 +279,7 @@ class PopoverContainer extends StatefulWidget {
     required this.windowPadding,
     required this.onClose,
     required this.onCloseAll,
+    required this.skipTraversal,
   });
 
   @override
@@ -293,6 +300,7 @@ class PopoverContainerState extends State<PopoverContainer> {
   Widget build(BuildContext context) {
     return Focus(
       autofocus: true,
+      skipTraversal: widget.skipTraversal,
       child: CustomSingleChildLayout(
         delegate: PopoverLayoutDelegate(
           direction: widget.direction,

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/src/flowy_overlay/appflowy_popover.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/src/flowy_overlay/appflowy_popover.dart
@@ -26,6 +26,10 @@ class AppFlowyPopover extends StatelessWidget {
   ///  the conflict won't be resolve by using Listener, we want these two gestures exclusive.
   final PopoverClickHandler clickHandler;
 
+  /// If true the popover will not participate in focus traversal.
+  ///
+  final bool skipTraversal;
+
   const AppFlowyPopover({
     super.key,
     required this.child,
@@ -43,6 +47,7 @@ class AppFlowyPopover extends StatelessWidget {
     this.windowPadding = const EdgeInsets.all(8.0),
     this.decoration,
     this.clickHandler = PopoverClickHandler.listener,
+    this.skipTraversal = false,
   });
 
   @override
@@ -58,6 +63,7 @@ class AppFlowyPopover extends StatelessWidget {
       windowPadding: windowPadding,
       offset: offset,
       clickHandler: clickHandler,
+      skipTraversal: skipTraversal,
       popupBuilder: (context) {
         return _PopoverContainer(
           constraints: constraints,

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/button.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/button.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+
 import 'package:flowy_infra/size.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flowy_infra_ui/style_widget/text.dart';
 import 'package:flowy_infra_ui/widget/flowy_tooltip.dart';
 import 'package:flowy_infra_ui/widget/ignore_parent_gesture.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
-import 'package:flutter/material.dart';
 
 class FlowyButton extends StatelessWidget {
   final Widget text;
@@ -213,6 +214,7 @@ class FlowyTextButton extends StatelessWidget {
     );
 
     child = RawMaterialButton(
+      focusNode: FocusNode(skipTraversal: onPressed == null),
       hoverElevation: 0,
       highlightElevation: 0,
       shape: RoundedRectangleBorder(borderRadius: radius ?? Corners.s6Border),
@@ -235,6 +237,10 @@ class FlowyTextButton extends StatelessWidget {
         message: tooltip!,
         child: child,
       );
+    }
+
+    if (onPressed == null) {
+      child = ExcludeFocus(child: child);
     }
 
     return child;


### PR DESCRIPTION
This PR fixes the traversal issue in the checlist editor.

- Disabled button receiving focus if the onPressed is null _(Default behavior for Flutter, onPressed == null means disabled)_
- Added skipTraversal to the Popover itself so it doesn't get included in the traversal order
- Only clear the new item text field if a new item was actually created
- Disable create button when it doesn't do anything. If you only added spaces you could click on the button, but it would only clear the text field, not create a new item

### Feature Preview


https://github.com/AppFlowy-IO/AppFlowy/assets/42929161/1b7adff0-9f11-419a-abdd-2e910b775aa9



#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
