### PR TITLE
fix: apply formatting to pasted text only when the block is a paragraph

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
@@ -13,8 +13,7 @@ extension PasteNodes on EditorState {
     }
     final transaction = this.transaction;
     final insertedDelta = insertedNode.delta;
-    // if the node is empty, replace it with the inserted node.
-    // fix: apply formatting to pasted text only when the block is a paragraph
+    // if the node is empty and its type is paragprah, replace it with the inserted node.
     if (delta.isEmpty && node.type == ParagraphBlockKeys.type) {
       transaction.insertNode(
         selection.end.path.next,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
@@ -14,6 +14,7 @@ extension PasteNodes on EditorState {
     final transaction = this.transaction;
     final insertedDelta = insertedNode.delta;
     // if the node is empty, replace it with the inserted node.
+    // fix: apply formatting to pasted text only when the block is a paragraph
     if (delta.isEmpty && node.type == ParagraphBlockKeys.type) {
       transaction.insertNode(
         selection.end.path.next,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/editor_state_paste_node_extension.dart
@@ -14,7 +14,7 @@ extension PasteNodes on EditorState {
     final transaction = this.transaction;
     final insertedDelta = insertedNode.delta;
     // if the node is empty, replace it with the inserted node.
-    if (delta.isEmpty) {
+    if (delta.isEmpty && node.type == ParagraphBlockKeys.type) {
       transaction.insertNode(
         selection.end.path.next,
         insertedNode,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

### Feature Preview

<!---
fix https://github.com/AppFlowy-IO/AppFlowy/issues/4905
-->

fix #4905 

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
