### PR TITLE
chore: bump collab and client api

### DIFF
--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -857,7 +857,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "bytes",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "again",
  "anyhow",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1371,7 +1371,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2704,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "workspace-template"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -97,10 +97,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -87,7 +87,7 @@ yrs = { git = "https://github.com/appflowy/y-crdt", rev = "3f25bb510ca5274e7657d
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4df32f6d3b53bec5e3715f5abfe4fb9079021b" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "01f1af98f50fa18db495a948918f35dc6fa6ae92" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #

--- a/frontend/appflowy_web/wasm-libs/Cargo.lock
+++ b/frontend/appflowy_web/wasm-libs/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "bytes",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "chrono",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -5073,4 +5073,4 @@ dependencies = [
 [[patch.unused]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"

--- a/frontend/appflowy_web/wasm-libs/Cargo.lock
+++ b/frontend/appflowy_web/wasm-libs/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -541,7 +541,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "again",
  "anyhow",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -765,7 +765,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1001,7 +1001,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1769,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",

--- a/frontend/appflowy_web/wasm-libs/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/Cargo.toml
@@ -65,10 +65,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }

--- a/frontend/appflowy_web/wasm-libs/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/Cargo.toml
@@ -55,7 +55,7 @@ codegen-units = 1
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4df32f6d3b53bec5e3715f5abfe4fb9079021b" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "01f1af98f50fa18db495a948918f35dc6fa6ae92" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #

--- a/frontend/appflowy_web_app/src-tauri/Cargo.lock
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -890,7 +890,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "bytes",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "chrono",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=a7a990dfc62a766829d28d2a9bb383840d8146f4#a7a990dfc62a766829d28d2a9bb383840d8146f4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -1859,6 +1859,7 @@ dependencies = [
  "lib-infra",
  "lib-log",
  "parking_lot 0.12.1",
+ "semver",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2232,6 +2233,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "protobuf",
+ "semver",
  "serde",
  "serde_json",
  "serde_repr",

--- a/frontend/appflowy_web_app/src-tauri/Cargo.lock
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "again",
  "anyhow",
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -982,7 +982,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1359,7 +1359,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -3221,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -7880,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "workspace-template"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -97,10 +97,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "a7a990dfc62a766829d28d2a9bb383840d8146f4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -87,7 +87,7 @@ yrs = { git = "https://github.com/appflowy/y-crdt", rev = "3f25bb510ca5274e7657d
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4df32f6d3b53bec5e3715f5abfe4fb9079021b" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "01f1af98f50fa18db495a948918f35dc6fa6ae92" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "again",
  "anyhow",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1293,7 +1293,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "app-error",
@@ -6405,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "workspace-template"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=aa4df32f6d3b53bec5e3715f5abfe4fb9079021b#aa4df32f6d3b53bec5e3715f5abfe4fb9079021b"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=01f1af98f50fa18db495a948918f35dc6fa6ae92#01f1af98f50fa18db495a948918f35dc6fa6ae92"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "bytes",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "chrono",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4#bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=5f66f8c921646d7d8762cafc8bbec72d56c2e157#5f66f8c921646d7d8762cafc8bbec72d56c2e157"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -121,10 +121,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "bb25e76d08d1fc99d5044907aa6fe1e8eabd41d4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "5f66f8c921646d7d8762cafc8bbec72d56c2e157" }

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -111,7 +111,7 @@ rocksdb = { git = "https://github.com/LucasXu0/rust-rocksdb", rev = "21cf4a23ec1
 # Run the script.add_workspace_members:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "aa4df32f6d3b53bec5e3715f5abfe4fb9079021b" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "01f1af98f50fa18db495a948918f35dc6fa6ae92" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #

--- a/frontend/rust-lib/dart-ffi/Cargo.toml
+++ b/frontend/rust-lib/dart-ffi/Cargo.toml
@@ -30,8 +30,8 @@ lib-dispatch = { workspace = true }
 
 # Core
 #flowy-core = { workspace = true, features = ["profiling"] }
-#flowy-core = { workspace = true, features = ["verbose_log"] }
-flowy-core = { workspace = true }
+flowy-core = { workspace = true, features = ["verbose_log"] }
+#flowy-core = { workspace = true }
 
 flowy-notification = { workspace = true, features = ["dart"] }
 flowy-document = { workspace = true, features = ["dart"] }

--- a/frontend/rust-lib/flowy-folder-pub/src/cloud.rs
+++ b/frontend/rust-lib/flowy-folder-pub/src/cloud.rs
@@ -51,7 +51,6 @@ pub struct FolderCollabParams {
   pub object_id: String,
   pub encoded_collab_v1: Vec<u8>,
   pub collab_type: CollabType,
-  pub override_if_exist: bool,
 }
 
 pub struct FolderSnapshot {

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
@@ -157,7 +157,6 @@ where
           object_id: object.object_id,
           encoded_collab_v1: object.encoded_collab_v1,
           collab_type: object.collab_type,
-          override_if_exist: object.override_if_exist,
         })
         .collect::<Vec<_>>();
       try_get_client?

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
@@ -278,7 +278,6 @@ where
     &self,
     collab_object: &CollabObject,
     data: Vec<u8>,
-    override_if_exist: bool,
   ) -> FutureResult<(), FlowyError> {
     let try_get_client = self.server.try_get_client();
     let collab_object = collab_object.clone();
@@ -289,7 +288,6 @@ where
         object_id: collab_object.object_id.clone(),
         encoded_collab_v1: data,
         collab_type: collab_object.collab_type.clone(),
-        override_if_exist,
       };
       client.create_collab(params).await?;
       Ok(())
@@ -310,7 +308,6 @@ where
           object_id: object.object_id,
           encoded_collab_v1: object.encoded_collab,
           collab_type: object.collab_type,
-          override_if_exist: false,
         })
         .collect::<Vec<_>>();
       try_get_client?

