### PR TITLE
Fix(Linux): Fixed AppImage build, removed Wayland Header

### DIFF
--- a/frontend/appflowy_flutter/linux/my_application.cc
+++ b/frontend/appflowy_flutter/linux/my_application.cc
@@ -28,38 +28,7 @@ static void my_application_activate(GApplication *application)
 
   GtkWindow *window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
-
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen *screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen))
-  {
-    const gchar *wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0)
-    {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar)
-  {
-    GtkHeaderBar *header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "AppFlowy");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  }
-  else
-  {
-    gtk_window_set_title(window, "AppFlowy");
-  }
+  gtk_window_set_title(window, "AppFlowy");
 
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));

--- a/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
+++ b/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
@@ -14,7 +14,7 @@ AppDir:
     id: io.appflowy.AppFlowy
     name: AppFlowy
     icon: appflowy.svg
-    version: [CHANGE_THIS]
+    version: Appflowy-dev
     exec: AppFlowy
     exec_args: $@
   apt:
@@ -22,20 +22,20 @@ AppDir:
       - amd64
     allow_unauthenticated: true
     sources:
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy main restricted
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy-updates main restricted
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy universe
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy-updates universe
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy multiverse
-      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ jammy-updates multiverse
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble main restricted
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble-updates main restricted
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble universe
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble-updates universe
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble multiverse
+      - sourceline: deb http://id.archive.ubuntu.com/ubuntu/ noble-updates multiverse
       - sourceline:
-          deb http://id.archive.ubuntu.com/ubuntu/ jammy-backports main restricted
+          deb http://id.archive.ubuntu.com/ubuntu/ noble-backports main restricted
           universe multiverse
-      - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security main restricted
-      - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security universe
-      - sourceline: deb http://security.ubuntu.com/ubuntu jammy-security multiverse
+      - sourceline: deb http://security.ubuntu.com/ubuntu noble-security main restricted
+      - sourceline: deb http://security.ubuntu.com/ubuntu noble-security universe
+      - sourceline: deb http://security.ubuntu.com/ubuntu noble-security multiverse
       - sourceline:
-          deb https://ppa.launchpadcontent.net/touchegg/stable/ubuntu/ jammy
+          deb https://ppa.launchpadcontent.net/touchegg/stable/ubuntu/ noble
           main
       - sourceline:
           deb https://packagecloud.io/slacktechnologies/slack/debian/ jessie

--- a/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
+++ b/frontend/scripts/linux_distribution/appimage/AppImageBuilder.yml
@@ -14,7 +14,7 @@ AppDir:
     id: io.appflowy.AppFlowy
     name: AppFlowy
     icon: appflowy.svg
-    version: Appflowy-dev
+    version: [CHANGE_THIS]
     exec: AppFlowy
     exec_args: $@
   apt:


### PR DESCRIPTION
fixes #3536
fixes #5306
related thread: https://github.com/flutter/flutter/issues/111453
Tested on KDE Tumbleweed for x11 and Wayland sessions. AppImage recipe was referencing Ubuntu 22.04 sources (Jammy), while the CI builds on Ubuntu-latest (24.04, Noble Numbat)

Before: ![image](https://github.com/user-attachments/assets/ea8dfd69-aa82-4dd5-aa7c-870bcebc1930)
After: ![image](https://github.com/user-attachments/assets/85388cae-aa30-4e2b-9c13-163e59365cf1)

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
(I don't think there're tests regarding the configs)