### PR TITLE
chore: add limitation when importing csv file

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/manager.rs
+++ b/frontend/rust-lib/flowy-database2/src/manager.rs
@@ -347,6 +347,12 @@ impl DatabaseManager {
     })
     .await
     .map_err(internal_error)??;
+
+    // Currently, we only support importing up to 500 rows. We can support more rows in the future.
+    if !cfg!(debug_assertions) && params.rows.len() > 500 {
+      return Err(FlowyError::internal().with_context("The number of rows exceeds the limit"));
+    }
+
     let result = ImportResult {
       database_id: params.database_id.clone(),
       view_id: params.inline_view_id.clone(),


### PR DESCRIPTION
Importing CSV files may fail if the file contains too many rows. 