--- a/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
+++ b/frontend/rust-lib/flowy-server/src/local_server/impls/user.rs
@@ -166,7 +166,6 @@ impl UserCloudService for LocalServerUserAuthServiceImpl {
     &self,
     _collab_object: &CollabObject,
     _data: Vec<u8>,
-    _override_if_exist: bool,
   ) -> FutureResult<(), FlowyError> {
     FutureResult::new(async { Ok(()) })
   }

--- a/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/api/user.rs
@@ -333,7 +333,6 @@ where
     &self,
     collab_object: &CollabObject,
     data: Vec<u8>,
-    _override_if_exist: bool,
   ) -> FutureResult<(), FlowyError> {
     let try_get_postgrest = self.server.try_get_weak_postgrest();
     let cloned_collab_object = collab_object.clone();

--- a/frontend/rust-lib/flowy-user-pub/src/cloud.rs
+++ b/frontend/rust-lib/flowy-user-pub/src/cloud.rs
@@ -231,7 +231,6 @@ pub trait UserCloudService: Send + Sync + 'static {
     &self,
     collab_object: &CollabObject,
     data: Vec<u8>,
-    override_if_exist: bool,
   ) -> FutureResult<(), FlowyError>;
 
   fn batch_create_collab_object(

--- a/frontend/rust-lib/flowy-user/src/anon_user/sync_supabase_user_collab.rs
+++ b/frontend/rust-lib/flowy-user/src/anon_user/sync_supabase_user_collab.rs
@@ -109,7 +109,7 @@ fn sync_view(
           doc_state.len()
         );
         user_service
-          .create_collab_object(&collab_object, doc_state, false)
+          .create_collab_object(&collab_object, doc_state)
           .await?;
       },
       ViewLayout::Grid | ViewLayout::Board | ViewLayout::Calendar => {
@@ -121,7 +121,7 @@ fn sync_view(
           database_doc_state.len()
         );
         user_service
-          .create_collab_object(&collab_object, database_doc_state, false)
+          .create_collab_object(&collab_object, database_doc_state)
           .await?;
 
         // sync database's row
@@ -145,7 +145,7 @@ fn sync_view(
           );
 
           let _ = user_service
-            .create_collab_object(&database_row_collab_object, database_row_doc_state, false)
+            .create_collab_object(&database_row_collab_object, database_row_doc_state)
             .await;
 
           let database_row_document = CollabObject::new(
@@ -165,7 +165,7 @@ fn sync_view(
               document_doc_state.len()
             );
             let _ = user_service
-              .create_collab_object(&database_row_document, document_doc_state, false)
+              .create_collab_object(&database_row_document, document_doc_state)
               .await;
           }
         }
@@ -287,7 +287,7 @@ async fn sync_folder(
     update.len()
   );
   if let Err(err) = user_service
-    .create_collab_object(&collab_object, update.to_vec(), false)
+    .create_collab_object(&collab_object, update.to_vec())
     .await
   {
     tracing::error!("🔴sync folder failed: {:?}", err);
@@ -334,7 +334,7 @@ async fn sync_database_views(
 
   if let Ok((records, doc_state)) = result {
     let _ = user_service
-      .create_collab_object(&collab_object, doc_state.to_vec(), false)
+      .create_collab_object(&collab_object, doc_state.to_vec())
       .await;
     records.into_iter().map(Arc::new).collect()
   } else {


### PR DESCRIPTION
We're currently enhancing AppFlowy Cloud to include team collaboration features. However, integrating these features with Supabase as the server option is proving to be more complex and requires additional work. As a result, we've decided to temporarily disable the option to use Supabase until we can fully support team collaboration functionalities with it. 