### PR TITLE
feat: add key '+'' as zoom-in key

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
@@ -66,7 +66,7 @@ void main() {
         tester: tester,
         withKeyUp: true,
       );
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(const Duration(seconds: 1));
 
       themeMode = tester.widget<MaterialApp>(appFinder).themeMode;
       expect(themeMode, ThemeMode.light);
@@ -93,7 +93,7 @@ void main() {
         withKeyUp: true,
       );
 
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.byType(HomeSideBar), findsNothing);
     });

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
@@ -17,7 +17,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('hotkeys test', () {
-    testWidgets('toggle theme mode', (tester) async {
+    testWidgets('toggle theme mode & sidebar', (tester) async {
       await tester.initializeAppFlowy();
 
       await tester.tapAnonymousSignInButton();
@@ -66,19 +66,11 @@ void main() {
         tester: tester,
         withKeyUp: true,
       );
+
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       themeMode = tester.widget<MaterialApp>(appFinder).themeMode;
       expect(themeMode, ThemeMode.light);
-    });
-
-    testWidgets('show or hide home menu', (tester) async {
-      await tester.initializeAppFlowy();
-
-      await tester.tapAnonymousSignInButton();
-      await tester.expectToSeeHomePageWithGetStartedPage();
-
-      await tester.pumpAndSettle();
 
       expect(find.byType(HomeSideBar), findsOneWidget);
 

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/hotkeys_test.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/application/settings/prelude.dart';
 import 'package:appflowy/workspace/presentation/home/menu/sidebar/sidebar.dart';
 import 'package:appflowy/workspace/presentation/settings/settings_dialog.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -65,6 +64,7 @@ void main() {
           LogicalKeyboardKey.keyL,
         ],
         tester: tester,
+        withKeyUp: true,
       );
       await tester.pumpAndSettle();
 
@@ -90,6 +90,7 @@ void main() {
           LogicalKeyboardKey.backslash,
         ],
         tester: tester,
+        withKeyUp: true,
       );
 
       await tester.pumpAndSettle();

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
@@ -70,6 +70,8 @@ void main() {
         withKeyUp: true,
       );
 
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
       expect(
         find.descendant(
           of: find.byType(TabBar),

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
@@ -67,6 +67,7 @@ void main() {
           LogicalKeyboardKey.keyW,
         ],
         tester: tester,
+        withKeyUp: true,
       );
 
       expect(

--- a/frontend/appflowy_flutter/integration_test/desktop_runner_3.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop_runner_3.dart
@@ -22,7 +22,6 @@ Future<void> runIntegration3OnDesktop() async {
 
   hotkeys_test.main();
   emoji_shortcut_test.main();
-  hotkeys_test.main();
   emoji_shortcut_test.main();
   settings_test_runner.main();
   share_markdown_test.main();

--- a/frontend/appflowy_flutter/integration_test/shared/keyboard.dart
+++ b/frontend/appflowy_flutter/integration_test/shared/keyboard.dart
@@ -12,6 +12,8 @@ class FlowyTestKeyboard {
       await tester.pumpAndSettle();
     }
 
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+
     if (withKeyUp) {
       for (final LogicalKeyboardKey key in keys) {
         await flutter_test.simulateKeyUpEvent(key);

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -10,6 +10,7 @@ import 'package:appflowy/workspace/presentation/home/menu/sidebar/shared/sidebar
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:provider/provider.dart';
 import 'package:scaled_app/scaled_app.dart';
@@ -59,8 +60,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Collapse sidebar menu (using slash)
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.backslash,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.slash,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => context
@@ -71,8 +74,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Collapse sidebar menu (using .)
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.period,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.period,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => context
@@ -83,10 +88,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Toggle theme mode light/dark
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.keyL,
+        key: LogicalKeyboardKey.keyL,
         modifiers: [
-          Platform.isMacOS ? KeyModifier.meta : KeyModifier.control,
-          KeyModifier.shift,
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+          HotKeyModifier.shift,
         ],
         scope: HotKeyScope.inapp,
       ),
@@ -97,8 +102,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Close current tab
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.keyW,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.keyW,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) =>
@@ -108,8 +115,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Go to previous tab
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.pageUp,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.pageUp,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => _selectTab(context, -1),
@@ -118,8 +127,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Go to next tab
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.pageDown,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.pageDown,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => _selectTab(context, 1),
@@ -128,7 +139,7 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Rename current view
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.f2,
+        key: LogicalKeyboardKey.f2,
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) =>
@@ -138,8 +149,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Scale up/down the app
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.equal,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.equal,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => _scaleWithStep(0.1),
@@ -147,8 +160,21 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
 
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.minus,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.add,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
+        scope: HotKeyScope.inapp,
+      ),
+      keyDownHandler: (_) => _scaleWithStep(0.1),
+    ),
+
+    HotKeyItem(
+      hotKey: HotKey(
+        key: LogicalKeyboardKey.minus,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => _scaleWithStep(-0.1),
@@ -157,8 +183,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Reset app scaling
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.digit0,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.digit0,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => _scaleToSize(1),
@@ -167,8 +195,10 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Switch to the next space
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.keyO,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
+        key: LogicalKeyboardKey.keyO,
+        modifiers: [
+          Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
+        ],
         scope: HotKeyScope.inapp,
       ),
       keyDownHandler: (_) => switchToTheNextSpace.value++,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -35,8 +35,14 @@ class HotKeyItem {
   final HotKey hotKey;
   final KeyDownHandler? keyDownHandler;
 
-  void register() =>
-      hotKeyManager.register(hotKey, keyDownHandler: keyDownHandler);
+  Future<void> register() async {
+    // Register the hot key if it's not already registered
+    if (hotKeyManager.registeredHotKeyList
+        .any((e) => e.identifier == hotKey.identifier)) {
+      return;
+    }
+    await hotKeyManager.register(hotKey, keyDownHandler: keyDownHandler);
+  }
 }
 
 class HomeHotKeys extends StatefulWidget {
@@ -60,7 +66,7 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     // Collapse sidebar menu (using slash)
     HotKeyItem(
       hotKey: HotKey(
-        key: LogicalKeyboardKey.slash,
+        key: LogicalKeyboardKey.backslash,
         modifiers: [
           Platform.isMacOS ? HotKeyModifier.meta : HotKeyModifier.control,
         ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/shared/sidebar_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/shared/sidebar_setting.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/application/document_appearance_cubit.dart';
@@ -15,6 +13,8 @@ import 'package:appflowy_editor/appflowy_editor.dart' hide Log;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/flowy_tooltip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hotkey_manager/hotkey_manager.dart';
 
@@ -26,10 +26,12 @@ HotKeyItem openSettingsHotKey(
 ) =>
     HotKeyItem(
       hotKey: HotKey(
-        KeyCode.comma,
+        key: LogicalKeyboardKey.comma,
         scope: HotKeyScope.inapp,
         modifiers: [
-          PlatformExtension.isMacOS ? KeyModifier.meta : KeyModifier.control,
+          PlatformExtension.isMacOS
+              ? HotKeyModifier.meta
+              : HotKeyModifier.control,
         ],
       ),
       keyDownHandler: (_) {

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -913,10 +913,42 @@ packages:
     dependency: "direct main"
     description:
       name: hotkey_manager
-      sha256: "8aaa0aeaca7015b8c561a58d02eb7ebba95e93357fc9540398c5751ee24afd7c"
+      sha256: "06f0655b76c8dd322fb7101dc615afbdbf39c3d3414df9e059c33892104479cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.8"
+    version: "0.2.3"
+  hotkey_manager_linux:
+    dependency: transitive
+    description:
+      name: hotkey_manager_linux
+      sha256: "83676bda8210a3377bc6f1977f193bc1dbdd4c46f1bdd02875f44b6eff9a8473"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_macos:
+    dependency: transitive
+    description:
+      name: hotkey_manager_macos
+      sha256: "03b5967e64357b9ac05188ea4a5df6fe4ed4205762cb80aaccf8916ee1713c96"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_platform_interface:
+    dependency: transitive
+    description:
+      name: hotkey_manager_platform_interface
+      sha256: "98ffca25b8cc9081552902747b2942e3bc37855389a4218c9d50ca316b653b13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  hotkey_manager_windows:
+    dependency: transitive
+    description:
+      name: hotkey_manager_windows
+      sha256: "0d03ced9fe563ed0b68f0a0e1b22c9ffe26eb8053cb960e401f68a4f070e0117"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   html:
     dependency: transitive
     description:
@@ -2065,6 +2097,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  uni_platform:
+    dependency: transitive
+    description:
+      name: uni_platform
+      sha256: e02213a7ee5352212412ca026afd41d269eb00d982faa552f419ffc2debfad84
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   universal_html:
     dependency: transitive
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
   table_calendar: ^3.0.9
   reorderables: ^0.6.0
   linked_scroll_controller: ^0.2.0
-  hotkey_manager: ^0.1.7
+  hotkey_manager: ^0.2.3
   fixnum: ^1.1.0
   flutter_svg: ^2.0.7
   protobuf: ^3.1.0


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/5601

In some keyboards, the system returns equal as + keycode, while others may return add as + keycode, so add them both as zoom in key.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
