### PR TITLE
feat: add key + as zoom-in key

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -136,13 +136,18 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     ),
 
     // Scale up/down the app
-    HotKeyItem(
-      hotKey: HotKey(
-        KeyCode.equal,
-        modifiers: [Platform.isMacOS ? KeyModifier.meta : KeyModifier.control],
-        scope: HotKeyScope.inapp,
+    // In some keyboards, the system returns equal as + keycode, while others may return add as + keycode, so add them both as zoom in key.
+    ...[KeyCode.equal, KeyCode.add].map(
+      (keycode) => HotKeyItem(
+        hotKey: HotKey(
+          keycode,
+          modifiers: [
+            Platform.isMacOS ? KeyModifier.meta : KeyModifier.control,
+          ],
+          scope: HotKeyScope.inapp,
+        ),
+        keyDownHandler: (_) => _scaleWithStep(0.1),
       ),
-      keyDownHandler: (_) => _scaleWithStep(0.1),
     ),
 
     HotKeyItem(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/5601

In some keyboards, the system returns equal as + keycode, while others may return add as + keycode, so add them both as zoom in key.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
