### PR TITLE
chore: reduce get view call

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/view_title/view_title_bar_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/view_title/view_title_bar_bloc.dart
@@ -10,19 +10,21 @@ class ViewTitleBarBloc extends Bloc<ViewTitleBarEvent, ViewTitleBarState> {
   ViewTitleBarBloc({
     required this.view,
   }) : super(ViewTitleBarState.initial()) {
+    viewListener = ViewListener(
+      viewId: view.id,
+    )..start(
+        onViewChildViewsUpdated: (p0) {
+          if (!isClosed) {
+            add(const ViewTitleBarEvent.reload());
+          }
+        },
+      );
+
     on<ViewTitleBarEvent>(
       (event, emit) async {
         await event.when(
           initial: () async {
             add(const ViewTitleBarEvent.reload());
-
-            viewListener = ViewListener(
-              viewId: view.id,
-            )..start(
-                onViewUpdated: (p0) {
-                  add(const ViewTitleBarEvent.reload());
-                },
-              );
           },
           reload: () async {
             final List<ViewPB> ancestors =

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/view_title_bar.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/view_title_bar.dart
@@ -143,6 +143,13 @@ class _ViewTitleState extends State<_ViewTitle> {
       create: (_) =>
           ViewTitleBloc(view: widget.view)..add(const ViewTitleEvent.initial()),
       child: BlocConsumer<ViewTitleBloc, ViewTitleState>(
+        listenWhen: (previous, current) {
+          if (previous.view == null || current.view == null) {
+            return false;
+          }
+
+          return previous.view != current.view;
+        },
         listener: (_, state) {
           _resetTextEditingController(state);
           widget.onUpdated();


### PR DESCRIPTION
Fix high cpu when open a new view

1. Print acquire folder lock
2. Reduce GetViewAncestors calls 