### PR TITLE
feat: double tab edit side panel 

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
@@ -355,17 +355,19 @@ class _SingleInnerViewItemState extends State<SingleInnerViewItem> {
       behavior: HitTestBehavior.translucent,
       onTap: () => widget.onSelected(widget.view),
       onTertiaryTapDown: (_) => widget.onTertiarySelected?.call(widget.view),
-      onDoubleTap: isSelected ? (){
-        NavigatorTextFieldDialog(
-          title: LocaleKeys.disclosureAction_rename.tr(),
-          autoSelectAllText: true,
-          value: widget.view.name,
-          maxLength: 256,
-          onConfirm: (newValue, _) {
-            context.read<ViewBloc>().add(ViewEvent.rename(newValue));
-          },
-        ).show(context);
-      } : null,
+      onDoubleTap: isSelected
+          ? () {
+              NavigatorTextFieldDialog(
+                title: LocaleKeys.disclosureAction_rename.tr(),
+                autoSelectAllText: true,
+                value: widget.view.name,
+                maxLength: 256,
+                onConfirm: (newValue, _) {
+                  context.read<ViewBloc>().add(ViewEvent.rename(newValue));
+                },
+              ).show(context);
+            }
+          : null,
       child: SizedBox(
         height: widget.height,
         child: Padding(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
@@ -355,7 +355,7 @@ class _SingleInnerViewItemState extends State<SingleInnerViewItem> {
       behavior: HitTestBehavior.translucent,
       onTap: () => widget.onSelected(widget.view),
       onTertiaryTapDown: (_) => widget.onTertiarySelected?.call(widget.view),
-      onDoubleTap: (){
+      onDoubleTap: isSelected ? (){
         NavigatorTextFieldDialog(
           title: LocaleKeys.disclosureAction_rename.tr(),
           autoSelectAllText: true,
@@ -365,7 +365,7 @@ class _SingleInnerViewItemState extends State<SingleInnerViewItem> {
             context.read<ViewBloc>().add(ViewEvent.rename(newValue));
           },
         ).show(context);
-      },
+      } : null,
       child: SizedBox(
         height: widget.height,
         child: Padding(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/view/view_item.dart
@@ -355,6 +355,17 @@ class _SingleInnerViewItemState extends State<SingleInnerViewItem> {
       behavior: HitTestBehavior.translucent,
       onTap: () => widget.onSelected(widget.view),
       onTertiaryTapDown: (_) => widget.onTertiarySelected?.call(widget.view),
+      onDoubleTap: (){
+        NavigatorTextFieldDialog(
+          title: LocaleKeys.disclosureAction_rename.tr(),
+          autoSelectAllText: true,
+          value: widget.view.name,
+          maxLength: 256,
+          onConfirm: (newValue, _) {
+            context.read<ViewBloc>().add(ViewEvent.rename(newValue));
+          },
+        ).show(context);
+      },
       child: SizedBox(
         height: widget.height,
         child: Padding(


### PR DESCRIPTION
This PR is for issue #4968, to edit side panel title with double click. 

I directly used GestureDetector of SingleInnerViewItem, I could have also passed it as function call back but it will require having MultiBlocProvider.

I am new here, any feedback @annieappflowy ?

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
