### PR TITLE
chore: remove single field listener

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/mobile_card_detail_screen.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/mobile_card_detail_screen.dart
@@ -322,6 +322,7 @@ class MobileRowDetailPageContentState
               BlocProvider<RowBannerBloc>(
                 create: (context) => RowBannerBloc(
                   viewId: viewId,
+                  fieldController: fieldController,
                   rowMeta: rowController.rowMeta,
                 )..add(const RowBannerEvent.initial()),
                 child: BlocBuilder<RowBannerBloc, RowBannerState>(

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/field/mobile_quick_field_editor.dart
@@ -62,7 +62,7 @@ class _QuickEditFieldState extends State<QuickEditField> {
         viewId: widget.viewId,
         fieldController: widget.fieldController,
         field: widget.fieldInfo.field,
-      )..add(const FieldEditorEvent.initial()),
+      ),
       child: BlocConsumer<FieldEditorBloc, FieldEditorState>(
         listenWhen: (previous, current) =>
             previous.field.name != current.field.name,

--- a/frontend/appflowy_flutter/lib/plugins/database/application/cell/bloc/relation_cell_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/cell/bloc/relation_cell_bloc.dart
@@ -87,15 +87,11 @@ class RelationCellBloc extends Bloc<RelationCellEvent, RelationCellState> {
         }
       },
       onCellFieldChanged: (field) {
-        // hack: SingleFieldListener receives notification before
-        // FieldController's copy is updated.
-        Future.delayed(const Duration(milliseconds: 50), () {
-          if (!isClosed) {
-            final RelationTypeOptionPB typeOption =
-                cellController.getTypeOption(RelationTypeOptionDataParser());
-            add(RelationCellEvent.didUpdateRelationTypeOption(typeOption));
-          }
-        });
+        if (!isClosed) {
+          final RelationTypeOptionPB typeOption =
+              cellController.getTypeOption(RelationTypeOptionDataParser());
+          add(RelationCellEvent.didUpdateRelationTypeOption(typeOption));
+        }
       },
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/field_controller.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/field_controller.dart
@@ -69,6 +69,7 @@ class _GridSortNotifier extends ChangeNotifier {
 }
 
 typedef OnReceiveUpdateFields = void Function(List<FieldInfo>);
+typedef OnReceiveField = void Function(FieldInfo);
 typedef OnReceiveFields = void Function(List<FieldInfo>);
 typedef OnReceiveFilters = void Function(List<FilterInfo>);
 typedef OnReceiveSorts = void Function(List<SortInfo>);
@@ -686,6 +687,31 @@ class FieldController {
     }
   }
 
