### PR TITLE
chore: checking workspace state consistent after switching workspace

### DIFF
--- a/frontend/appflowy_flutter/lib/startup/deps_resolver.dart
+++ b/frontend/appflowy_flutter/lib/startup/deps_resolver.dart
@@ -184,12 +184,6 @@ void _resolveHomeDeps(GetIt getIt) {
     (user, _) => UserListener(userProfile: user),
   );
 
-  getIt.registerFactoryParam<WorkspaceBloc, UserProfilePB, void>(
-    (user, _) => WorkspaceBloc(
-      userService: UserBackendService(userId: user.id),
-    ),
-  );
-
   // share
   getIt.registerFactoryParam<DocumentShareBloc, ViewPB, void>(
     (view, _) => DocumentShareBloc(view: view),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
@@ -1,3 +1,4 @@
+import 'package:appflowy/startup/startup.dart';
 import 'package:flutter/material.dart';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';
@@ -77,6 +78,8 @@ class _SidebarWorkspaceState extends State<SidebarWorkspace> {
     } else {
       loadingIndicator?.stop();
       loadingIndicator = null;
+
+      runAppFlowy();
     }
 
     if (result == null) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
@@ -1,4 +1,3 @@
-import 'package:appflowy/startup/startup.dart';
 import 'package:flutter/material.dart';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/sidebar_workspace.dart
@@ -78,8 +78,6 @@ class _SidebarWorkspaceState extends State<SidebarWorkspace> {
     } else {
       loadingIndicator?.stop();
       loadingIndicator = null;
-
-      runAppFlowy();
     }
 
     if (result == null) {

--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "again",
  "anyhow",
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "bytes",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1025,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -1404,7 +1404,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.lock
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",
@@ -933,7 +933,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "bytes",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -97,10 +97,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -87,7 +87,7 @@ yrs = { git = "https://github.com/appflowy/y-crdt", rev = "3f25bb510ca5274e7657d
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fdaac9d4aa0db222d69d346b65bfd85d50bf3c00" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "54dfeb552752eb0e4d887af3a0affaa80863943d" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #
@@ -97,10 +97,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -97,10 +97,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }

--- a/frontend/appflowy_web/wasm-libs/Cargo.lock
+++ b/frontend/appflowy_web/wasm-libs/Cargo.lock
@@ -112,6 +112,7 @@ version = "0.1.0"
 dependencies = [
  "af-persistence",
  "af-user",
+ "anyhow",
  "collab",
  "collab-integrate",
  "console_error_panic_hook",
@@ -631,7 +632,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -655,7 +656,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",
@@ -674,7 +675,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "bytes",
@@ -689,7 +690,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -727,7 +728,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -804,7 +805,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",
@@ -4980,4 +4981,4 @@ dependencies = [
 [[patch.unused]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"

--- a/frontend/appflowy_web/wasm-libs/Cargo.lock
+++ b/frontend/appflowy_web/wasm-libs/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",
@@ -4981,4 +4981,4 @@ dependencies = [
 [[patch.unused]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"

--- a/frontend/appflowy_web/wasm-libs/Cargo.lock
+++ b/frontend/appflowy_web/wasm-libs/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "again",
  "anyhow",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "bytes",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -1002,7 +1002,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2093,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -4981,4 +4981,4 @@ dependencies = [
 [[patch.unused]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"

--- a/frontend/appflowy_web/wasm-libs/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/Cargo.toml
@@ -65,10 +65,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }

--- a/frontend/appflowy_web/wasm-libs/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/Cargo.toml
@@ -65,10 +65,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }

--- a/frontend/appflowy_web/wasm-libs/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/Cargo.toml
@@ -55,7 +55,7 @@ codegen-units = 1
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fdaac9d4aa0db222d69d346b65bfd85d50bf3c00" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "54dfeb552752eb0e4d887af3a0affaa80863943d" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #
@@ -65,10 +65,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }

--- a/frontend/appflowy_web/wasm-libs/af-wasm/Cargo.toml
+++ b/frontend/appflowy_web/wasm-libs/af-wasm/Cargo.toml
@@ -36,7 +36,7 @@ wasm-bindgen-futures.workspace = true
 uuid.workspace = true
 serde-wasm-bindgen.workspace = true
 js-sys = "0.3.67"
-
+anyhow = "1.0"
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. However, it is slower than the default

--- a/frontend/appflowy_web/wasm-libs/af-wasm/src/core.rs
+++ b/frontend/appflowy_web/wasm-libs/af-wasm/src/core.rs
@@ -83,7 +83,7 @@ impl WorkspaceCollabIntegrate for WorkspaceCollabIntegrateImpl {
     Ok(workspace_id)
   }
 
-  fn device_id(&self) -> String {
-    "fake device id".to_string()
+  fn device_id(&self) -> Result<String, anyhow::Error> {
+    Ok("fake device id".to_string())
   }
 }

--- a/frontend/appflowy_web_app/src-tauri/Cargo.lock
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/appflowy_web_app/src-tauri/Cargo.lock
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "bytes",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/appflowy_web_app/src-tauri/Cargo.lock
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "again",
  "anyhow",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -916,7 +916,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "bytes",
@@ -931,7 +931,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1008,7 +1008,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -1391,7 +1391,7 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -3298,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -96,10 +96,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -86,7 +86,7 @@ yrs = { git = "https://github.com/appflowy/y-crdt", rev = "3f25bb510ca5274e7657d
 # Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fdaac9d4aa0db222d69d346b65bfd85d50bf3c00" }
+client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "54dfeb552752eb0e4d887af3a0affaa80863943d" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #
@@ -96,10 +96,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -96,10 +96,10 @@ client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fda
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 [[package]]
 name = "app-error"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "client-api"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "again",
  "anyhow",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "client-websocket"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "bytes",
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "collab-rt-protocol"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86#9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86"
 dependencies = [
  "anyhow",
  "collab",
@@ -1326,7 +1326,7 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 [[package]]
 name = "database-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -1610,6 +1610,7 @@ dependencies = [
  "flowy-storage",
  "flowy-user",
  "flowy-user-pub",
+ "futures",
  "futures-util",
  "lib-dispatch",
  "lib-infra",
@@ -2595,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "gotrue"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -2612,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "gotrue-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",
@@ -2983,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "infra"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5109,7 +5110,7 @@ dependencies = [
 [[package]]
 name = "shared-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=fdaac9d4aa0db222d69d346b65bfd85d50bf3c00#fdaac9d4aa0db222d69d346b65bfd85d50bf3c00"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Cloud?rev=54dfeb552752eb0e4d887af3a0affaa80863943d#54dfeb552752eb0e4d887af3a0affaa80863943d"
 dependencies = [
  "anyhow",
  "app-error",

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=dde872fca19f1be7ca3db3ed3aa7abb30d2756f5#dde872fca19f1be7ca3db3ed3aa7abb30d2756f5"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "bytes",
@@ -873,7 +873,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "chrono",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -989,7 +989,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=f8930ed1b19b65dd7b890df2b0db54048141e8c4#f8930ed1b19b65dd7b890df2b0db54048141e8c4"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=e05ffad336313ad4d506b0a9153165eb60231e79#e05ffad336313ad4d506b0a9153165eb60231e79"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -125,10 +125,10 @@ client-api = { git = " https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fd
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "f8930ed1b19b65dd7b890df2b0db54048141e8c4" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -115,7 +115,7 @@ rocksdb = { git = "https://github.com/LucasXu0/rust-rocksdb", rev = "21cf4a23ec1
 # Run the script.add_workspace_members:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
-client-api = { git = " https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fdaac9d4aa0db222d69d346b65bfd85d50bf3c00" }
+client-api = { git = " https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "54dfeb552752eb0e4d887af3a0affaa80863943d" }
 # Please use the following script to update collab.
 # Working directory: frontend
 #
@@ -125,10 +125,10 @@ client-api = { git = " https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fd
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "9efc5d6e13aca7d8ed3763bf57646bf2ddf1ff86" }

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -125,10 +125,10 @@ client-api = { git = " https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "fd
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
-collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "e05ffad336313ad4d506b0a9153165eb60231e79" }
+collab = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-folder = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-document = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-database = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-plugins = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-user = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }
+collab-entity = { git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "dde872fca19f1be7ca3db3ed3aa7abb30d2756f5" }

--- a/frontend/rust-lib/collab-integrate/src/collab_builder.rs
+++ b/frontend/rust-lib/collab-integrate/src/collab_builder.rs
@@ -146,6 +146,7 @@ impl AppFlowyCollabBuilder {
   /// - `raw_data`: The raw data of the collaboration object, defined by the [CollabDocState] type.
   /// - `collab_db`: A weak reference to the [CollabKVDB].
   ///
+  #[allow(clippy::too_many_arguments)]
   pub async fn build(
     &self,
     workspace_id: &str,

--- a/frontend/rust-lib/collab-integrate/src/collab_builder.rs
+++ b/frontend/rust-lib/collab-integrate/src/collab_builder.rs
@@ -203,7 +203,7 @@ impl AppFlowyCollabBuilder {
     let actual_workspace_id = self.workspace_integrate.workspace_id()?;
     if workspace_id != actual_workspace_id {
       return Err(anyhow::anyhow!(
-        "workspace_id not match when build collab. expected: {}, actual: {}",
+        "workspace_id not match when build collab. expect workspace_id: {}, actual workspace_id: {}",
         workspace_id,
         actual_workspace_id
       ));

--- a/frontend/rust-lib/collab-integrate/src/native/plugin_provider.rs
+++ b/frontend/rust-lib/collab-integrate/src/native/plugin_provider.rs
@@ -1,7 +1,5 @@
 use crate::collab_builder::{CollabPluginProviderContext, CollabPluginProviderType};
 use collab::preclude::CollabPlugin;
-use std::rc::Rc;
-use std::sync::Arc;
 
 #[cfg(target_arch = "wasm32")]
 pub trait CollabCloudPluginProvider: 'static {
@@ -13,7 +11,7 @@ pub trait CollabCloudPluginProvider: 'static {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl<T> CollabCloudPluginProvider for Rc<T>
+impl<T> CollabCloudPluginProvider for std::rc::Rc<T>
 where
   T: CollabCloudPluginProvider,
 {
@@ -40,7 +38,7 @@ pub trait CollabCloudPluginProvider: Send + Sync + 'static {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl<T> CollabCloudPluginProvider for Arc<T>
+impl<T> CollabCloudPluginProvider for std::sync::Arc<T>
 where
   T: CollabCloudPluginProvider,
 {

--- a/frontend/rust-lib/collab-integrate/src/native/plugin_provider.rs
+++ b/frontend/rust-lib/collab-integrate/src/native/plugin_provider.rs
@@ -1,7 +1,36 @@
 use crate::collab_builder::{CollabPluginProviderContext, CollabPluginProviderType};
 use collab::preclude::CollabPlugin;
+use std::rc::Rc;
 use std::sync::Arc;
 
+#[cfg(target_arch = "wasm32")]
+pub trait CollabCloudPluginProvider: 'static {
+  fn provider_type(&self) -> CollabPluginProviderType;
+
+  fn get_plugins(&self, context: CollabPluginProviderContext) -> Vec<Box<dyn CollabPlugin>>;
+
+  fn is_sync_enabled(&self) -> bool;
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> CollabCloudPluginProvider for Rc<T>
+where
+  T: CollabCloudPluginProvider,
+{
+  fn provider_type(&self) -> CollabPluginProviderType {
+    (**self).provider_type()
+  }
+
+  fn get_plugins(&self, context: CollabPluginProviderContext) -> Vec<Box<dyn CollabPlugin>> {
+    (**self).get_plugins(context)
+  }
+
+  fn is_sync_enabled(&self) -> bool {
+    (**self).is_sync_enabled()
+  }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub trait CollabCloudPluginProvider: Send + Sync + 'static {
   fn provider_type(&self) -> CollabPluginProviderType;
 
@@ -10,6 +39,7 @@ pub trait CollabCloudPluginProvider: Send + Sync + 'static {
   fn is_sync_enabled(&self) -> bool;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> CollabCloudPluginProvider for Arc<T>
 where
   T: CollabCloudPluginProvider,

--- a/frontend/rust-lib/event-integration/Cargo.toml
+++ b/frontend/rust-lib/event-integration/Cargo.toml
@@ -20,7 +20,7 @@ lib-dispatch = { workspace = true }
 lib-infra = { workspace = true }
 flowy-server = { path = "../flowy-server" }
 flowy-server-pub = { workspace = true }
-flowy-notification  = { workspace = true }
+flowy-notification = { workspace = true }
 anyhow.workspace = true
 flowy-storage = { workspace = true }
 flowy-search = { workspace = true }
@@ -28,7 +28,7 @@ flowy-search = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 protobuf.workspace = true
-tokio = { workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 futures-util = "0.3.26"
 thread-id = "3.3.0"
 bytes.workspace = true
@@ -53,6 +53,7 @@ tokio-postgres = { version = "0.7.8" }
 chrono = "0.4.31"
 zip = "0.6.6"
 walkdir = "2.5.0"
+futures = "0.3.30"
 
 [features]
 default = ["supabase_cloud_test"]

--- a/frontend/rust-lib/event-integration/src/folder_event.rs
+++ b/frontend/rust-lib/event-integration/src/folder_event.rs
@@ -143,7 +143,8 @@ impl EventIntegrationTest {
     let mutex_folder = self.appflowy_core.folder_manager.get_mutex_folder().clone();
     let folder_lock_guard = mutex_folder.read();
     let folder = folder_lock_guard.as_ref().unwrap();
-    folder.get_folder_data().clone().unwrap()
+    let workspace_id = self.appflowy_core.user_manager.workspace_id().unwrap();
+    folder.get_folder_data(&workspace_id).clone().unwrap()
   }
 
   pub async fn get_all_workspace_views(&self) -> Vec<ViewPB> {

--- a/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
+++ b/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
@@ -432,7 +432,7 @@ async fn update_text_cell_event_test() {
 
   let row_id = database.rows[0].id.clone();
   let field_id = fields[0].id.clone();
-  assert_eq!(fields[0].field_type, FieldType::RichText);
+  assert_eq!(fields[0].field_type, FieldType::RichText)Flowy Core DroFlowy Core Dro;
 
   // Update the first cell of the first row.
   let error = test

--- a/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
+++ b/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
@@ -432,7 +432,7 @@ async fn update_text_cell_event_test() {
 
   let row_id = database.rows[0].id.clone();
   let field_id = fields[0].id.clone();
-  assert_eq!(fields[0].field_type, FieldType::RichText)Flowy Core DroFlowy Core Dro;
+  assert_eq!(fields[0].field_type, FieldType::RichText)
 
   // Update the first cell of the first row.
   let error = test

--- a/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
+++ b/frontend/rust-lib/event-integration/tests/database/local_test/test.rs
@@ -432,7 +432,7 @@ async fn update_text_cell_event_test() {
 
   let row_id = database.rows[0].id.clone();
   let field_id = fields[0].id.clone();
-  assert_eq!(fields[0].field_type, FieldType::RichText)
+  assert_eq!(fields[0].field_type, FieldType::RichText);
 
   // Update the first cell of the first row.
   let error = test

--- a/frontend/rust-lib/event-integration/tests/user/af_cloud_test/util.rs
+++ b/frontend/rust-lib/event-integration/tests/user/af_cloud_test/util.rs
@@ -20,7 +20,7 @@ pub async fn get_synced_workspaces(
       &sub_id,
       UserNotification::DidUpdateUserWorkspaces as i32,
     );
-  receive_with_timeout(rx, Duration::from_secs(30))
+  receive_with_timeout(rx, Duration::from_secs(60))
     .await
     .unwrap()
     .items

--- a/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
+++ b/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
@@ -159,11 +159,11 @@ async fn af_cloud_different_open_same_workspace_test() {
 
   // Set up the primary client and sign them up to the cloud.
   let client_1 = EventIntegrationTest::new().await;
-  let client_1_profile = client_1.af_cloud_sign_up().await;
+  let owner_profile = client_1.af_cloud_sign_up().await;
   let shared_workspace_id = client_1.get_current_workspace().await.id.clone();
 
   // Verify that the workspace ID from the profile matches the current session's workspace ID.
-  assert_eq!(shared_workspace_id, client_1_profile.workspace_id);
+  assert_eq!(shared_workspace_id, owner_profile.workspace_id);
 
   // Define the number of additional clients
   let num_clients = 5;
@@ -182,7 +182,7 @@ async fn af_cloud_different_open_same_workspace_test() {
     }
 
     client_1
-      .add_workspace_member(&client_1_profile.workspace_id, &client_profile.email)
+      .add_workspace_member(&owner_profile.workspace_id, &client_profile.email)
       .await;
     clients.push((client, client_profile));
   }
@@ -193,7 +193,7 @@ async fn af_cloud_different_open_same_workspace_test() {
     assert_eq!(all_workspaces.len(), 2);
   }
 
-  // Simulate each client open different workspace 60 times
+  // Simulate each client open different workspace 30 times
   let mut handles = vec![];
   for client in clients.clone() {
     let cloned_shared_workspace_id = shared_workspace_id.clone();
@@ -224,7 +224,7 @@ async fn af_cloud_different_open_same_workspace_test() {
     .await
     .unwrap();
   let folder = Folder::from_collab_doc_state(
-    &client_1_profile.id,
+    owner_profile.id,
     CollabOrigin::Empty,
     DocStateV1(doc_state),
     &shared_workspace_id,

--- a/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
+++ b/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
@@ -1,3 +1,7 @@
+use collab::core::collab::DataSource::DocStateV1;
+use collab::core::origin::CollabOrigin;
+use collab_entity::CollabType;
+use collab_folder::Folder;
 use event_integration::user_event::user_localhost_af_cloud;
 use event_integration::EventIntegrationTest;
 use std::time::Duration;
@@ -147,4 +151,92 @@ async fn af_cloud_open_workspace_test() {
   assert_eq!(views[0].name, default_document_name);
   assert_eq!(views[1].name, "C");
   assert_eq!(views[2].name, "D");
+}
+
+#[tokio::test]
+async fn af_cloud_different_open_same_workspace_test() {
+  user_localhost_af_cloud().await;
+
+  // Set up the primary client and sign them up to the cloud.
+  let client_1 = EventIntegrationTest::new().await;
+  let client_1_profile = client_1.af_cloud_sign_up().await;
+  let shared_workspace_id = client_1.get_current_workspace().await.id.clone();
+
+  // Verify that the workspace ID from the profile matches the current session's workspace ID.
+  assert_eq!(shared_workspace_id, client_1_profile.workspace_id);
+
+  // Define the number of additional clients
+  let num_clients = 5;
+  let mut clients = Vec::new();
+
+  // Initialize and sign up additional clients
+  for _ in 0..num_clients {
+    let client = EventIntegrationTest::new().await;
+    let client_profile = client.af_cloud_sign_up().await;
+
+    let views = client.get_all_workspace_views().await;
+    // only the getting started view should be present
+    assert_eq!(views.len(), 1);
+    for view in views {
+      client.delete_view(&view.id).await;
+    }
+
+    client_1
+      .add_workspace_member(&client_1_profile.workspace_id, &client_profile.email)
+      .await;
+    clients.push((client, client_profile));
+  }
+
+  // Verify that each client has exactly two workspaces: one from sign-up and another from invitation
+  for (client, profile) in &clients {
+    let all_workspaces = get_synced_workspaces(client, profile.id).await;
+    assert_eq!(all_workspaces.len(), 2);
+  }
+
+  // Simulate each client open different workspace 60 times
+  let mut handles = vec![];
+  for client in clients.clone() {
+    let cloned_shared_workspace_id = shared_workspace_id.clone();
+    let handle = tokio::spawn(async move {
+      let (client, profile) = client;
+      let all_workspaces = get_synced_workspaces(&client, profile.id).await;
+      for i in 0..30 {
+        let index = i % 2;
+        let iter_workspace_id = &all_workspaces[index].workspace_id;
+        client.open_workspace(iter_workspace_id).await;
+        if iter_workspace_id == &cloned_shared_workspace_id {
+          let views = client.get_all_workspace_views().await;
+          assert_eq!(views.len(), 1);
+          sleep(Duration::from_millis(300)).await;
+        } else {
+          let views = client.get_all_workspace_views().await;
+          assert!(views.is_empty());
+        }
+      }
+    });
+    handles.push(handle);
+  }
+  futures::future::join_all(handles).await;
+
+  // Retrieve and verify the collaborative document state for Client 1's workspace.
+  let doc_state = client_1
+    .get_collab_doc_state(&shared_workspace_id, CollabType::Folder)
+    .await
+    .unwrap();
+  let folder = Folder::from_collab_doc_state(
+    &client_1_profile.id,
+    CollabOrigin::Empty,
+    DocStateV1(doc_state),
+    &shared_workspace_id,
+    vec![],
+  )
+  .unwrap();
+
+  // Retrieve and verify the views associated with the workspace.
+  let views = folder.get_views_belong_to(&shared_workspace_id);
+  let folder_workspace_id = folder.get_workspace_id();
+  assert_eq!(folder_workspace_id, shared_workspace_id);
+
+  assert_eq!(views.len(), 1, "only get: {:?}", views); // Expecting two views.
+  assert_eq!(views[0].name, "Getting started");
 }

--- a/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
+++ b/frontend/rust-lib/event-integration/tests/user/af_cloud_test/workspace_test.rs
@@ -123,23 +123,27 @@ async fn af_cloud_open_workspace_test() {
   for i in 0..30 {
     if i % 2 == 0 {
       test.open_workspace(&first_workspace.id).await;
-      sleep(Duration::from_millis(400)).await;
+      sleep(Duration::from_millis(300)).await;
+      test
+        .create_document(&uuid::Uuid::new_v4().to_string())
+        .await;
     } else {
       test.open_workspace(&second_workspace.id).await;
       sleep(Duration::from_millis(200)).await;
+      test
+        .create_document(&uuid::Uuid::new_v4().to_string())
+        .await;
     }
   }
 
   test.open_workspace(&first_workspace.id).await;
   let views = test.get_all_workspace_views().await;
-  assert_eq!(views.len(), 3);
   assert_eq!(views[0].name, default_document_name);
   assert_eq!(views[1].name, "A");
   assert_eq!(views[2].name, "B");
 
   test.open_workspace(&second_workspace.id).await;
   let views = test.get_all_workspace_views().await;
-  assert_eq!(views.len(), 3);
   assert_eq!(views[0].name, default_document_name);
   assert_eq!(views[1].name, "C");
   assert_eq!(views[2].name, "D");

--- a/frontend/rust-lib/flowy-core/src/integrate/user.rs
+++ b/frontend/rust-lib/flowy-core/src/integrate/user.rs
@@ -67,16 +67,8 @@ impl UserStatusCallback for UserStatusCallbackImpl {
           },
         )
         .await?;
-      database_manager
-        .initialize(
-          user_id,
-          user_workspace.id.clone(),
-          user_workspace.workspace_database_object_id,
-        )
-        .await?;
-      document_manager
-        .initialize(user_id, user_workspace.id)
-        .await?;
+      database_manager.initialize(user_id).await?;
+      document_manager.initialize(user_id).await?;
       Ok(())
     })
   }
@@ -102,19 +94,9 @@ impl UserStatusCallback for UserStatusCallbackImpl {
         device_id
       );
 
-      folder_manager
-        .initialize_with_workspace_id(user_id, &user_workspace.id)
-        .await?;
-      database_manager
-        .initialize(
-          user_id,
-          user_workspace.id.clone(),
-          user_workspace.workspace_database_object_id,
-        )
-        .await?;
-      document_manager
-        .initialize(user_id, user_workspace.id)
-        .await?;
+      folder_manager.initialize_with_workspace_id(user_id).await?;
+      database_manager.initialize(user_id).await?;
+      document_manager.initialize(user_id).await?;
       Ok(())
     })
   }
@@ -197,16 +179,12 @@ impl UserStatusCallback for UserStatusCallbackImpl {
         .context("FolderManager error")?;
 
       database_manager
-        .initialize_with_new_user(
-          user_profile.uid,
-          user_workspace.id.clone(),
-          user_workspace.workspace_database_object_id,
-        )
+        .initialize_with_new_user(user_profile.uid)
         .await
         .context("DatabaseManager error")?;
 
       document_manager
-        .initialize_with_new_user(user_profile.uid, user_workspace.id)
+        .initialize_with_new_user(user_profile.uid)
         .await
         .context("DocumentManager error")?;
       Ok(())
@@ -221,27 +199,15 @@ impl UserStatusCallback for UserStatusCallbackImpl {
     })
   }
 
-  fn open_workspace(&self, user_id: i64, user_workspace: &UserWorkspace) -> Fut<FlowyResult<()>> {
-    let user_workspace = user_workspace.clone();
+  fn open_workspace(&self, user_id: i64, _user_workspace: &UserWorkspace) -> Fut<FlowyResult<()>> {
     let folder_manager = self.folder_manager.clone();
     let database_manager = self.database_manager.clone();
     let document_manager = self.document_manager.clone();
 
     to_fut(async move {
-      folder_manager
-        .initialize_with_workspace_id(user_id, &user_workspace.id)
-        .await?;
-
-      database_manager
-        .initialize(
-          user_id,
-          user_workspace.id.clone(),
-          user_workspace.workspace_database_object_id,
-        )
-        .await?;
-      document_manager
-        .initialize(user_id, user_workspace.id)
-        .await?;
+      folder_manager.initialize_with_workspace_id(user_id).await?;
+      database_manager.initialize(user_id).await?;
+      document_manager.initialize(user_id).await?;
       Ok(())
     })
   }

--- a/frontend/rust-lib/flowy-core/src/integrate/user.rs
+++ b/frontend/rust-lib/flowy-core/src/integrate/user.rs
@@ -38,7 +38,6 @@ impl UserStatusCallback for UserStatusCallbackImpl {
   ) -> Fut<FlowyResult<()>> {
     let user_id = user_id.to_owned();
     let user_workspace = user_workspace.clone();
-    let collab_builder = self.collab_builder.clone();
     let folder_manager = self.folder_manager.clone();
     let database_manager = self.database_manager.clone();
     let document_manager = self.document_manager.clone();
@@ -59,7 +58,6 @@ impl UserStatusCallback for UserStatusCallbackImpl {
     }
 
     to_fut(async move {
-      collab_builder.initialize(user_workspace.id.clone());
       folder_manager
         .initialize(
           user_id,
@@ -225,13 +223,11 @@ impl UserStatusCallback for UserStatusCallbackImpl {
 
   fn open_workspace(&self, user_id: i64, user_workspace: &UserWorkspace) -> Fut<FlowyResult<()>> {
     let user_workspace = user_workspace.clone();
-    let collab_builder = self.collab_builder.clone();
     let folder_manager = self.folder_manager.clone();
     let database_manager = self.database_manager.clone();
     let document_manager = self.document_manager.clone();
 
     to_fut(async move {
-      collab_builder.initialize(user_workspace.id.clone());
       folder_manager
         .initialize_with_workspace_id(user_id, &user_workspace.id)
         .await?;

--- a/frontend/rust-lib/flowy-core/src/lib.rs
+++ b/frontend/rust-lib/flowy-core/src/lib.rs
@@ -4,18 +4,18 @@ use flowy_search::folder::indexer::FolderIndexManagerImpl;
 use flowy_search::services::manager::SearchManager;
 use flowy_storage::ObjectStorageService;
 use semver::Version;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 use sysinfo::System;
 use tokio::sync::RwLock;
 use tracing::{debug, error, event, info, instrument};
 
-use collab_integrate::collab_builder::{
-  AppFlowyCollabBuilder, CollabPluginProviderType, WorkspaceCollabIntegrate,
-};
+use collab_integrate::collab_builder::{AppFlowyCollabBuilder, CollabPluginProviderType};
 use flowy_database2::DatabaseManager;
 use flowy_document::manager::DocumentManager;
+use flowy_error::{FlowyError, FlowyResult};
 use flowy_folder::manager::FolderManager;
+use flowy_server::af_cloud::define::ServerUser;
 
 use flowy_sqlite::kv::StorePreferences;
 use flowy_user::services::authenticate_user::AuthenticateUser;
@@ -106,14 +106,29 @@ impl AppFlowyCore {
     let task_dispatcher = Arc::new(RwLock::new(task_scheduler));
     runtime.spawn(TaskRunner::run(task_dispatcher.clone()));
 
+    let app_version = Version::parse(&config.app_version).unwrap_or_else(|_| Version::new(0, 5, 4));
+    let user_config = UserConfig::new(
+      &config.name,
+      &config.storage_path,
+      &config.application_path,
+      &config.device_id,
+      app_version,
+    );
+
+    let authenticate_user = Arc::new(AuthenticateUser::new(
+      user_config.clone(),
+      store_preference.clone(),
+    ));
+
     let server_type = current_server_type();
     debug!("🔥runtime:{}, server:{}", runtime, server_type);
+
     let server_provider = Arc::new(ServerProvider::new(
       config.clone(),
       server_type,
       Arc::downgrade(&store_preference),
+      ServerUserImpl(Arc::downgrade(&authenticate_user)),
     ));
-    let app_version = Version::parse(&config.app_version).unwrap_or_else(|_| Version::new(0, 5, 4));
 
     event!(tracing::Level::DEBUG, "Init managers",);
     let (
@@ -125,24 +140,11 @@ impl AppFlowyCore {
       collab_builder,
       search_manager,
     ) = async {
-      let user_config = UserConfig::new(
-        &config.name,
-        &config.storage_path,
-        &config.application_path,
-        &config.device_id,
-        app_version,
-      );
-
-      let authenticate_user = Arc::new(AuthenticateUser::new(
-        user_config.clone(),
-        store_preference.clone(),
-      ));
-
       /// The shared collab builder is used to build the [Collab] instance. The plugins will be loaded
       /// on demand based on the [CollabPluginConfig].
       let collab_builder = Arc::new(AppFlowyCollabBuilder::new(
         server_provider.clone(),
-        WorkspaceCollabIntegrateImpl(authenticate_user.clone()),
+        WorkspaceCollabIntegrateImpl(Arc::downgrade(&authenticate_user)),
       ));
 
       collab_builder
@@ -270,14 +272,19 @@ impl Drop for AppFlowyCore {
   }
 }
 
-struct WorkspaceCollabIntegrateImpl(Arc<AuthenticateUser>);
-impl WorkspaceCollabIntegrate for WorkspaceCollabIntegrateImpl {
-  fn workspace_id(&self) -> Result<String, anyhow::Error> {
-    let workspace_id = self.0.workspace_id()?;
-    Ok(workspace_id)
-  }
+struct ServerUserImpl(Weak<AuthenticateUser>);
 
-  fn device_id(&self) -> String {
-    self.0.user_config.device_id.clone()
+impl ServerUserImpl {
+  fn upgrade_user(&self) -> Result<Arc<AuthenticateUser>, FlowyError> {
+    let user = self
+      .0
+      .upgrade()
+      .ok_or(FlowyError::internal().with_context("Unexpected error: UserSession is None"))?;
+    Ok(user)
+  }
+}
+impl ServerUser for ServerUserImpl {
+  fn workspace_id(&self) -> FlowyResult<String> {
+    self.upgrade_user()?.workspace_id()
   }
 }

--- a/frontend/rust-lib/flowy-core/src/lib.rs
+++ b/frontend/rust-lib/flowy-core/src/lib.rs
@@ -265,13 +265,6 @@ impl From<Server> for CollabPluginProviderType {
   }
 }
 
-impl Drop for AppFlowyCore {
-  fn drop(&mut self) {
-    info!("🔥AppFlowy Core Drop");
-    self.close_db();
-  }
-}
-
 struct ServerUserImpl(Weak<AuthenticateUser>);
 
 impl ServerUserImpl {

--- a/frontend/rust-lib/flowy-database2/src/manager.rs
+++ b/frontend/rust-lib/flowy-database2/src/manager.rs
@@ -82,6 +82,9 @@ impl DatabaseManager {
     }
     self.editors.lock().await.clear();
     // 3. Clear the workspace database
+    if let Some(old_workspace_database) = self.workspace_database.write().await.take() {
+      old_workspace_database.close();
+    }
     *self.workspace_database.write().await = None;
 
     let collab_db = self.user.collab_db(uid)?;

--- a/frontend/rust-lib/flowy-database2/src/manager.rs
+++ b/frontend/rust-lib/flowy-database2/src/manager.rs
@@ -214,7 +214,7 @@ impl DatabaseManager {
       .await?
       .get_database(database_id)
       .await
-      .ok_or_else(FlowyError::collab_not_sync)?;
+      .ok_or_else(|| FlowyError::collab_not_sync().with_context("open database error"))?;
 
     // Subscribe the [BlockEvent]
     subscribe_block_event(&database);

--- a/frontend/rust-lib/flowy-database2/src/manager.rs
+++ b/frontend/rust-lib/flowy-database2/src/manager.rs
@@ -32,6 +32,8 @@ use crate::services::share::csv::{CSVFormat, CSVImporter, ImportResult};
 pub trait DatabaseUser: Send + Sync {
   fn user_id(&self) -> Result<i64, FlowyError>;
   fn collab_db(&self, uid: i64) -> Result<Weak<CollabKVDB>, FlowyError>;
+  fn workspace_id(&self) -> Result<String, FlowyError>;
+  fn workspace_database_object_id(&self) -> Result<String, FlowyError>;
 }
 
 pub struct DatabaseManager {
@@ -71,12 +73,7 @@ impl DatabaseManager {
   }
 
   /// When initialize with new workspace, all the resources will be cleared.
-  pub async fn initialize(
-    &self,
-    uid: i64,
-    workspace_id: String,
-    workspace_database_object_id: String,
-  ) -> FlowyResult<()> {
+  pub async fn initialize(&self, uid: i64) -> FlowyResult<()> {
     // 1. Clear all existing tasks
     self.task_scheduler.write().await.clear_task();
     // 2. Release all existing editors
@@ -89,12 +86,14 @@ impl DatabaseManager {
 
     let collab_db = self.user.collab_db(uid)?;
     let collab_builder = UserDatabaseCollabServiceImpl {
-      workspace_id: workspace_id.clone(),
+      user: self.user.clone(),
       collab_builder: self.collab_builder.clone(),
       cloud_service: self.cloud_service.clone(),
     };
     let config = CollabPersistenceConfig::new().snapshot_per_update(100);
 
+    let workspace_id = self.user.workspace_id()?;
+    let workspace_database_object_id = self.user.workspace_database_object_id()?;
     let mut workspace_database_doc_state = DataSource::Disk;
     // If the workspace database not exist in disk, try to fetch from remote.
     if !self.is_collab_exist(uid, &collab_db, &workspace_database_object_id) {
@@ -151,15 +150,8 @@ impl DatabaseManager {
     skip_all,
     err
   )]
-  pub async fn initialize_with_new_user(
-    &self,
-    user_id: i64,
-    workspace_id: String,
-    workspace_database_object_id: String,
-  ) -> FlowyResult<()> {
-    self
-      .initialize(user_id, workspace_id, workspace_database_object_id)
-      .await?;
+  pub async fn initialize_with_new_user(&self, user_id: i64) -> FlowyResult<()> {
+    self.initialize(user_id).await?;
     Ok(())
   }
 
@@ -445,7 +437,7 @@ fn subscribe_block_event(database: &Arc<MutexDatabase>) {
 }
 
 struct UserDatabaseCollabServiceImpl {
-  workspace_id: String,
+  user: Arc<dyn DatabaseUser>,
   collab_builder: Arc<AppFlowyCollabBuilder>,
   cloud_service: Arc<dyn DatabaseCloudService>,
 }
@@ -456,7 +448,7 @@ impl DatabaseCollabService for UserDatabaseCollabServiceImpl {
     object_id: &str,
     object_ty: CollabType,
   ) -> CollabFuture<Result<DataSource, DatabaseError>> {
-    let workspace_id = self.workspace_id.clone();
+    let workspace_id = self.user.workspace_id().unwrap();
     let object_id = object_id.to_string();
     let weak_cloud_service = Arc::downgrade(&self.cloud_service);
     Box::pin(async move {
@@ -480,9 +472,12 @@ impl DatabaseCollabService for UserDatabaseCollabServiceImpl {
     object_ids: Vec<String>,
     object_ty: CollabType,
   ) -> CollabFuture<Result<CollabDocStateByOid, DatabaseError>> {
-    let workspace_id = self.workspace_id.clone();
+    let cloned_user = self.user.clone();
     let weak_cloud_service = Arc::downgrade(&self.cloud_service);
     Box::pin(async move {
+      let workspace_id = cloned_user
+        .workspace_id()
+        .map_err(|err| DatabaseError::Internal(err.into()))?;
       match weak_cloud_service.upgrade() {
         None => {
           tracing::warn!("Cloud service is dropped");
@@ -505,15 +500,19 @@ impl DatabaseCollabService for UserDatabaseCollabServiceImpl {
     object_type: CollabType,
     collab_db: Weak<CollabKVDB>,
     collab_raw_data: DataSource,
-    persistence_config: CollabPersistenceConfig,
+    _persistence_config: CollabPersistenceConfig,
   ) -> Result<Arc<MutexCollab>, DatabaseError> {
+    let workspace_id = self
+      .user
+      .workspace_id()
+      .map_err(|err| DatabaseError::Internal(err.into()))?;
     let collab = self.collab_builder.build_with_config(
+      &workspace_id,
       uid,
       object_id,
       object_type.clone(),
       collab_db.clone(),
       collab_raw_data,
-      persistence_config,
       CollabBuilderConfig::default().sync_enable(true),
     )?;
     Ok(collab)

--- a/frontend/rust-lib/flowy-document/src/manager.rs
+++ b/frontend/rust-lib/flowy-document/src/manager.rs
@@ -20,7 +20,6 @@ use tracing::{error, trace};
 use tracing::{event, instrument};
 
 use collab_integrate::collab_builder::{AppFlowyCollabBuilder, CollabBuilderConfig};
-use collab_integrate::CollabPersistenceConfig;
 use flowy_document_pub::cloud::DocumentCloudService;
 use flowy_error::{internal_error, ErrorCode, FlowyError, FlowyResult};
 use flowy_storage::ObjectStorageService;
@@ -77,7 +76,7 @@ impl DocumentManager {
     }
   }
 
-  pub async fn initialize(&self, _uid: i64, _workspace_id: String) -> FlowyResult<()> {
+  pub async fn initialize(&self, _uid: i64) -> FlowyResult<()> {
     self.documents.clear();
     Ok(())
   }
@@ -88,8 +87,8 @@ impl DocumentManager {
     skip_all,
     err
   )]
-  pub async fn initialize_with_new_user(&self, uid: i64, workspace_id: String) -> FlowyResult<()> {
-    self.initialize(uid, workspace_id).await?;
+  pub async fn initialize_with_new_user(&self, uid: i64) -> FlowyResult<()> {
+    self.initialize(uid).await?;
     Ok(())
   }
 
@@ -382,13 +381,14 @@ impl DocumentManager {
     sync_enable: bool,
   ) -> FlowyResult<Arc<MutexCollab>> {
     let db = self.user_service.collab_db(uid)?;
+    let workspace_id = self.user_service.workspace_id()?;
     let collab = self.collab_builder.build_with_config(
+      &workspace_id,
       uid,
       doc_id,
       CollabType::Document,
       db,
       doc_state,
-      CollabPersistenceConfig::default().snapshot_per_update(1000),
       CollabBuilderConfig::default().sync_enable(sync_enable),
     )?;
     Ok(collab)

--- a/frontend/rust-lib/flowy-document/tests/document/util.rs
+++ b/frontend/rust-lib/flowy-document/tests/document/util.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use collab_integrate::collab_builder::{
   AppFlowyCollabBuilder, CollabCloudPluginProvider, CollabPluginProviderContext,
-  CollabPluginProviderType,
+  CollabPluginProviderType, WorkspaceCollabIntegrate,
 };
 use collab_integrate::CollabKVDB;
 use flowy_document::document::MutexDocument;
@@ -101,8 +101,11 @@ pub fn setup_log() {
 }
 
 pub fn default_collab_builder() -> Arc<AppFlowyCollabBuilder> {
-  let builder =
-    AppFlowyCollabBuilder::new(DefaultCollabStorageProvider(), "fake_device_id".to_string());
+  let builder = AppFlowyCollabBuilder::new(
+    "fake_device_id".to_string(),
+    DefaultCollabStorageProvider(),
+    WorkspaceCollabIntegrateImpl,
+  );
   builder.initialize(uuid::Uuid::new_v4().to_string());
   Arc::new(builder)
 }
@@ -219,6 +222,17 @@ impl DocumentSnapshotService for DocumentTestSnapshot {
   }
 
   fn get_document_snapshot(&self, _snapshot_id: &str) -> FlowyResult<DocumentSnapshotData> {
+    todo!()
+  }
+}
+
+struct WorkspaceCollabIntegrateImpl;
+impl WorkspaceCollabIntegrate for WorkspaceCollabIntegrateImpl {
+  fn workspace_id(&self) -> Result<String, Error> {
+    todo!()
+  }
+
+  fn device_id(&self) -> String {
     todo!()
   }
 }

--- a/frontend/rust-lib/flowy-document/tests/document/util.rs
+++ b/frontend/rust-lib/flowy-document/tests/document/util.rs
@@ -101,12 +101,8 @@ pub fn setup_log() {
 }
 
 pub fn default_collab_builder() -> Arc<AppFlowyCollabBuilder> {
-  let builder = AppFlowyCollabBuilder::new(
-    "fake_device_id".to_string(),
-    DefaultCollabStorageProvider(),
-    WorkspaceCollabIntegrateImpl,
-  );
-  builder.initialize(uuid::Uuid::new_v4().to_string());
+  let builder =
+    AppFlowyCollabBuilder::new(DefaultCollabStorageProvider(), WorkspaceCollabIntegrateImpl);
   Arc::new(builder)
 }
 
@@ -232,7 +228,7 @@ impl WorkspaceCollabIntegrate for WorkspaceCollabIntegrateImpl {
     todo!()
   }
 
-  fn device_id(&self) -> String {
-    todo!()
+  fn device_id(&self) -> Result<String, Error> {
+    Ok("fake_device_id".to_string())
   }
 }

--- a/frontend/rust-lib/flowy-document/tests/document/util.rs
+++ b/frontend/rust-lib/flowy-document/tests/document/util.rs
@@ -9,7 +9,6 @@ use nanoid::nanoid;
 use parking_lot::Once;
 use tempfile::TempDir;
 use tracing_subscriber::{fmt::Subscriber, util::SubscriberInitExt, EnvFilter};
-use uuid::Uuid;
 
 use collab_integrate::collab_builder::{
   AppFlowyCollabBuilder, CollabCloudPluginProvider, CollabPluginProviderContext,
@@ -231,7 +230,7 @@ impl DocumentSnapshotService for DocumentTestSnapshot {
 
 struct WorkspaceCollabIntegrateImpl {
   workspace_id: String,
-};
+}
 impl WorkspaceCollabIntegrate for WorkspaceCollabIntegrateImpl {
   fn workspace_id(&self) -> Result<String, Error> {
     Ok(self.workspace_id.clone())

--- a/frontend/rust-lib/flowy-folder/src/lib.rs
+++ b/frontend/rust-lib/flowy-folder/src/lib.rs
@@ -11,6 +11,9 @@ pub mod view_operation;
 
 mod manager_init;
 mod manager_observer;
+#[cfg(debug_assertions)]
+pub mod manager_test_util;
+
 pub mod share;
 #[cfg(feature = "test_helper")]
 mod test_helper;

--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -21,8 +21,8 @@ use collab::core::collab::{DataSource, MutexCollab};
 use collab_entity::CollabType;
 use collab_folder::error::FolderError;
 use collab_folder::{
-  Folder, FolderData, FolderNotify, Section, SectionItem, TrashInfo, UserId, View, ViewLayout,
-  ViewUpdate, Workspace,
+  Folder, FolderNotify, Section, SectionItem, TrashInfo, UserId, View, ViewLayout, ViewUpdate,
+  Workspace,
 };
 use collab_integrate::collab_builder::{AppFlowyCollabBuilder, CollabBuilderConfig};
 use collab_integrate::CollabKVDB;
@@ -117,6 +117,7 @@ impl FolderManager {
     }))
   }
 
+  #[instrument(level = "trace", skip_all, err)]
   pub(crate) async fn make_folder<T: Into<Option<FolderNotify>>>(
     &self,
     uid: i64,
@@ -152,7 +153,7 @@ impl FolderManager {
           let folder_workspace_id = folder.get_workspace_id();
           if folder_workspace_id != workspace_id {
             error!(
-              "expected workspace id: {}, actual workspace id: {}",
+              "expect workspace_id: {}, actual workspace_id: {}",
               workspace_id, folder_workspace_id
             );
             return Err(FlowyError::workspace_data_not_match());
@@ -1304,8 +1305,6 @@ pub enum FolderInitDataSource {
   LocalDisk { create_if_not_exist: bool },
   /// If there is no data stored on local disk, we will use the data from the server to initialize the folder
   Cloud(Vec<u8>),
-  /// If the user is new, we use the [DefaultFolderBuilder] to create the default folder.
-  FolderData(FolderData),
 }
 
 impl Display for FolderInitDataSource {
@@ -1313,7 +1312,6 @@ impl Display for FolderInitDataSource {
     match self {
       FolderInitDataSource::LocalDisk { .. } => f.write_fmt(format_args!("LocalDisk")),
       FolderInitDataSource::Cloud(_) => f.write_fmt(format_args!("Cloud")),
-      FolderInitDataSource::FolderData(_) => f.write_fmt(format_args!("Custom FolderData")),
     }
   }
 }

--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -88,7 +88,7 @@ impl FolderManager {
           Ok::<WorkspacePB, FlowyError>(workspace)
         };
 
-        match folder.get_current_workspace(&workspace_id) {
+        match folder.get_workspace_info(&workspace_id) {
           None => Err(FlowyError::record_not_found().with_context("Can not find the workspace")),
           Some(workspace) => workspace_pb_from_workspace(workspace, folder),
         }
@@ -328,7 +328,7 @@ impl FolderManager {
       .as_ref()
       .ok_or(FlowyError::internal().with_context("folder is not initialized"))?;
     let workspace = folder
-      .get_current_workspace(&workspace_id)
+      .get_workspace_info(&workspace_id)
       .ok_or_else(|| FlowyError::record_not_found().with_context("Can not find the workspace"))?;
 
     let views = folder
@@ -1069,20 +1069,18 @@ impl FolderManager {
       |folder| {
         let view = folder.views.get_view(view_id)?;
         match folder.views.get_view(&view.parent_view_id) {
-          None => folder
-            .get_current_workspace(&workspace_id)
-            .map(|workspace| {
-              (
-                true,
-                workspace.id,
-                workspace
-                  .child_views
-                  .items
-                  .into_iter()
-                  .map(|view| view.id)
-                  .collect::<Vec<String>>(),
-              )
-            }),
+          None => folder.get_workspace_info(&workspace_id).map(|workspace| {
+            (
+              true,
+              workspace.id,
+              workspace
+                .child_views
+                .items
+                .into_iter()
+                .map(|view| view.id)
+                .collect::<Vec<String>>(),
+            )
+          }),
           Some(parent_view) => Some((
             false,
             parent_view.id.clone(),

--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -256,17 +256,17 @@ impl FolderManager {
         .map_err(FlowyError::from);
 
       match result {
-        Ok(folder_updates) => {
+        Ok(folder_doc_state) => {
           info!(
             "Get folder updates via {}, doc state len: {}",
             self.cloud_service.service_name(),
-            folder_updates.len()
+            folder_doc_state.len()
           );
           self
             .initialize(
               user_id,
               workspace_id,
-              FolderInitDataSource::Cloud(folder_updates),
+              FolderInitDataSource::Cloud(folder_doc_state),
             )
             .await?;
         },
@@ -1117,18 +1117,6 @@ impl FolderManager {
       .collect::<Vec<_>>();
 
     Ok(snapshots)
-  }
-
-  /// Only expose this method for testing
-  #[cfg(debug_assertions)]
-  pub fn get_mutex_folder(&self) -> &Arc<MutexFolder> {
-    &self.mutex_folder
-  }
-
-  /// Only expose this method for testing
-  #[cfg(debug_assertions)]
-  pub fn get_cloud_service(&self) -> &Arc<dyn FolderCloudService> {
-    &self.cloud_service
   }
 
   pub fn set_views_visibility(&self, view_ids: Vec<String>, is_public: bool) {

--- a/frontend/rust-lib/flowy-folder/src/manager_init.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_init.rs
@@ -1,22 +1,14 @@
+use crate::manager::{FolderInitDataSource, FolderManager};
+use crate::manager_observer::*;
+use crate::user_default::DefaultFolderBuilder;
+use collab::core::collab::DataSource;
 use collab_entity::CollabType;
-
 use collab_folder::{Folder, FolderNotify, UserId};
+use collab_integrate::CollabKVDB;
+use flowy_error::{FlowyError, FlowyResult};
+use std::sync::{Arc, Weak};
 use tokio::task::spawn_blocking;
 use tracing::{event, Level};
-
-use collab_integrate::CollabKVDB;
-
-use flowy_error::{FlowyError, FlowyResult};
-
-use collab::core::collab::DataSource;
-use std::sync::{Arc, Weak};
-
-use crate::manager::{FolderInitDataSource, FolderManager};
-use crate::manager_observer::{
-  subscribe_folder_snapshot_state_changed, subscribe_folder_sync_state_changed,
-  subscribe_folder_trash_changed, subscribe_folder_view_changed,
-};
-use crate::user_default::DefaultFolderBuilder;
 
 impl FolderManager {
   /// Called immediately after the application launched if the user already sign in/sign up.
@@ -152,10 +144,28 @@ impl FolderManager {
     *self.mutex_folder.write() = Some(folder);
 
     let weak_mutex_folder = Arc::downgrade(&self.mutex_folder);
-    subscribe_folder_sync_state_changed(workspace_id.clone(), folder_state_rx, &weak_mutex_folder);
-    subscribe_folder_snapshot_state_changed(workspace_id.clone(), &weak_mutex_folder);
-    subscribe_folder_trash_changed(workspace_id.clone(), section_change_rx, &weak_mutex_folder);
-    subscribe_folder_view_changed(workspace_id.clone(), view_rx, &weak_mutex_folder);
+    subscribe_folder_sync_state_changed(
+      workspace_id.clone(),
+      folder_state_rx,
+      Arc::downgrade(&self.user),
+    );
+    subscribe_folder_snapshot_state_changed(
+      workspace_id.clone(),
+      &weak_mutex_folder,
+      Arc::downgrade(&self.user),
+    );
+    subscribe_folder_trash_changed(
+      workspace_id.clone(),
+      section_change_rx,
+      &weak_mutex_folder,
+      Arc::downgrade(&self.user),
+    );
+    subscribe_folder_view_changed(
+      workspace_id.clone(),
+      view_rx,
+      &weak_mutex_folder,
+      Arc::downgrade(&self.user),
+    );
     Ok(())
   }
 

--- a/frontend/rust-lib/flowy-folder/src/manager_init.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_init.rs
@@ -8,7 +8,7 @@ use collab_integrate::CollabKVDB;
 use flowy_error::{FlowyError, FlowyResult};
 use std::sync::{Arc, Weak};
 use tokio::task::spawn_blocking;
-use tracing::{event, Level};
+use tracing::{event, info, Level};
 
 impl FolderManager {
   /// Called immediately after the application launched if the user already sign in/sign up.
@@ -141,6 +141,9 @@ impl FolderManager {
       });
     }
 
+    if let Some(old_folder) = self.mutex_folder.write().take() {
+      info!("remove old folder: {}", old_folder.get_workspace_id());
+    }
     *self.mutex_folder.write() = Some(folder);
 
     let weak_mutex_folder = Arc::downgrade(&self.mutex_folder);

--- a/frontend/rust-lib/flowy-folder/src/manager_init.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_init.rs
@@ -155,9 +155,9 @@ impl FolderManager {
 
     let weak_mutex_folder = Arc::downgrade(&self.mutex_folder);
     subscribe_folder_sync_state_changed(workspace_id.clone(), folder_state_rx, &weak_mutex_folder);
-    subscribe_folder_snapshot_state_changed(workspace_id, &weak_mutex_folder);
-    subscribe_folder_trash_changed(section_change_rx, &weak_mutex_folder);
-    subscribe_folder_view_changed(view_rx, &weak_mutex_folder);
+    subscribe_folder_snapshot_state_changed(workspace_id.clone(), &weak_mutex_folder);
+    subscribe_folder_trash_changed(workspace_id.clone(), section_change_rx, &weak_mutex_folder);
+    subscribe_folder_view_changed(workspace_id.clone(), view_rx, &weak_mutex_folder);
     Ok(())
   }
 

--- a/frontend/rust-lib/flowy-folder/src/manager_init.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_init.rs
@@ -34,9 +34,7 @@ impl FolderManager {
       workspace_id,
       initial_data
     );
-    *self.workspace_id.write() = Some(workspace_id.to_string());
     let workspace_id = workspace_id.to_string();
-
     // Get the collab db for the user with given user id.
     let collab_db = self.user.collab_db(uid)?;
 

--- a/frontend/rust-lib/flowy-folder/src/manager_init.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_init.rs
@@ -142,6 +142,7 @@ impl FolderManager {
     }
 
     if let Some(old_folder) = self.mutex_folder.write().take() {
+      old_folder.close();
       info!("remove old folder: {}", old_folder.get_workspace_id());
     }
     *self.mutex_folder.write() = Some(folder);

--- a/frontend/rust-lib/flowy-folder/src/manager_test_util.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager_test_util.rs
@@ -1,0 +1,32 @@
+use crate::manager::{FolderManager, FolderUser, MutexFolder};
+use crate::view_operation::FolderOperationHandlers;
+use collab_integrate::collab_builder::AppFlowyCollabBuilder;
+use flowy_folder_pub::cloud::FolderCloudService;
+use flowy_search_pub::entities::FolderIndexManager;
+use std::sync::Arc;
+
+impl FolderManager {
+  pub fn get_mutex_folder(&self) -> Arc<MutexFolder> {
+    self.mutex_folder.clone()
+  }
+
+  pub fn get_cloud_service(&self) -> Arc<dyn FolderCloudService> {
+    self.cloud_service.clone()
+  }
+
+  pub fn get_user(&self) -> Arc<dyn FolderUser> {
+    self.user.clone()
+  }
+
+  pub fn get_indexer(&self) -> Arc<dyn FolderIndexManager> {
+    self.folder_indexer.clone()
+  }
+
+  pub fn get_collab_builder(&self) -> Arc<AppFlowyCollabBuilder> {
+    self.collab_builder.clone()
+  }
+
+  pub fn get_operation_handlers(&self) -> FolderOperationHandlers {
+    self.operation_handlers.clone()
+  }
+}

--- a/frontend/rust-lib/flowy-search/src/services/manager.rs
+++ b/frontend/rust-lib/flowy-search/src/services/manager.rs
@@ -1,14 +1,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::notifier::{SearchNotifier, SearchResultChanged, SearchResultReceiverRunner};
+use crate::entities::{SearchFilterPB, SearchResultNotificationPB, SearchResultPB};
 use flowy_error::FlowyResult;
 use lib_dispatch::prelude::af_spawn;
 use tokio::{sync::broadcast, task::spawn_blocking};
-
-use crate::entities::{SearchFilterPB, SearchResultNotificationPB, SearchResultPB};
-
-use super::notifier::{SearchNotifier, SearchResultChanged, SearchResultReceiverRunner};
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum SearchType {
   Folder,

--- a/frontend/rust-lib/flowy-server/src/af_cloud/define.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/define.rs
@@ -1,4 +1,12 @@
+use flowy_error::FlowyResult;
+
 pub const USER_SIGN_IN_URL: &str = "sign_in_url";
 pub const USER_UUID: &str = "uuid";
 pub const USER_EMAIL: &str = "email";
 pub const USER_DEVICE_ID: &str = "device_id";
+
+/// Represents a user that is currently using the server.
+pub trait ServerUser: Send + Sync {
+  /// different user might return different workspace id.
+  fn workspace_id(&self) -> FlowyResult<String>;
+}

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/document.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/document.rs
@@ -5,6 +5,7 @@ use collab::core::origin::CollabOrigin;
 use collab_document::document::Document;
 use collab_entity::CollabType;
 use std::sync::Arc;
+use tracing::instrument;
 
 use flowy_document_pub::cloud::*;
 use flowy_error::FlowyError;
@@ -23,6 +24,7 @@ impl<T> DocumentCloudService for AFCloudDocumentCloudServiceImpl<T>
 where
   T: AFServer,
 {
+  #[instrument(level = "debug", skip_all, fields(document_id = %document_id))]
   fn get_document_doc_state(
     &self,
     document_id: &str,
@@ -48,7 +50,11 @@ where
         .doc_state
         .to_vec();
 
-      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(
+        &workspace_id,
+        &cloned_user,
+        format!("get document doc state:{}", document_id),
+      )?;
 
       Ok(doc_state)
     })
@@ -63,6 +69,7 @@ where
     FutureResult::new(async move { Ok(vec![]) })
   }
 
+  #[instrument(level = "debug", skip_all)]
   fn get_document_data(
     &self,
     document_id: &str,
@@ -87,7 +94,11 @@ where
         .encode_collab
         .doc_state
         .to_vec();
-      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(
+        &workspace_id,
+        &cloned_user,
+        format!("Get {} document", document_id),
+      )?;
       let document = Document::from_doc_state(
         CollabOrigin::Empty,
         DataSource::DocStateV1(doc_state),

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/document.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/document.rs
@@ -4,14 +4,20 @@ use collab::core::collab::DataSource;
 use collab::core::origin::CollabOrigin;
 use collab_document::document::Document;
 use collab_entity::CollabType;
+use std::sync::Arc;
 
 use flowy_document_pub::cloud::*;
 use flowy_error::FlowyError;
 use lib_infra::future::FutureResult;
 
+use crate::af_cloud::define::ServerUser;
+use crate::af_cloud::impls::util::check_request_workspace_id_is_match;
 use crate::af_cloud::AFServer;
 
-pub(crate) struct AFCloudDocumentCloudServiceImpl<T>(pub T);
+pub(crate) struct AFCloudDocumentCloudServiceImpl<T> {
+  pub inner: T,
+  pub user: Arc<dyn ServerUser>,
+}
 
 impl<T> DocumentCloudService for AFCloudDocumentCloudServiceImpl<T>
 where
@@ -23,11 +29,12 @@ where
     workspace_id: &str,
   ) -> FutureResult<Vec<u8>, FlowyError> {
     let workspace_id = workspace_id.to_string();
-    let try_get_client = self.0.try_get_client();
+    let try_get_client = self.inner.try_get_client();
     let document_id = document_id.to_string();
+    let cloned_user = self.user.clone();
     FutureResult::new(async move {
       let params = QueryCollabParams {
-        workspace_id,
+        workspace_id: workspace_id.clone(),
         inner: QueryCollab {
           object_id: document_id.to_string(),
           collab_type: CollabType::Document,
@@ -40,6 +47,9 @@ where
         .encode_collab
         .doc_state
         .to_vec();
+
+      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+
       Ok(doc_state)
     })
   }
@@ -58,12 +68,13 @@ where
     document_id: &str,
     workspace_id: &str,
   ) -> FutureResult<Option<DocumentData>, Error> {
-    let try_get_client = self.0.try_get_client();
+    let try_get_client = self.inner.try_get_client();
     let document_id = document_id.to_string();
     let workspace_id = workspace_id.to_string();
+    let cloned_user = self.user.clone();
     FutureResult::new(async move {
       let params = QueryCollabParams {
-        workspace_id,
+        workspace_id: workspace_id.clone(),
         inner: QueryCollab {
           object_id: document_id.clone(),
           collab_type: CollabType::Document,
@@ -76,6 +87,7 @@ where
         .encode_collab
         .doc_state
         .to_vec();
+      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
       let document = Document::from_doc_state(
         CollabOrigin::Empty,
         DataSource::DocStateV1(doc_state),

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
@@ -7,6 +7,7 @@ use collab::core::origin::CollabOrigin;
 use collab_entity::CollabType;
 use collab_folder::RepeatedViewIdentifier;
 use std::sync::Arc;
+use tracing::instrument;
 
 use flowy_error::FlowyError;
 use flowy_folder_pub::cloud::{
@@ -79,7 +80,7 @@ where
       Ok(records)
     })
   }
-
+  #[instrument(level = "debug", skip_all)]
   fn get_folder_data(
     &self,
     workspace_id: &str,
@@ -104,7 +105,7 @@ where
         .encode_collab
         .doc_state
         .to_vec();
-      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(&workspace_id, &cloned_user, "get folder data")?;
       let folder = Folder::from_collab_doc_state(
         uid,
         CollabOrigin::Empty,
@@ -124,6 +125,7 @@ where
     FutureResult::new(async move { Ok(vec![]) })
   }
 
+  #[instrument(level = "debug", skip_all)]
   fn get_folder_doc_state(
     &self,
     workspace_id: &str,
@@ -150,7 +152,7 @@ where
         .encode_collab
         .doc_state
         .to_vec();
-      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(&workspace_id, &cloned_user, "get folder doc state")?;
       Ok(doc_state)
     })
   }

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/folder.rs
@@ -104,7 +104,7 @@ where
         &workspace_id,
         vec![],
       )?;
-      Ok(folder.get_folder_data())
+      Ok(folder.get_folder_data(&workspace_id))
     })
   }
 

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/mod.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/mod.rs
@@ -9,3 +9,4 @@ mod document;
 mod file_storage;
 mod folder;
 mod user;
+mod util;

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
@@ -24,11 +24,12 @@ use lib_infra::box_any::BoxAny;
 use lib_infra::future::FutureResult;
 use uuid::Uuid;
 
-use crate::af_cloud::define::USER_SIGN_IN_URL;
+use crate::af_cloud::define::{ServerUser, USER_SIGN_IN_URL};
 use crate::af_cloud::impls::user::dto::{
   af_update_from_update_params, from_af_workspace_member, to_af_role, user_profile_from_af_profile,
 };
 use crate::af_cloud::impls::user::util::encryption_type_from_profile;
+use crate::af_cloud::impls::util::check_request_workspace_id_is_match;
 use crate::af_cloud::{AFCloudClient, AFServer};
 
 use super::dto::{from_af_workspace_invitation_status, to_workspace_invitation_status};
@@ -36,13 +37,19 @@ use super::dto::{from_af_workspace_invitation_status, to_workspace_invitation_st
 pub(crate) struct AFCloudUserAuthServiceImpl<T> {
   server: T,
   user_change_recv: RwLock<Option<tokio::sync::mpsc::Receiver<UserUpdate>>>,
+  user: Arc<dyn ServerUser>,
 }
 
 impl<T> AFCloudUserAuthServiceImpl<T> {
-  pub(crate) fn new(server: T, user_change_recv: tokio::sync::mpsc::Receiver<UserUpdate>) -> Self {
+  pub(crate) fn new(
+    server: T,
+    user_change_recv: tokio::sync::mpsc::Receiver<UserUpdate>,
+    user: Arc<dyn ServerUser>,
+  ) -> Self {
     Self {
       server,
       user_change_recv: RwLock::new(Some(user_change_recv)),
+      user,
     }
   }
 }
@@ -171,11 +178,17 @@ where
     _credential: UserCredentials,
   ) -> FutureResult<UserProfile, FlowyError> {
     let try_get_client = self.server.try_get_client();
+    let cloned_user = self.user.clone();
     FutureResult::new(async move {
+      let expected_workspace_id = cloned_user.workspace_id()?;
       let client = try_get_client?;
       let profile = client.get_profile().await?;
       let token = client.get_token()?;
       let profile = user_profile_from_af_profile(token, profile)?;
+
+      // Discard the response if the user has switched to a new workspace. This avoids updating the
+      // user profile with potentially outdated information when the workspace ID no longer matches.
+      check_request_workspace_id_is_match(&expected_workspace_id, &cloned_user)?;
       Ok(profile)
     })
   }
@@ -324,16 +337,17 @@ where
     let workspace_id = workspace_id.to_string();
     let object_id = object_id.to_string();
     let try_get_client = self.server.try_get_client();
-    FutureResult::new(async {
+    let cloned_user = self.user.clone();
+    FutureResult::new(async move {
       let params = QueryCollabParams {
-        workspace_id,
+        workspace_id: workspace_id.clone(),
         inner: QueryCollab {
           object_id,
           collab_type: CollabType::UserAwareness,
         },
       };
-
       let resp = try_get_client?.get_collab(params).await?;
+      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
       Ok(resp.encode_collab.doc_state.to_vec())
     })
   }

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
@@ -13,6 +13,7 @@ use client_api::entity::{QueryCollab, QueryCollabParams};
 use client_api::{Client, ClientConfiguration};
 use collab_entity::{CollabObject, CollabType};
 use parking_lot::RwLock;
+use tracing::instrument;
 
 use flowy_error::{ErrorCode, FlowyError, FlowyResult};
 use flowy_user_pub::cloud::{UserCloudService, UserCollabParams, UserUpdate, UserUpdateReceiver};
@@ -173,6 +174,7 @@ where
     })
   }
 
+  #[instrument(level = "debug", skip_all)]
   fn get_user_profile(
     &self,
     _credential: UserCredentials,
@@ -188,7 +190,11 @@ where
 
       // Discard the response if the user has switched to a new workspace. This avoids updating the
       // user profile with potentially outdated information when the workspace ID no longer matches.
-      check_request_workspace_id_is_match(&expected_workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(
+        &expected_workspace_id,
+        &cloned_user,
+        "get user profile",
+      )?;
       Ok(profile)
     })
   }
@@ -328,6 +334,7 @@ where
     })
   }
 
+  #[instrument(level = "debug", skip_all)]
   fn get_user_awareness_doc_state(
     &self,
     _uid: i64,
@@ -347,7 +354,11 @@ where
         },
       };
       let resp = try_get_client?.get_collab(params).await?;
-      check_request_workspace_id_is_match(&workspace_id, &cloned_user)?;
+      check_request_workspace_id_is_match(
+        &workspace_id,
+        &cloned_user,
+        "get user awareness object",
+      )?;
       Ok(resp.encode_collab.doc_state.to_vec())
     })
   }

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
@@ -9,12 +9,15 @@ use tracing::warn;
 pub fn check_request_workspace_id_is_match(
   expected_workspace_id: &str,
   user: &Arc<dyn ServerUser>,
+  action: impl AsRef<str>,
 ) -> FlowyResult<()> {
   let actual_workspace_id = user.workspace_id()?;
   if expected_workspace_id != actual_workspace_id {
     warn!(
-      "Expect workspace_id: {}, actual workspace_id: {}",
-      expected_workspace_id, actual_workspace_id
+      "{}, expect workspace_id: {}, actual workspace_id: {}",
+      action.as_ref(),
+      expected_workspace_id,
+      actual_workspace_id
     );
 
     return Err(

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
@@ -13,7 +13,7 @@ pub fn check_request_workspace_id_is_match(
   let actual_workspace_id = user.workspace_id()?;
   if expected_workspace_id != actual_workspace_id {
     warn!(
-      "Expected workspace id: {}, actual workspace id: {}",
+      "Expect workspace_id: {}, actual workspace_id: {}",
       expected_workspace_id, actual_workspace_id
     );
 

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/util.rs
@@ -1,0 +1,26 @@
+use crate::af_cloud::define::ServerUser;
+use flowy_error::{FlowyError, FlowyResult};
+use std::sync::Arc;
+use tracing::warn;
+
+/// Validates the workspace_id provided in the request.
+/// It checks that the workspace_id from the request matches the current user's active workspace_id.
+/// This ensures that the operation is being performed in the correct workspace context, enhancing security.
+pub fn check_request_workspace_id_is_match(
+  expected_workspace_id: &str,
+  user: &Arc<dyn ServerUser>,
+) -> FlowyResult<()> {
+  let actual_workspace_id = user.workspace_id()?;
+  if expected_workspace_id != actual_workspace_id {
+    warn!(
+      "Expected workspace id: {}, actual workspace id: {}",
+      expected_workspace_id, actual_workspace_id
+    );
+
+    return Err(
+      FlowyError::internal()
+        .with_context("Current workspace was changed when processing the request"),
+    );
+  }
+  Ok(())
+}

--- a/frontend/rust-lib/flowy-server/src/af_cloud/server.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/server.rs
@@ -17,6 +17,7 @@ use tokio_stream::wrappers::WatchStream;
 use tracing::{error, event, info, warn};
 use uuid::Uuid;
 
+use crate::af_cloud::define::ServerUser;
 use flowy_database_pub::cloud::DatabaseCloudService;
 use flowy_document_pub::cloud::DocumentCloudService;
 use flowy_error::{ErrorCode, FlowyError};
@@ -42,6 +43,7 @@ pub struct AppFlowyCloudServer {
   network_reachable: Arc<AtomicBool>,
   pub device_id: String,
   ws_client: Arc<WSClient>,
+  user: Arc<dyn ServerUser>,
 }
 
 impl AppFlowyCloudServer {
@@ -50,6 +52,7 @@ impl AppFlowyCloudServer {
     enable_sync: bool,
     mut device_id: String,
     client_version: &str,
+    user: Arc<dyn ServerUser>,
   ) -> Self {
     // The device id can't be empty, so we generate a new one if it is.
     if device_id.is_empty() {
@@ -83,6 +86,7 @@ impl AppFlowyCloudServer {
       network_reachable,
       device_id,
       ws_client,
+      user,
     }
   }
 
@@ -166,21 +170,30 @@ impl AppFlowyServer for AppFlowyCloudServer {
     let server = AFServerImpl {
       client: self.get_client(),
     };
-    Arc::new(AFCloudFolderCloudServiceImpl(server))
+    Arc::new(AFCloudFolderCloudServiceImpl {
+      inner: server,
+      user: self.user.clone(),
+    })
   }
 
   fn database_service(&self) -> Arc<dyn DatabaseCloudService> {
     let server = AFServerImpl {
       client: self.get_client(),
     };
-    Arc::new(AFCloudDatabaseCloudServiceImpl(server))
+    Arc::new(AFCloudDatabaseCloudServiceImpl {
+      inner: server,
+      user: self.user.clone(),
+    })
   }
 
   fn document_service(&self) -> Arc<dyn DocumentCloudService> {
     let server = AFServerImpl {
       client: self.get_client(),
     };
-    Arc::new(AFCloudDocumentCloudServiceImpl(server))
+    Arc::new(AFCloudDocumentCloudServiceImpl {
+      inner: server,
+      user: self.user.clone(),
+    })
   }
 
   fn subscribe_ws_state(&self) -> Option<WSConnectStateReceiver> {

--- a/frontend/rust-lib/flowy-server/src/af_cloud/server.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/server.rs
@@ -163,7 +163,11 @@ impl AppFlowyServer for AppFlowyCloudServer {
       }
     });
 
-    Arc::new(AFCloudUserAuthServiceImpl::new(server, rx))
+    Arc::new(AFCloudUserAuthServiceImpl::new(
+      server,
+      rx,
+      self.user.clone(),
+    ))
   }
 
   fn folder_service(&self) -> Arc<dyn FolderCloudService> {

--- a/frontend/rust-lib/flowy-server/src/supabase/api/folder.rs
+++ b/frontend/rust-lib/flowy-server/src/supabase/api/folder.rs
@@ -109,7 +109,7 @@ where
         &workspace_id,
         vec![],
       )?;
-      Ok(folder.get_folder_data())
+      Ok(folder.get_folder_data(&workspace_id))
     })
   }
 

--- a/frontend/rust-lib/flowy-server/tests/af_cloud_test/util.rs
+++ b/frontend/rust-lib/flowy-server/tests/af_cloud_test/util.rs
@@ -2,8 +2,10 @@ use client_api::ClientConfiguration;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use flowy_error::FlowyResult;
 use uuid::Uuid;
 
+use flowy_server::af_cloud::define::ServerUser;
 use flowy_server::af_cloud::AppFlowyCloudServer;
 use flowy_server::supabase::define::{USER_DEVICE_ID, USER_SIGN_IN_URL};
 use flowy_server_pub::af_cloud_config::AFCloudConfiguration;
@@ -31,7 +33,15 @@ pub fn af_cloud_server(config: AFCloudConfiguration) -> Arc<AppFlowyCloudServer>
     true,
     fake_device_id,
     "0.5.1",
+    Arc::new(FakeServerUserImpl),
   ))
+}
+
+struct FakeServerUserImpl;
+impl ServerUser for FakeServerUserImpl {
+  fn workspace_id(&self) -> FlowyResult<String> {
+    todo!()
+  }
 }
 
 pub async fn generate_sign_in_url(user_email: &str, config: &AFCloudConfiguration) -> String {

--- a/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
+++ b/frontend/rust-lib/flowy-server/tests/supabase_test/util.rs
@@ -134,7 +134,7 @@ pub async fn print_encryption_folder_snapshot(
   ));
   let folder_data = Folder::open(uid, collab, None)
     .unwrap()
-    .get_folder_data()
+    .get_folder_data(folder_id)
     .unwrap();
   let json = serde_json::to_value(folder_data).unwrap();
   println!("{}", serde_json::to_string_pretty(&json).unwrap());

--- a/frontend/rust-lib/flowy-user/src/anon_user/migrate_anon_user_collab.rs
+++ b/frontend/rust-lib/flowy-user/src/anon_user/migrate_anon_user_collab.rs
@@ -226,11 +226,12 @@ where
     None,
   )
   .map_err(|err| PersistenceError::InvalidData(err.to_string()))?;
-  let mut folder_data = old_folder
-    .get_folder_data()
-    .ok_or(PersistenceError::Internal(anyhow!(
-      "Can't migrate the folder data"
-    )))?;
+  let mut folder_data =
+    old_folder
+      .get_folder_data(old_workspace_id)
+      .ok_or(PersistenceError::Internal(anyhow!(
+        "Can't migrate the folder data"
+      )))?;
 
   if let Some(old_fav_map) = folder_data.favorites.remove(&old_user_id) {
     let fav_map = old_fav_map

--- a/frontend/rust-lib/flowy-user/src/anon_user/sync_supabase_user_collab.rs
+++ b/frontend/rust-lib/flowy-user/src/anon_user/sync_supabase_user_collab.rs
@@ -49,7 +49,7 @@ pub async fn sync_supabase_user_data_to_cloud(
   )
   .await;
 
-  let views = folder.lock().get_current_workspace_views();
+  let views = folder.lock().get_views_belong_to(&workspace_id);
   for view in views {
     let view_id = view.id.clone();
     if let Err(err) = sync_view(

--- a/frontend/rust-lib/flowy-user/src/migrations/document_empty_content.rs
+++ b/frontend/rust-lib/flowy-user/src/migrations/document_empty_content.rs
@@ -53,17 +53,18 @@ impl UserDataMigration for HistoricalEmptyDocumentMigration {
 
       let folder = Folder::open(session.user_id, folder_collab, None)
         .map_err(|err| PersistenceError::Internal(err.into()))?;
-      let migration_views = folder.get_workspace_views();
-
-      // For historical reasons, the first level documents are empty. So migrate them by inserting
-      // the default document data.
-      for view in migration_views {
-        if migrate_empty_document(write_txn, &origin, &view, session.user_id).is_err() {
-          event!(
-            tracing::Level::ERROR,
-            "Failed to migrate document {}",
-            view.id
-          );
+      if let Ok(workspace_id) = folder.try_get_workspace_id() {
+        let migration_views = folder.views.get_views_belong_to(&workspace_id);
+        // For historical reasons, the first level documents are empty. So migrate them by inserting
+        // the default document data.
+        for view in migration_views {
+          if migrate_empty_document(write_txn, &origin, &view, session.user_id).is_err() {
+            event!(
+              tracing::Level::ERROR,
+              "Failed to migrate document {}",
+              view.id
+            );
+          }
         }
       }
 

--- a/frontend/rust-lib/flowy-user/src/services/authenticate_user.rs
+++ b/frontend/rust-lib/flowy-user/src/services/authenticate_user.rs
@@ -16,7 +16,7 @@ use tracing::{error, info};
 const SQLITE_VACUUM_042: &str = "sqlite_vacuum_042_version";
 
 pub struct AuthenticateUser {
-  pub(crate) user_config: UserConfig,
+  pub user_config: UserConfig,
   pub(crate) database: Arc<UserDB>,
   pub(crate) user_paths: UserPaths,
   store_preferences: Arc<StorePreferences>,

--- a/frontend/rust-lib/flowy-user/src/services/authenticate_user.rs
+++ b/frontend/rust-lib/flowy-user/src/services/authenticate_user.rs
@@ -67,6 +67,11 @@ impl AuthenticateUser {
     Ok(session.user_workspace.id)
   }
 
+  pub fn workspace_database_object_id(&self) -> FlowyResult<String> {
+    let session = self.get_session()?;
+    Ok(session.user_workspace.workspace_database_object_id.clone())
+  }
+
   pub fn get_collab_db(&self, uid: i64) -> FlowyResult<Weak<CollabKVDB>> {
     self
       .database

--- a/frontend/rust-lib/flowy-user/src/services/data_import/appflowy_data_import.rs
+++ b/frontend/rust-lib/flowy-user/src/services/data_import/appflowy_data_import.rs
@@ -509,7 +509,7 @@ where
   .map_err(|err| PersistenceError::InvalidData(err.to_string()))?;
 
   let other_folder_data = other_folder
-    .get_folder_data()
+    .get_folder_data(&other_session.user_workspace.id)
     .ok_or(PersistenceError::Internal(anyhow!(
       "Can't read the folder data"
     )))?;

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager.rs
@@ -518,7 +518,6 @@ impl UserManager {
 
   pub async fn prepare_user(&self, session: &Session) {
     let _ = self.authenticate_user.database.close(session.user_id);
-    self.prepare_collab(session);
   }
 
   pub async fn prepare_backup(&self, session: &Session) {
@@ -722,11 +721,6 @@ impl UserManager {
       .save_user(uid, (user_profile, authenticator.clone()).into())
       .await?;
     Ok(())
-  }
-
-  fn prepare_collab(&self, session: &Session) {
-    let collab_builder = self.collab_builder.upgrade().unwrap();
-    collab_builder.initialize(session.user_workspace.id.clone());
   }
 
   async fn handler_user_update(&self, user_update: UserUpdate) -> FlowyResult<()> {

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_awareness.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_awareness.rs
@@ -136,6 +136,7 @@ impl UserManager {
     let weak_builder = self.collab_builder.clone();
     let cloned_is_loading = self.is_loading_awareness.clone();
     let session = session.clone();
+    let workspace_id = session.user_workspace.id.clone();
     tokio::spawn(async move {
       if cloned_is_loading.load(Ordering::SeqCst) {
         return Ok(());
@@ -160,6 +161,7 @@ impl UserManager {
           Ok(data) => {
             trace!("Get user awareness collab from remote: {}", data.len());
             let collab = Self::collab_for_user_awareness(
+              &workspace_id,
               &weak_builder,
               session.user_id,
               &object_id,
@@ -173,6 +175,7 @@ impl UserManager {
             if err.is_record_not_found() {
               info!("User awareness not found, creating new");
               let collab = Self::collab_for_user_awareness(
+                &workspace_id,
                 &weak_builder,
                 session.user_id,
                 &object_id,
@@ -206,6 +209,7 @@ impl UserManager {
   /// using a collaboration builder. This instance is specifically geared towards handling
   /// user awareness.
   async fn collab_for_user_awareness(
+    workspace_id: &str,
     collab_builder: &Weak<AppFlowyCollabBuilder>,
     uid: i64,
     object_id: &str,
@@ -218,6 +222,7 @@ impl UserManager {
     ))?;
     let collab = collab_builder
       .build(
+        workspace_id,
         uid,
         object_id,
         CollabType::UserAwareness,

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
@@ -146,16 +146,16 @@ impl UserManager {
       .authenticate_user
       .set_user_workspace(user_workspace.clone())?;
 
-    // let uid = self.user_id()?;
-    // if let Err(err) = self
-    //   .user_status_callback
-    //   .read()
-    //   .await
-    //   .open_workspace(uid, &user_workspace)
-    //   .await
-    // {
-    //   error!("Open workspace failed: {:?}", err);
-    // }
+    let uid = self.user_id()?;
+    if let Err(err) = self
+      .user_status_callback
+      .read()
+      .await
+      .open_workspace(uid, &user_workspace)
+      .await
+    {
+      error!("Open workspace failed: {:?}", err);
+    }
 
     Ok(())
   }

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
@@ -136,7 +136,6 @@ impl UserManager {
   #[instrument(skip(self), err)]
   pub async fn open_workspace(&self, workspace_id: &str) -> FlowyResult<()> {
     info!("open workspace: {}", workspace_id);
-    let uid = self.user_id()?;
     let user_workspace = self
       .cloud_services
       .get_user_service()?
@@ -146,15 +145,17 @@ impl UserManager {
     self
       .authenticate_user
       .set_user_workspace(user_workspace.clone())?;
-    if let Err(err) = self
-      .user_status_callback
-      .read()
-      .await
-      .open_workspace(uid, &user_workspace)
-      .await
-    {
-      error!("Open workspace failed: {:?}", err);
-    }
+
+    // let uid = self.user_id()?;
+    // if let Err(err) = self
+    //   .user_status_callback
+    //   .read()
+    //   .await
+    //   .open_workspace(uid, &user_workspace)
+    //   .await
+    // {
+    //   error!("Open workspace failed: {:?}", err);
+    // }
 
     Ok(())
   }


### PR DESCRIPTION
1. Retrieve Workspace ID: Obtain the workspace ID from a single source of truth.
2. Validate Workspace ID on HTTP Response: When an HTTP request completes, check if the workspace ID from the request matches the current user's workspace ID. Discard the response if the IDs do not match to prevent processing outdated or incorrect data.