### PR TITLE
fix: Add retry for admin client sign in for test

### DIFF
--- a/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
+++ b/frontend/rust-lib/flowy-server/src/af_cloud/impls/user/cloud_service_impl.rs
@@ -620,9 +620,18 @@ async fn get_admin_client(client: &Arc<AFCloudClient>) -> FlowyResult<Client> {
     ClientConfiguration::default(),
     &client.client_version.to_string(),
   );
-  admin_client
+  // When multiple admin_client instances attempt to sign in concurrently, multiple admin user
+  // creation transaction will be created, but only the first attempt will succeed due to the
+  // unique email constraint. Once the user has been created, admin_client instances can sign in
+  // concurrently without issue.
+  let resp = admin_client
     .sign_in_password(&admin_email, &admin_password)
-    .await?;
+    .await;
+  if resp.is_err() {
+    admin_client
+      .sign_in_password(&admin_email, &admin_password)
+      .await?;
+  };
   Ok(admin_client)
 }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview
In https://github.com/AppFlowy-IO/AppFlowy-Cloud/pull/690 , the pg advisory lock has been removed. As a result, if there are concurrent requests to verify a new user's token, only the first request will succeed. In practice, this should rarely happen, and if they do, it's good to throw an error in such case, as concurrent requests like this could be a sign
that there is a bug on the client end.

However, this scenario can happen in test. Cargo execute tests in parallel. Even though unique users and emails are created for most cases, all of them still rely on the admin client to send a request to appflowy cloud in order to generate a sign in url. And all admin client instances share the same user name and email.

This can be resolved if we retry the admin sign in attempt once.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