+  void addSingleFieldListener(
+    String fieldId, {
+    required OnReceiveField onFieldChanged,
+    bool Function()? listenWhen,
+  }) {
+    void key(List<FieldInfo> fieldInfos) {
+      final fieldInfo = fieldInfos.firstWhereOrNull(
+        (fieldInfo) => fieldInfo.id == fieldId,
+      );
+      if (fieldInfo != null) {
+        onFieldChanged(fieldInfo);
+      }
+    }
+
+    void callback() {
+      if (listenWhen != null && listenWhen() == false) {
+        return;
+      }
+      key(fieldInfos);
+    }
+
+    _fieldCallbacks[key] = callback;
+    _fieldNotifier.addListener(callback);
+  }
+
   void removeListener({
     OnReceiveFields? onFieldsListener,
     OnReceiveSorts? onSortsListener,
@@ -710,6 +736,25 @@ class FieldController {
       if (callback != null) {
         _sortNotifier?.removeListener(callback);
       }
+    }
+  }
+
+  void removeSingleFieldListener({
+    required String fieldId,
+    required OnReceiveField onFieldChanged,
+  }) {
+    void key(List<FieldInfo> fieldInfos) {
+      final fieldInfo = fieldInfos.firstWhereOrNull(
+        (fieldInfo) => fieldInfo.id == fieldId,
+      );
+      if (fieldInfo != null) {
+        onFieldChanged(fieldInfo);
+      }
+    }
+
+    final callback = _fieldCallbacks.remove(key);
+    if (callback != null) {
+      _fieldNotifier.removeListener(callback);
     }
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/field_editor_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/field_editor_bloc.dart
@@ -29,6 +29,7 @@ class FieldEditorBloc extends Bloc<FieldEditorEvent, FieldEditorState> {
         super(FieldEditorState(field: FieldInfo.initial(field))) {
     _dispatch();
     _startListening();
+    _init();
   }
 
   final String viewId;
@@ -113,6 +114,16 @@ class FieldEditorBloc extends Bloc<FieldEditorEvent, FieldEditorState> {
       fieldId,
       onFieldChanged: _listener,
     );
+  }
+
+  void _init() async {
+    await Future.delayed(const Duration(milliseconds: 50));
+    if (!isClosed) {
+      final field = fieldController.getField(fieldId);
+      if (field != null) {
+        add(FieldEditorEvent.didUpdateField(field));
+      }
+    }
   }
 
   void _logIfError(FlowyResult<void, FlowyError> result) {

--- a/frontend/appflowy_flutter/lib/plugins/database/domain/field_listener.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/domain/field_listener.dart
@@ -2,53 +2,10 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:appflowy/core/notification/grid_notification.dart';
-import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
 import 'package:appflowy_backend/protobuf/flowy-error/errors.pb.dart';
 import 'package:appflowy_result/appflowy_result.dart';
 import 'package:flowy_infra/notifier.dart';
-
-typedef UpdateFieldNotifiedValue = FieldPB;
-
-class SingleFieldListener {
-  SingleFieldListener({required this.fieldId});
-
-  final String fieldId;
-
-  void Function(UpdateFieldNotifiedValue)? _updateFieldNotifier;
-  DatabaseNotificationListener? _listener;
-
-  void start({
-    required void Function(UpdateFieldNotifiedValue) onFieldChanged,
-  }) {
-    _updateFieldNotifier = onFieldChanged;
-    _listener = DatabaseNotificationListener(
-      objectId: fieldId,
-      handler: _handler,
-    );
-  }
-
-  void _handler(
-    DatabaseNotification ty,
-    FlowyResult<Uint8List, FlowyError> result,
-  ) {
-    switch (ty) {
-      case DatabaseNotification.DidUpdateField:
-        result.fold(
-          (payload) => _updateFieldNotifier?.call(FieldPB.fromBuffer(payload)),
-          (error) => Log.error(error),
-        );
-        break;
-      default:
-        break;
-    }
-  }
-
-  Future<void> stop() async {
-    await _listener?.stop();
-    _updateFieldNotifier = null;
-  }
-}
 
 typedef UpdateFieldsNotifiedValue
     = FlowyResult<DatabaseFieldChangesetPB, FlowyError>;

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/field/field_editor.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/field/field_editor.dart
@@ -72,7 +72,7 @@ class _FieldEditorState extends State<FieldEditor> {
         field: widget.field,
         fieldController: widget.fieldController,
         onFieldInserted: widget.onFieldInserted,
-      )..add(const FieldEditorEvent.initial()),
+      ),
       child: _currentPage == FieldEditorPage.details
           ? _fieldDetails()
           : _fieldGeneral(),

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
@@ -1,6 +1,7 @@
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database/application/cell/cell_controller.dart';
+import 'package:appflowy/plugins/database/application/field/field_controller.dart';
 import 'package:appflowy/plugins/database/application/row/row_banner_bloc.dart';
 import 'package:appflowy/plugins/database/application/row/row_controller.dart';
 import 'package:appflowy/plugins/database/widgets/cell/editable_cell_builder.dart';
@@ -21,10 +22,12 @@ const _kBannerActionHeight = 40.0;
 class RowBanner extends StatefulWidget {
   const RowBanner({
     super.key,
+    required this.fieldController,
     required this.rowController,
     required this.cellBuilder,
   });
 
+  final FieldController fieldController;
   final RowController rowController;
   final EditableCellBuilder cellBuilder;
 
@@ -47,6 +50,7 @@ class _RowBannerState extends State<RowBanner> {
     return BlocProvider<RowBannerBloc>(
       create: (context) => RowBannerBloc(
         viewId: widget.rowController.viewId,
+        fieldController: widget.fieldController,
         rowMeta: widget.rowController.rowMeta,
       )..add(const RowBannerEvent.initial()),
       child: MouseRegion(

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_detail.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_detail.dart
@@ -57,6 +57,7 @@ class _RowDetailPageState extends State<RowDetailPage> {
           controller: scrollController,
           children: [
             RowBanner(
+              fieldController: widget.databaseController.fieldController,
               rowController: widget.rowController,
               cellBuilder: cellBuilder,
             ),

--- a/frontend/appflowy_flutter/test/bloc_test/board_test/create_or_edit_field_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/create_or_edit_field_test.dart
@@ -38,7 +38,7 @@ void main() {
       viewId: context.gridView.id,
       field: fieldInfo.field,
       fieldController: context.fieldController,
-    )..add(const FieldEditorEvent.initial());
+    );
     await boardResponseFuture();
 
     editorBloc.add(const FieldEditorEvent.renameField('Hello world'));

--- a/frontend/appflowy_flutter/test/bloc_test/board_test/group_by_unsupport_field_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/group_by_unsupport_field_test.dart
@@ -18,7 +18,7 @@ void main() {
     final fieldInfo = context.singleSelectFieldContext();
     editorBloc = context.makeFieldEditor(
       fieldInfo: fieldInfo,
-    )..add(const FieldEditorEvent.initial());
+    );
 
     await boardResponseFuture();
   });

--- a/frontend/appflowy_flutter/test/bloc_test/board_test/util.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/board_test/util.dart
@@ -96,8 +96,7 @@ class BoardTestContext {
 
   Future<FieldEditorBloc> createField(FieldType fieldType) async {
     final editorBloc =
-        await createFieldEditor(databaseController: _boardDataController)
-          ..add(const FieldEditorEvent.initial());
+        await createFieldEditor(databaseController: _boardDataController);
     await gridResponseFuture();
     editorBloc.add(FieldEditorEvent.switchFieldType(fieldType));
     await gridResponseFuture();

--- a/frontend/appflowy_flutter/test/bloc_test/grid_test/field/edit_field_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/grid_test/field/edit_field_test.dart
@@ -11,7 +11,7 @@ Future<FieldEditorBloc> createEditorBloc(AppFlowyGridTest gridTest) async {
     viewId: context.gridView.id,
     fieldController: context.fieldController,
     field: fieldInfo.field,
-  )..add(const FieldEditorEvent.initial());
+  );
 }
 
 void main() {

--- a/frontend/appflowy_flutter/test/bloc_test/grid_test/util.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/grid_test/util.dart
@@ -31,8 +31,7 @@ class GridTestContext {
 
   Future<FieldEditorBloc> createField(FieldType fieldType) async {
     final editorBloc =
-        await createFieldEditor(databaseController: gridController)
-          ..add(const FieldEditorEvent.initial());
+        await createFieldEditor(databaseController: gridController);
     await gridResponseFuture();
     editorBloc.add(FieldEditorEvent.switchFieldType(fieldType));
     await gridResponseFuture();


### PR DESCRIPTION
Remove `SingleFieldListener` and replace usage with `FieldController`'s `addSingleFieldListener` callback which gets triggered on `FieldInfo` changes instead of only `FieldPB` changes

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
