### PR TITLE
fix: only adding http(s) scheme if needed

### DIFF
--- a/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
+++ b/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
@@ -15,23 +15,34 @@ Future<bool> afLaunchUrl(
   OnFailureCallback? onFailure,
   launcher.LaunchMode mode = launcher.LaunchMode.platformDefault,
   String? webOnlyWindowName,
+  bool addingHttpSchemeWhenFailed = false,
 }) async {
   // try to launch the uri directly
   bool result;
   try {
-    result = await launcher.launchUrl(uri);
+    result = await launcher.launchUrl(
+      uri,
+      mode: mode,
+      webOnlyWindowName: webOnlyWindowName,
+    );
   } on PlatformException catch (e) {
     Log.error('Failed to open uri: $e');
   } finally {
     result = false;
   }
 
-  // if the uri is not a valid url, try to launch it with https scheme
+  // if the uri is not a valid url, try to launch it with http scheme
   final url = uri.toString();
-  if (!result && !isURL(url, {'require_protocol': true})) {
+  if (addingHttpSchemeWhenFailed &&
+      !result &&
+      !isURL(url, {'require_protocol': true})) {
     try {
-      final uriWithScheme = Uri.parse('https://$url');
-      result = await launcher.launchUrl(uriWithScheme);
+      final uriWithScheme = Uri.parse('http://$url');
+      result = await launcher.launchUrl(
+        uriWithScheme,
+        mode: mode,
+        webOnlyWindowName: webOnlyWindowName,
+      );
     } on PlatformException catch (e) {
       Log.error('Failed to open uri: $e');
       if (context != null && context.mounted) {
@@ -43,7 +54,10 @@ Future<bool> afLaunchUrl(
   return result;
 }
 
-Future<bool> afLaunchUrlString(String url) async {
+Future<bool> afLaunchUrlString(
+  String url, {
+  bool addingHttpSchemeWhenFailed = false,
+}) async {
   final Uri uri;
   try {
     uri = Uri.parse(url);
@@ -53,7 +67,10 @@ Future<bool> afLaunchUrlString(String url) async {
   }
 
   // try to launch the uri directly
-  return afLaunchUrl(uri);
+  return afLaunchUrl(
+    uri,
+    addingHttpSchemeWhenFailed: addingHttpSchemeWhenFailed,
+  );
 }
 
 void _errorHandler(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -1,8 +1,5 @@
 import 'dart:math';
 
-import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-
 import 'package:appflowy/core/helpers/url_launcher.dart';
 import 'package:appflowy/plugins/document/application/document_appearance_cubit.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_block.dart';
@@ -15,6 +12,8 @@ import 'package:appflowy/workspace/application/settings/appearance/appearance_cu
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:appflowy_editor/appflowy_editor.dart' hide Log;
 import 'package:collection/collection.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -294,7 +293,10 @@ class EditorStyleCustomizer {
           ..onTap = () {
             final editorState = context.read<EditorState>();
             if (editorState.selection == null) {
-              afLaunchUrlString(href);
+              afLaunchUrlString(
+                href,
+                addingHttpSchemeWhenFailed: true,
+              );
               return;
             }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

Remove the logic that automatically adds the HTTP(S) scheme, because the `launchUrl` function will return **false** even when it successfully opens a URL the `file://` scheme.




<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
