### PR TITLE
fix: try to reopen the first workspace if the workspace deletion failed

### DIFF
--- a/frontend/rust-lib/flowy-core/src/deps_resolve/user_deps.rs
+++ b/frontend/rust-lib/flowy-core/src/deps_resolve/user_deps.rs
@@ -11,6 +11,7 @@ use flowy_user_pub::workspace_service::UserWorkspaceService;
 use lib_infra::async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::info;
 
 pub struct UserDepsResolver();
 
@@ -61,9 +62,14 @@ impl UserWorkspaceService for UserWorkspaceServiceImpl {
   }
 
   fn did_delete_workspace(&self, workspace_id: String) -> FlowyResult<()> {
-    self
+    // The remove_indices_for_workspace should not block the deletion of the workspace
+    // Log the error and continue
+    if let Err(err) = self
       .folder_manager
-      .remove_indices_for_workspace(workspace_id)?;
+      .remove_indices_for_workspace(workspace_id)
+    {
+      info!("Error removing indices for workspace: {}", err);
+    }
 
     Ok(())
   }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

In some cases, the delete workspace API may return an error even though the deletion actually succeeded. Verify by checking the workspace list again to cover this case.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
