### PR TITLE
fix: maximized window optimization

### DIFF
--- a/frontend/appflowy_flutter/lib/core/config/kv_keys.dart
+++ b/frontend/appflowy_flutter/lib/core/config/kv_keys.dart
@@ -18,6 +18,13 @@ class KVKeys {
   ///   {'dx': 10.0, 'dy': 10.0}
   static const String windowPosition = 'windowPosition';
 
+  /// The key for saving the window status
+  ///
+  /// The value is a json string with the following format:
+  ///  { 'windowMaximized': true }
+  ///
+  static const String windowMaximized = 'windowMaximized';
+
   static const String kDocumentAppearanceFontSize =
       'kDocumentAppearanceFontSize';
   static const String kDocumentAppearanceFontFamily =

--- a/frontend/appflowy_flutter/lib/startup/tasks/app_window_size_manager.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/app_window_size_manager.dart
@@ -83,4 +83,19 @@ class WindowSizeManager {
       '${scaleFactor.clamp(minScaleFactor, maxScaleFactor)}',
     );
   }
+
+  /// Set the window maximized status
+  Future<void> setWindowMaximized(bool isMaximized) async {
+    await getIt<KeyValueStorage>()
+        .set(KVKeys.windowMaximized, isMaximized.toString());
+  }
+
+  /// Get the window maximized status
+  Future<bool> getWindowMaximized() async {
+    return await getIt<KeyValueStorage>().getWithFormat<bool>(
+          KVKeys.windowMaximized,
+          (v) => bool.tryParse(v) ?? false,
+        ) ??
+        false;
+  }
 }

--- a/frontend/appflowy_flutter/lib/startup/tasks/windows.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/windows.dart
@@ -13,12 +13,9 @@ import 'package:scaled_app/scaled_app.dart';
 import 'package:window_manager/window_manager.dart';
 
 class InitAppWindowTask extends LaunchTask with WindowListener {
-  InitAppWindowTask({
-    this.title = 'AppFlowy',
-  });
+  InitAppWindowTask({this.title = 'AppFlowy'});
 
   final String title;
-
   final windowSizeManager = WindowSizeManager();
 
   @override
@@ -48,7 +45,7 @@ class InitAppWindowTask extends LaunchTask with WindowListener {
     final position = await windowSizeManager.getPosition();
 
     if (PlatformExtension.isWindows) {
-      doWhenWindowReady(() {
+      doWhenWindowReady(() async {
         appWindow.minSize = windowOptions.minimumSize;
         appWindow.maxSize = windowOptions.maximumSize;
         appWindow.size = windowSize;
@@ -58,6 +55,13 @@ class InitAppWindowTask extends LaunchTask with WindowListener {
         }
 
         appWindow.show();
+
+        /// on Windows we maximize the window if it was previously closed
+        /// from a maximized state.
+        final isMaximized = await windowSizeManager.getWindowMaximized();
+        if (isMaximized) {
+          appWindow.maximize();
+        }
       });
     } else {
       await windowManager.waitUntilReadyToShow(windowOptions, () async {
@@ -78,16 +82,20 @@ class InitAppWindowTask extends LaunchTask with WindowListener {
   }
 
   @override
-  Future<void> onWindowResize() async {
-    super.onWindowResize();
-
-    final currentWindowSize = await windowManager.getSize();
-    return windowSizeManager.setSize(currentWindowSize);
+  Future<void> onWindowMaximize() async {
+    super.onWindowMaximize();
+    await windowSizeManager.setWindowMaximized(true);
   }
 
   @override
-  void onWindowMaximize() async {
-    super.onWindowMaximize();
+  Future<void> onWindowUnmaximize() async {
+    super.onWindowUnmaximize();
+    await windowSizeManager.setWindowMaximized(false);
+  }
+
+  @override
+  Future<void> onWindowResize() async {
+    super.onWindowResize();
 
     final currentWindowSize = await windowManager.getSize();
     return windowSizeManager.setSize(currentWindowSize);


### PR DESCRIPTION
I've stopped saving the size of the window when it has been maximized, this means that when closing the application on Linux and MacOS from a maximized state, the application will open in it's previously regular state and size.

For Windows, I've added the previous maximized state to persistence, and maximize the window if it was previously maximized on application launch. This seems to be the standard behavior for Windows applications.

Relates: #3287 
Closes: #2904  - PS. This is for windows only, applications on MacOS when closed will turn to regular state, so it cannot open maximized.

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
