### PR TITLE
chore: remove deprecated

### DIFF
--- a/frontend/appflowy_flutter/lib/user/application/user_service.dart
+++ b/frontend/appflowy_flutter/lib/user/application/user_service.dart
@@ -175,16 +175,6 @@ class UserBackendService implements IUserBackendService {
     return UserEventGetWorkspaceMembers(data).send();
   }
 
-  Future<FlowyResult<void, FlowyError>> addWorkspaceMember(
-    String workspaceId,
-    String email,
-  ) async {
-    final data = AddWorkspaceMemberPB()
-      ..workspaceId = workspaceId
-      ..email = email;
-    return UserEventAddWorkspaceMember(data).send();
-  }
-
   Future<FlowyResult<void, FlowyError>> inviteWorkspaceMember(
     String workspaceId,
     String email, {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/members/workspace_member_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/members/workspace_member_bloc.dart
@@ -200,8 +200,6 @@ class WorkspaceMemberEvent with _$WorkspaceMemberEvent {
   const factory WorkspaceMemberEvent.getWorkspaceMembers() =
       GetWorkspaceMembers;
   const factory WorkspaceMemberEvent.addWorkspaceMember(String email) =
-      AddWorkspaceMember;
-  const factory WorkspaceMemberEvent.inviteWorkspaceMember(String email) =
       InviteWorkspaceMember;
   const factory WorkspaceMemberEvent.removeWorkspaceMember(String email) =
       RemoveWorkspaceMember;

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -94,7 +94,7 @@ validator = { version = "0.16.1", features = ["derive"] }
 
 # Please using the following command to update the revision id
 # Current directory: frontend
-# Run the script.add_workspace_members:
+# Run the script:
 # scripts/tool/update_client_api_rev.sh  new_rev_id
 # ⚠️⚠️⚠️️
 client-api = { git = "https://github.com/AppFlowy-IO/AppFlowy-Cloud", rev = "6262816043efeede8823d7a7ea252083adf407e9" }

--- a/frontend/rust-lib/event-integration-test/src/folder_event.rs
+++ b/frontend/rust-lib/event-integration-test/src/folder_event.rs
@@ -7,7 +7,7 @@ use flowy_folder::event_map::FolderEvent::*;
 use flowy_folder::{entities::*, ViewLayout};
 use flowy_search::services::manager::{SearchHandler, SearchType};
 use flowy_user::entities::{
-  AcceptWorkspaceInvitationPB, AddWorkspaceMemberPB, QueryWorkspacePB, RemoveWorkspaceMemberPB,
+  AcceptWorkspaceInvitationPB, QueryWorkspacePB, RemoveWorkspaceMemberPB,
   RepeatedWorkspaceInvitationPB, RepeatedWorkspaceMemberPB, WorkspaceMemberInvitationPB,
   WorkspaceMemberPB,
 };
@@ -19,21 +19,6 @@ use crate::event_builder::EventBuilder;
 use crate::EventIntegrationTest;
 
 impl EventIntegrationTest {
-  pub async fn add_workspace_member(&self, workspace_id: &str, email: &str) {
-    if let Some(err) = EventBuilder::new(self.clone())
-      .event(UserEvent::AddWorkspaceMember)
-      .payload(AddWorkspaceMemberPB {
-        workspace_id: workspace_id.to_string(),
-        email: email.to_string(),
-      })
-      .async_send()
-      .await
-      .error()
-    {
-      panic!("Add workspace member failed: {:?}", err);
-    }
-  }
-
   pub async fn invite_workspace_member(&self, workspace_id: &str, email: &str, role: Role) {
     EventBuilder::new(self.clone())
       .event(UserEvent::InviteWorkspaceMember)
@@ -43,6 +28,26 @@ impl EventIntegrationTest {
         role: role.into(),
       })
       .async_send()
+      .await;
+  }
+
+  // convenient function to add workspace member by inviting and accepting the invitation
+  pub async fn add_workspace_member(&self, workspace_id: &str, other: &EventIntegrationTest) {
+    let other_email = other.get_user_profile().await.unwrap().email;
+
+    self
+      .invite_workspace_member(workspace_id, &other_email, Role::Member)
+      .await;
+
+    let invitations = other.list_workspace_invitations().await;
+    let target_invi = invitations
+      .items
+      .into_iter()
+      .find(|i| i.workspace_id == workspace_id)
+      .unwrap();
+
+    other
+      .accept_workspace_invitation(&target_invi.invite_id)
       .await;
   }
 

--- a/frontend/rust-lib/event-integration-test/tests/user/af_cloud_test/member_test.rs
+++ b/frontend/rust-lib/event-integration-test/tests/user/af_cloud_test/member_test.rs
@@ -47,7 +47,7 @@ async fn af_cloud_add_workspace_member_test() {
   assert_eq!(members[0].email, user_1.email);
 
   test_1
-    .add_workspace_member(&user_1.workspace_id, &user_2.email)
+    .add_workspace_member(&user_1.workspace_id, &test_2)
     .await;
 
   let members = test_1.get_workspace_members(&user_1.workspace_id).await;
@@ -66,7 +66,7 @@ async fn af_cloud_delete_workspace_member_test() {
   let user_2 = test_2.af_cloud_sign_up().await;
 
   test_1
-    .add_workspace_member(&user_1.workspace_id, &user_2.email)
+    .add_workspace_member(&user_1.workspace_id, &test_2)
     .await;
 
   test_1
@@ -88,7 +88,7 @@ async fn af_cloud_leave_workspace_test() {
   let user_2 = test_2.af_cloud_sign_up().await;
 
   test_1
-    .add_workspace_member(&user_1.workspace_id, &user_2.email)
+    .add_workspace_member(&user_1.workspace_id, &test_2)
     .await;
 
   // test_2 should have 2 workspace

--- a/frontend/rust-lib/event-integration-test/tests/user/af_cloud_test/workspace_test.rs
+++ b/frontend/rust-lib/event-integration-test/tests/user/af_cloud_test/workspace_test.rs
@@ -182,7 +182,7 @@ async fn af_cloud_different_open_same_workspace_test() {
     }
 
     client_1
-      .add_workspace_member(&owner_profile.workspace_id, &client_profile.email)
+      .add_workspace_member(&owner_profile.workspace_id, &client)
       .await;
     clients.push((client, client_profile));
   }

--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
@@ -6,8 +6,7 @@ use client_api::entity::billing_dto::{
   SubscriptionPlan, SubscriptionStatus, WorkspaceSubscriptionPlan, WorkspaceSubscriptionStatus,
 };
 use client_api::entity::workspace_dto::{
-  CreateWorkspaceMember, CreateWorkspaceParam, PatchWorkspaceParam, WorkspaceMemberChangeset,
-  WorkspaceMemberInvitation,
+  CreateWorkspaceParam, PatchWorkspaceParam, WorkspaceMemberChangeset, WorkspaceMemberInvitation,
 };
 use client_api::entity::{
   AFRole, AFWorkspace, AFWorkspaceInvitation, AuthProvider, CollabParams, CreateCollabParams,
@@ -219,28 +218,6 @@ where
     FutureResult::new(async move {
       let workspaces = try_get_client?.get_workspaces().await?;
       to_user_workspaces(workspaces.0)
-    })
-  }
-
-  #[allow(deprecated)]
-  fn add_workspace_member(
-    &self,
-    user_email: String,
-    workspace_id: String,
-  ) -> FutureResult<(), FlowyError> {
-    let try_get_client = self.server.try_get_client();
-    FutureResult::new(async move {
-      // TODO(zack): add_workspace_members will be deprecated after finishing the invite logic. Don't forget to remove the #[allow(deprecated)]
-      try_get_client?
-        .add_workspace_members(
-          workspace_id,
-          vec![CreateWorkspaceMember {
-            email: user_email,
-            role: AFRole::Member,
-          }],
-        )
-        .await?;
-      Ok(())
     })
   }
 

--- a/frontend/rust-lib/flowy-user-pub/src/cloud.rs
+++ b/frontend/rust-lib/flowy-user-pub/src/cloud.rs
@@ -178,15 +178,6 @@ pub trait UserCloudService: Send + Sync + 'static {
   /// Deletes a workspace owned by the user.
   fn delete_workspace(&self, workspace_id: &str) -> FutureResult<(), FlowyError>;
 
-  // Deprecated, use invite instead
-  fn add_workspace_member(
-    &self,
-    user_email: String,
-    workspace_id: String,
-  ) -> FutureResult<(), FlowyError> {
-    FutureResult::new(async { Ok(()) })
-  }
-
   fn invite_workspace_member(
     &self,
     invitee_email: String,

--- a/frontend/rust-lib/flowy-user/src/entities/workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/workspace.rs
@@ -99,17 +99,6 @@ pub struct AcceptWorkspaceInvitationPB {
 }
 
 #[derive(ProtoBuf, Default, Clone, Validate)]
-pub struct AddWorkspaceMemberPB {
-  #[pb(index = 1)]
-  #[validate(custom = "required_not_empty_str")]
-  pub workspace_id: String,
-
-  #[pb(index = 2)]
-  #[validate(email)]
-  pub email: String,
-}
-
-#[derive(ProtoBuf, Default, Clone, Validate)]
 pub struct QueryWorkspacePB {
   #[pb(index = 1)]
   #[validate(custom = "required_not_empty_str")]

--- a/frontend/rust-lib/flowy-user/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-user/src/event_handler.rs
@@ -624,19 +624,6 @@ pub async fn update_reminder_event_handler(
 }
 
 #[tracing::instrument(level = "debug", skip_all, err)]
-pub async fn add_workspace_member_handler(
-  data: AFPluginData<AddWorkspaceMemberPB>,
-  manager: AFPluginState<Weak<UserManager>>,
-) -> Result<(), FlowyError> {
-  let data = data.try_into_inner()?;
-  let manager = upgrade_manager(manager)?;
-  manager
-    .add_workspace_member(data.email, data.workspace_id)
-    .await?;
-  Ok(())
-}
-
-#[tracing::instrument(level = "debug", skip_all, err)]
 pub async fn delete_workspace_member_handler(
   data: AFPluginData<RemoveWorkspaceMemberPB>,
   manager: AFPluginState<Weak<UserManager>>,

--- a/frontend/rust-lib/flowy-user/src/event_map.rs
+++ b/frontend/rust-lib/flowy-user/src/event_map.rs
@@ -54,9 +54,6 @@ pub fn init(user_manager: Weak<UserManager>) -> AFPlugin {
     .event(UserEvent::SetNotificationSettings, set_notification_settings)
     .event(UserEvent::GetNotificationSettings, get_notification_settings)
     .event(UserEvent::ImportAppFlowyDataFolder, import_appflowy_data_folder_handler)
-      // Workspace member
-    .event(UserEvent::AddWorkspaceMember, add_workspace_member_handler) // deprecated, use invite
-                                                                        // instead
     .event(UserEvent::GetMemberInfo, get_workspace_member_info)
     .event(UserEvent::RemoveWorkspaceMember, delete_workspace_member_handler)
     .event(UserEvent::GetWorkspaceMembers, get_workspace_members_handler)
@@ -195,9 +192,6 @@ pub enum UserEvent {
 
   #[event(output = "NotificationSettingsPB")]
   GetNotificationSettings = 36,
-
-  #[event(input = "AddWorkspaceMemberPB")]
-  AddWorkspaceMember = 37,
 
   #[event(input = "RemoveWorkspaceMemberPB")]
   RemoveWorkspaceMember = 38,

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
@@ -327,20 +327,6 @@ impl UserManager {
     Ok(())
   }
 
-  // deprecated, use invite instead
-  pub async fn add_workspace_member(
-    &self,
-    user_email: String,
-    workspace_id: String,
-  ) -> FlowyResult<()> {
-    self
-      .cloud_services
-      .get_user_service()?
-      .add_workspace_member(user_email, workspace_id)
-      .await?;
-    Ok(())
-  }
-
   pub async fn remove_workspace_member(
     &self,
     user_email: String,


### PR DESCRIPTION
- remove old directly add member to workspace
- integration tests uses convenient method to invite and accept workspace member