### PR TITLE
fix: color selection compatible with older versions

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
@@ -172,7 +172,9 @@ class _RecentCover extends StatelessWidget {
 
     if (type == PageStyleCoverImageType.pureColor) {
       return ColoredBox(
-        color: FlowyTint.fromId(value).color(context),
+        color: FlowyTint.fromId(value)?.color(context) ??
+            value.tryToColor() ??
+            Colors.white,
       );
     }
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/recent_folder/mobile_recent_view.dart
@@ -7,11 +7,11 @@ import 'package:appflowy/plugins/base/emoji/emoji_text.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy/shared/appflowy_network_image.dart';
 import 'package:appflowy/shared/flowy_gradient_colors.dart';
+import 'package:appflowy/util/string_extension.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
-import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -171,11 +171,12 @@ class _RecentCover extends StatelessWidget {
     }
 
     if (type == PageStyleCoverImageType.pureColor) {
-      return ColoredBox(
-        color: FlowyTint.fromId(value)?.color(context) ??
-            value.tryToColor() ??
-            Colors.white,
-      );
+      final color = value.coverColor(context);
+      if (color != null) {
+        return ColoredBox(
+          color: color,
+        );
+      }
     }
 
     if (type == PageStyleCoverImageType.gradientColor) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/document_immersive_cover.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/document_immersive_cover.dart
@@ -210,7 +210,8 @@ class _DocumentImmersiveCoverState extends State<DocumentImmersiveCover> {
       return Container(
         height: height,
         width: double.infinity,
-        color: FlowyTint.fromId(cover.value).color(context),
+        color: FlowyTint.fromId(cover.value)?.color(context) ??
+            cover.value.tryToColor(),
       );
     }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/document_immersive_cover.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/cover/document_immersive_cover.dart
@@ -10,12 +10,12 @@ import 'package:appflowy/plugins/document/presentation/editor_plugins/header/emo
 import 'package:appflowy/shared/appflowy_network_image.dart';
 import 'package:appflowy/shared/flowy_gradient_colors.dart';
 import 'package:appflowy/shared/google_fonts_extension.dart';
+import 'package:appflowy/util/string_extension.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
 import 'package:appflowy/workspace/application/view/view_bloc.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
-import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/ignore_parent_gesture.dart';
 import 'package:flutter/material.dart';
@@ -210,8 +210,7 @@ class _DocumentImmersiveCoverState extends State<DocumentImmersiveCover> {
       return Container(
         height: height,
         width: double.infinity,
-        color: FlowyTint.fromId(cover.value)?.color(context) ??
-            cover.value.tryToColor(),
+        color: cover.value.coverColor(context),
       );
     }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/desktop_cover.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/desktop_cover.dart
@@ -89,10 +89,14 @@ class _DesktopCoverState extends State<DesktopCover> {
           }
 
           if (type == PageStyleCoverImageType.pureColor) {
+            // try to parse the color from the tint id,
+            //  if it fails, try to parse the color as a hex string
+            final color = FlowyTint.fromId(cover.value)?.color(context) ??
+                cover.value.tryToColor();
             return Container(
               height: height,
               width: double.infinity,
-              color: FlowyTint.fromId(cover.value).color(context),
+              color: color,
             );
           }
 

--- a/frontend/appflowy_flutter/lib/util/string_extension.dart
+++ b/frontend/appflowy_flutter/lib/util/string_extension.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
-
 import 'package:appflowy/shared/patterns/common_patterns.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flowy_infra/theme_extension.dart';
+import 'package:flutter/material.dart';
 
 extension StringExtension on String {
   static const _specialCharacters = r'\/:*?"<>| ';
@@ -35,4 +36,13 @@ extension StringExtension on String {
 
   /// Returns true if the string is a appflowy cloud url.
   bool get isAppFlowyCloudUrl => appflowyCloudUrlRegex.hasMatch(this);
+
+  /// Returns the color of the string.
+  ///
+  /// ONLY used for the cover.
+  Color? coverColor(BuildContext context) {
+    // try to parse the color from the tint id,
+    //  if it fails, try to parse the color as a hex string
+    return FlowyTint.fromId(this)?.color(context) ?? tryToColor();
+  }
 }

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/theme_extension.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/theme_extension.dart
@@ -189,13 +189,15 @@ enum FlowyTint {
     }
   }
 
-  static FlowyTint fromId(String id) {
-    return FlowyTint.values.firstWhere(
-      (element) => element.id == id,
-      orElse: () => FlowyTint.tint1,
-    );
+  static FlowyTint? fromId(String id) {
+    for (final value in FlowyTint.values) {
+      if (value.id == id) {
+        return value;
+      }
+    }
+    return null;
   }
-  
+
   Color color(BuildContext context) => switch (this) {
         FlowyTint.tint1 => AFThemeExtension.of(context).tint1,
         FlowyTint.tint2 => AFThemeExtension.of(context).tint2,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

In the older versions, the cover color used a hex string as its value. Now, we use a tint color that adjusts based on the theme. Therefore, I added compatible logic for the hex string.


<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
