### PR TITLE
fix: workspace id not match

### DIFF
--- a/frontend/rust-lib/flowy-document/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-document/src/event_handler.rs
@@ -56,6 +56,8 @@ pub(crate) async fn open_document_handler(
   let manager = upgrade_document(manager)?;
   let params: OpenDocumentParams = data.into_inner().try_into()?;
   let doc_id = params.document_id;
+  manager.open_document(&doc_id).await?;
+
   let document = manager.get_document(&doc_id).await?;
   let document_data = document.lock().get_document_data()?;
   data_result_ok(DocumentDataPB::from(document_data))


### PR DESCRIPTION
When switching to or creating a new workspace, there is a possibility that it will attempt to retrieve the previous workspace document using the current new workspace ID.

For example, SET_DOCUMENT_AWARENESS_LOCAL_STATE will get document async.
```text
{"msg":"[🟢 SET_DOCUMENT_AWARENESS_LOCAL_STATE - START]","time":"06-03 15:54:40","target":"flowy_document::manager"}
{"msg":"[🟢 GET_DOCUMENT - START]","time":"06-03 15:54:40","target":"flowy_document::manager"}
  2024-06-03 15:54:40 ERROR flowy_document::manager: error: Internal: "Call open document first"
    at flowy-document/src/manager.rs:138
    in flowy_document::managerget_document with doc_id: "949be6c4-3804-480b-aa5a-278358d06371"
    in flowy_document::managerset_document_awareness_local_state
```

