### PR TITLE
chore(flutter): bump sentry version to fix building

### DIFF
--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -1727,18 +1727,18 @@ packages:
     dependency: "direct main"
     description:
       name: sentry
-      sha256: "0f787e27ff617e4f88f7074977240406a9c5509444bac64a4dfa5b3200fb5632"
+      sha256: "1af8308298977259430d118ab25be8e1dda626cdefa1e6ce869073d530d39271"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: fbbb47d72ccca48be25bf3c2ced6ab6e872991af3a0ba78e54be8d138f2e053f
+      sha256: "18fe4d125c2d529bd6127200f0d2895768266a8c60b4fb50b2086fd97e1a4ab2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.7.0"
+    version: "8.8.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -152,7 +152,7 @@ dependencies:
   extended_text_field: ^15.0.0
   extended_text_library: ^12.0.0
   sentry_flutter: ^8.7.0
-  sentry: ^8.7.0
+  sentry: ^8.8.0
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
```
Launching lib/main.dart on macOS in debug mode...
CocoaPods' output:
↳
    -- snip --

    -> Installing Sentry (8.33.0)
     > Git download
     > Git download
         $ /usr/bin/git clone https://github.com/getsentry/sentry-cocoa.git /var/folders/pj/jl4sz3pj2mv_7ycqnnn7pvjr0000gn/T/d20240903-13323-joyk9s --template= --single-branch --depth 1 --branch 8.33.0

    [!] Error installing Sentry
    [!] /usr/bin/git clone https://github.com/getsentry/sentry-cocoa.git /var/folders/pj/jl4sz3pj2mv_7ycqnnn7pvjr0000gn/T/d20240903-13323-joyk9s --template= --single-branch --depth 1 --branch 8.33.0

    Cloning into '/var/folders/pj/jl4sz3pj2mv_7ycqnnn7pvjr0000gn/T/d20240903-13323-joyk9s'...
    warning: Could not find remote branch 8.33.0 to clone.
    fatal: Remote branch 8.33.0 not found in upstream origin

    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:144:in `rescue in execute_command'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:141:in `execute_command'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/base.rb:175:in `block in executable'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/git.rb:107:in `block in clone'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:175:in `block in ui_sub_action'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/user_interface.rb:64:in `section'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:174:in `ui_sub_action'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/git.rb:105:in `clone'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/git.rb:73:in `download!'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/base.rb:83:in `block in download'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:159:in `block in ui_action'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/user_interface.rb:64:in `section'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:158:in `ui_action'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-downloader-2.1/lib/cocoapods-downloader/base.rb:81:in `download'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:110:in `download_source'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:77:in `download_request'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader/cache.rb:256:in `download'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader/cache.rb:239:in `block in uncached_pod'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader/cache.rb:266:in `in_tmpdir'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader/cache.rb:238:in `uncached_pod'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader/cache.rb:33:in `download_pod'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/downloader.rb:42:in `download'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer/pod_source_downloader.rb:69:in `download!'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer/pod_source_installer.rb:117:in `download_source'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer/pod_source_installer.rb:67:in `install!'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:621:in `install_source_of_pod'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:539:in `block (2 levels) in install_pod_sources'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/user_interface.rb:86:in `titled_section'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:538:in `block in install_pod_sources'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:535:in `each'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:535:in `install_pod_sources'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:258:in `block in download_dependencies'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/user_interface.rb:64:in `section'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:257:in `download_dependencies'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/installer.rb:163:in `install!'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/command/install.rb:52:in `run'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/claide-1.1.0/lib/claide/command.rb:334:in `run'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/lib/cocoapods/command.rb:52:in `run'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/gems/cocoapods-1.15.2/bin/pod:55:in `<top (required)>'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/bin/pod:25:in `load'
    /opt/homebrew/Cellar/cocoapods/1.15.2/libexec/bin/pod:25:in `<main>'

Error output from CocoaPods:
↳
         Cloning into '/var/folders/pj/jl4sz3pj2mv_7ycqnnn7pvjr0000gn/T/d20240903-13323-joyk9s'...
         warning: Could not find remote branch 8.33.0 to clone.
         fatal: Remote branch 8.33.0 not found in upstream origin

Error: Error running pod install


Exited (1).
```

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
