### PR TITLE
fix: more default image extensions

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/custom_cover_picker_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/custom_cover_picker_bloc.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/startup/startup.dart';
+import 'package:appflowy/util/default_extensions.dart';
 import 'package:appflowy/workspace/application/settings/prelude.dart';
 import 'package:appflowy_backend/protobuf/flowy-error/errors.pb.dart';
 import 'package:appflowy_result/appflowy_result.dart';
@@ -22,8 +23,6 @@ class CoverImagePickerBloc
   CoverImagePickerBloc() : super(const CoverImagePickerState.initial()) {
     _dispatch();
   }
-
-  static const allowedExtensions = ['jpg', 'png', 'jpeg'];
 
   void _dispatch() {
     on<CoverImagePickerEvent>(
@@ -128,7 +127,7 @@ class CoverImagePickerBloc
     final result = await getIt<FilePickerService>().pickFiles(
       dialogTitle: LocaleKeys.document_plugins_cover_addLocalImage.tr(),
       type: FileType.image,
-      allowedExtensions: allowedExtensions,
+      allowedExtensions: defaultImageExtensions,
     );
     if (result != null && result.files.isNotEmpty) {
       return result.files.first.path;
@@ -176,7 +175,7 @@ class CoverImagePickerBloc
     if (ext != null && ext.isNotEmpty) {
       ext = ext.substring(1);
     }
-    if (allowedExtensions.contains(ext)) {
+    if (defaultImageExtensions.contains(ext)) {
       return ext;
     }
     return null;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/upload_image_menu/widgets/upload_image_file_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/upload_image_menu/widgets/upload_image_file_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/shared/permission/permission_checker.dart';
 import 'package:appflowy/startup/startup.dart';
+import 'package:appflowy/util/default_extensions.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_editor/appflowy_editor.dart' hide Log;
 import 'package:easy_localization/easy_localization.dart';
@@ -15,7 +16,7 @@ class UploadImageFileWidget extends StatelessWidget {
   const UploadImageFileWidget({
     super.key,
     required this.onPickFiles,
-    this.allowedExtensions = const ['jpg', 'png', 'jpeg', 'gif', 'webp', 'bmp'],
+    this.allowedExtensions = defaultImageExtensions,
     this.allowMultipleImages = false,
   });
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/upload_image_menu/widgets/upload_image_file_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/upload_image_menu/widgets/upload_image_file_widget.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/shared/permission/permission_checker.dart';
 import 'package:appflowy/startup/startup.dart';
@@ -7,14 +9,13 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/file_picker/file_picker_service.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
-import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
 class UploadImageFileWidget extends StatelessWidget {
   const UploadImageFileWidget({
     super.key,
     required this.onPickFiles,
-    this.allowedExtensions = const ['jpg', 'png', 'jpeg'],
+    this.allowedExtensions = const ['jpg', 'png', 'jpeg', 'gif', 'webp', 'bmp'],
     this.allowMultipleImages = false,
   });
 

--- a/frontend/appflowy_flutter/lib/util/default_extensions.dart
+++ b/frontend/appflowy_flutter/lib/util/default_extensions.dart
@@ -1,0 +1,15 @@
+/// List of default file extensions used for images.
+///
+/// This is used to make sure that only images that are allowed are picked/uploaded. The extensions
+/// should be supported by Flutter, to avoid causing issues.
+///
+/// See [Image-class documentation](https://api.flutter.dev/flutter/widgets/Image-class.html)
+///
+const List<String> defaultImageExtensions = [
+  'jpg',
+  'png',
+  'jpeg',
+  'gif',
+  'webp',
+  'bmp',
+];


### PR DESCRIPTION
Closes: https://github.com/AppFlowy-IO/AppFlowy/issues/5760

Adds webp, gif, and bmp file formats to the default allows.

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
