### PR TITLE
docs: replace broken links with working ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You are in charge of your data and customizations.
 
 ## User Installation
 
-- [Windows/Mac/Linux](https://docs.appflowy.io/docs/documentation/software-contributions/submitting-code/submitting-your-first-pull-request)
+- [Windows/Mac/Linux](https://docs.appflowy.io/docs/appflowy/install-appflowy/installation-methods/mac-windows-linux-packages)
 - [Docker](https://docs.appflowy.io/docs/appflowy/install-appflowy/installation-methods/installing-with-docker)
 - [Source](https://docs.appflowy.io/docs/documentation/appflowy/from-source)
 
@@ -51,7 +51,7 @@ Please view the [documentation](https://docs.appflowy.io/docs/documentation/appf
 
 ## Roadmap
 
-- [AppFlowy Roadmap ReadMe](https://appflowy.gitbook.io/docs/essential-documentation/roadmap)
+- [AppFlowy Roadmap ReadMe](https://docs.appflowy.io/docs/appflowy/roadmap)
 - [AppFlowy Public Roadmap](https://github.com/orgs/AppFlowy-IO/projects/5/views/12)
 
 If you'd like to propose a feature, submit a feature request [here](https://github.com/AppFlowy-IO/AppFlowy/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5BFR%5D+) <br/>

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ You are in charge of your data and customizations.
 
 ## User Installation
 
-* [Windows/Mac/Linux](https://appflowy.gitbook.io/docs/essential-documentation/install-appflowy/installation-methods/mac-windows-linux-packages)
-* [Docker](https://appflowy.gitbook.io/docs/essential-documentation/install-appflowy/installation-methods/installing-with-docker)
-* [Source](https://appflowy.gitbook.io/docs/essential-documentation/install-appflowy/installation-methods/from-source)
+- [Windows/Mac/Linux](https://docs.appflowy.io/docs/documentation/software-contributions/submitting-code/submitting-your-first-pull-request)
+- [Docker](https://docs.appflowy.io/docs/appflowy/install-appflowy/installation-methods/installing-with-docker)
+- [Source](https://docs.appflowy.io/docs/documentation/appflowy/from-source)
 
 ## Built With
 
-* [Flutter](https://flutter.dev/)
+- [Flutter](https://flutter.dev/)
 
-* [Rust](https://www.rust-lang.org/)
+- [Rust](https://www.rust-lang.org/)
 
 ## Stay Up-to-Date
 
@@ -51,8 +51,8 @@ Please view the [documentation](https://docs.appflowy.io/docs/documentation/appf
 
 ## Roadmap
 
-* [AppFlowy Roadmap ReadMe](https://appflowy.gitbook.io/docs/essential-documentation/roadmap)
-* [AppFlowy Public Roadmap](https://github.com/orgs/AppFlowy-IO/projects/5/views/12)
+- [AppFlowy Roadmap ReadMe](https://appflowy.gitbook.io/docs/essential-documentation/roadmap)
+- [AppFlowy Public Roadmap](https://github.com/orgs/AppFlowy-IO/projects/5/views/12)
 
 If you'd like to propose a feature, submit a feature request [here](https://github.com/AppFlowy-IO/AppFlowy/issues/new?assignees=&labels=&template=feature_request.yaml&title=%5BFR%5D+) <br/>
 If you'd like to report a bug, submit a bug report [here](https://github.com/AppFlowy-IO/AppFlowy/issues/new?assignees=&labels=&template=bug_report.yaml&title=%5BBug%5D+)
@@ -63,18 +63,16 @@ Please see the [changelog](https://www.appflowy.io/whatsnew) for more details ab
 
 ## Contributing
 
-Contributions make the open-source community a fantastic place to learn, inspire, and create. Any contributions you make are **greatly appreciated**. Please look at [Contributing to AppFlowy](https://appflowy.gitbook.io/docs/essential-documentation/contribute-to-appflowy/contributing-to-appflowy) for details.
+Contributions make the open-source community a fantastic place to learn, inspire, and create. Any contributions you make are **greatly appreciated**. Please look at [Contributing to AppFlowy](https://docs.appflowy.io/docs/documentation/software-contributions/contributing-to-appflowy) for details.
 
 If your Pull Request is accepted as it fixes a bug, adds functionality, or makes AppFlowy's codebase significantly easier to use or understand, **Congratulations!** If your administrative and managerial work behind the scenes sustains the community, **Congratulations!** You are now an official contributor to AppFlowy. Get in touch with us ([link](https://tally.so/r/mKP5z3)) to receive the very special Contributor T-shirt!
 Proudly wear your T-shirt and show it to us by tagging [@appflowy](https://twitter.com/appflowy) on Twitter.
-
 
 ## Translations 🌎🗺
 
 [![translation badge](https://inlang.com/badge?url=github.com/AppFlowy-IO/AppFlowy)](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy?ref=badge)
 
 To add translations, you can manually edit the JSON translation files in `/frontend/resources/translations`, use the [inlang online editor](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy), or run `npx inlang machine translate` to add missing translations.
-
 
 ## Join the community to build AppFlowy together
 
@@ -92,14 +90,14 @@ When a customer's evolving core needs are not satisfied, they either switch to a
 
 All these restrictions necessitate our mission - to make it possible for anyone to create apps that suit their needs well.
 
-* To individuals, we would like to offer Notion's functionality, data security, and cross-platform native experience.
-* To enterprises and hackers, AppFlowy is dedicated to offering building blocks and collaboration infra services to enable you to make apps on your own. Moreover, you have 100% control of your data. You can design and modify AppFlowy your way, with a single codebase written in Flutter and Rust supporting multiple platforms armed with long-term maintainability.
+- To individuals, we would like to offer Notion's functionality, data security, and cross-platform native experience.
+- To enterprises and hackers, AppFlowy is dedicated to offering building blocks and collaboration infra services to enable you to make apps on your own. Moreover, you have 100% control of your data. You can design and modify AppFlowy your way, with a single codebase written in Flutter and Rust supporting multiple platforms armed with long-term maintainability.
 
 We decided to achieve this mission by upholding the three most fundamental values:
 
-* Data privacy first
-* Reliable native experience
-* Community-driven extensibility
+- Data privacy first
+- Reliable native experience
+- Community-driven extensibility
 
 We do not claim to outperform Notion in terms of functionality and design, at least for now. Besides, our priority doesn't lie in more functionality at the moment. Instead, we would like to cultivate a community to democratize the knowledge and wheels of making complex workplace management tools while enabling people and businesses to create beautiful things on their own by equipping them with a versatile toolbox of building blocks.
 
@@ -111,6 +109,6 @@ Distributed under the AGPLv3 License. See [`LICENSE.md`](https://github.com/AppF
 
 Special thanks to these amazing projects which help power AppFlowy.IO:
 
-* [flutter-quill](https://github.com/singerdmx/flutter-quill)
-* [cargo-make](https://github.com/sagiegurari/cargo-make)
-* [contrib.rocks](https://contrib.rocks)
+- [flutter-quill](https://github.com/singerdmx/flutter-quill)
+- [cargo-make](https://github.com/sagiegurari/cargo-make)
+- [contrib.rocks](https://contrib.rocks)


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

Solves: #4987 

- replaces broken links with the docs.appflowy.io domain which is the working domain for the docs.

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
