### PR TITLE
chore: typo fix

### DIFF
--- a/frontend/resources/translations/ja-JP.json
+++ b/frontend/resources/translations/ja-JP.json
@@ -110,7 +110,7 @@
       "caption": "この操作は元に戻すことができません。"
     },
     "mobile": {
-      "empty": "ゴミ箱を殻にする",
+      "empty": "ゴミ箱を空にする",
       "emptyDescription": "削除されたファイルはありません",
       "isDeleted": "削除済み"
     }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

Sorry, I’m just learning to contribute. :)

The kanji for  `"ゴミ箱を殻にする"` is incorrect and may not convey the correct meaning.

before: `"ゴミ箱を殻にする"`("殻" means grain's Hull)
after: `"ゴミ箱を空にする"`("空" means empty)

Please pay attention!

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
