### PR TITLE
fix: ignore case sensitive of image name when dragging image to document

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/document_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/document_page.dart
@@ -197,13 +197,15 @@ class _DocumentPageState extends State<DocumentPage>
 
               final isLocalMode = context.read<DocumentBloc>().isLocalMode;
               final List<XFile> imageFiles = [];
-              final List<XFile> otherfiles = [];
+              final List<XFile> otherFiles = [];
+
               for (final file in details.files) {
+                final fileName = file.name.toLowerCase();
                 if (file.mimeType?.startsWith('image/') ??
-                    false || imgExtensionRegex.hasMatch(file.name)) {
+                    false || imgExtensionRegex.hasMatch(fileName)) {
                   imageFiles.add(file);
                 } else {
-                  otherfiles.add(file);
+                  otherFiles.add(file);
                 }
               }
 
@@ -215,7 +217,7 @@ class _DocumentPageState extends State<DocumentPage>
               );
               await editorState!.dropFiles(
                 data.dropTarget!,
-                otherfiles,
+                otherFiles,
                 widget.view.id,
                 isLocalMode,
               );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
@@ -35,7 +35,7 @@ extension PasteFromImage on EditorState {
     final imageFiles = files.where(
       (file) =>
           file.mimeType?.startsWith('image/') ??
-          false || imgExtensionRegex.hasMatch(file.name),
+          false || imgExtensionRegex.hasMatch(file.name.toLowerCase()),
     );
 
     for (final file in imageFiles) {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

ignore case sensitive of image name when dragging image to document

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
