### PR TITLE
fix: show row name instead of db view name when screen is small on br…

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database_document/presentation/database_document_title.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_document/presentation/database_document_title.dart
@@ -54,12 +54,7 @@ class ViewTitleBarWithRow extends StatelessWidget {
               return Visibility(
                 visible: maxWidth < constraints.maxWidth,
                 // if the width is too small, only show one view title bar without the ancestors
-                replacement: _ViewTitle(
-                  key: ValueKey(state.ancestors.last),
-                  view: state.ancestors.last,
-                  maxTitleWidth: constraints.maxWidth - 50.0,
-                  onUpdated: () {},
-                ),
+                replacement: _buildRowName(),
                 child: Row(
                   // refresh the view title bar when the ancestors changed
                   key: ValueKey(state.ancestors.hashCode),
@@ -104,42 +99,39 @@ class ViewTitleBarWithRow extends StatelessWidget {
   }
 
   Widget _buildRowName() {
-    return BlocBuilder<DatabaseDocumentTitleBloc, DatabaseDocumentTitleState>(
-      builder: (context, state) {
-        if (state.databaseController == null) {
-          return const SizedBox.shrink();
-        }
-        return _RowName(
-          cellBuilder: EditableCellBuilder(
-            databaseController: state.databaseController!,
-          ),
-          primaryFieldId: state.fieldId!,
-          rowId: rowId,
-        );
-      },
+    return _RowName(
+      rowId: rowId,
     );
   }
 }
 
 class _RowName extends StatelessWidget {
   const _RowName({
-    required this.cellBuilder,
-    required this.primaryFieldId,
     required this.rowId,
   });
 
-  final EditableCellBuilder cellBuilder;
-  final String primaryFieldId;
   final String rowId;
 
   @override
   Widget build(BuildContext context) {
-    return cellBuilder.buildCustom(
-      CellContext(
-        fieldId: primaryFieldId,
-        rowId: rowId,
-      ),
-      skinMap: EditableCellSkinMap(textSkin: _TitleSkin()),
+    return BlocBuilder<DatabaseDocumentTitleBloc, DatabaseDocumentTitleState>(
+      builder: (context, state) {
+        if (state.databaseController == null) {
+          return const SizedBox.shrink();
+        }
+
+        final cellBuilder = EditableCellBuilder(
+          databaseController: state.databaseController!,
+        );
+
+        return cellBuilder.buildCustom(
+          CellContext(
+            fieldId: state.fieldId!,
+            rowId: rowId,
+          ),
+          skinMap: EditableCellSkinMap(textSkin: _TitleSkin()),
+        );
+      },
     );
   }
 }
@@ -220,12 +212,10 @@ enum _ViewTitleBehavior {
 
 class _ViewTitle extends StatefulWidget {
   const _ViewTitle({
-    super.key,
     required this.view,
     this.behavior = _ViewTitleBehavior.editable,
-    this.maxTitleWidth = 180,
     required this.onUpdated,
-  });
+  }) : maxTitleWidth = 180;
 
   final ViewPB view;
   final _ViewTitleBehavior behavior;


### PR DESCRIPTION
before:
![image](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/89190b59-6ea5-4817-a2df-b7048f869cd5)

after: 
![image](https://github.com/AppFlowy-IO/AppFlowy/assets/71320345/f915f3cd-d81e-45e4-b784-0e4787de5fbc)


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
