### PR TITLE
fix: reordering or creating a row while sorts are active

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/board/board_row_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/board/board_row_test.dart
@@ -29,7 +29,7 @@ void main() {
         },
       );
       await tester.tapButtonWithName(LocaleKeys.button_delete.tr());
-      await tester.tapOKButton();
+      await tester.tapButtonWithName(LocaleKeys.button_delete.tr());
       expect(find.text(name), findsNothing);
     });
 

--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/field_info.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/field_info.dart
@@ -86,6 +86,7 @@ class FieldInfo with _$FieldInfo {
       case FieldType.LastEditedTime:
       case FieldType.CreatedTime:
       case FieldType.Checklist:
+      case FieldType.URL:
       case FieldType.Time:
         return true;
       default:

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database/application/row/row_service.dart';
+import 'package:appflowy/plugins/database/domain/sort_service.dart';
 import 'package:appflowy/plugins/database/grid/presentation/widgets/calculations/calculations_row.dart';
 import 'package:appflowy/plugins/database/grid/presentation/widgets/toolbar/grid_setting_bar.dart';
 import 'package:appflowy/plugins/database/tab_bar/desktop/setting_menu.dart';
@@ -9,8 +11,10 @@ import 'package:appflowy/shared/flowy_error_page.dart';
 import 'package:appflowy/workspace/application/action_navigation/action_navigation_bloc.dart';
 import 'package:appflowy/workspace/application/action_navigation/navigation_action.dart';
 import 'package:appflowy/workspace/application/view/view_bloc.dart';
+import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/style_widget/scrolling/styled_scrollview.dart';
 import 'package:flutter/material.dart';
@@ -361,11 +365,33 @@ class _GridRowsState extends State<_GridRows> {
               ),
             ),
             onReorder: (fromIndex, newIndex) {
-              final toIndex = newIndex > fromIndex ? newIndex - 1 : newIndex;
-              if (fromIndex != toIndex) {
-                context
-                    .read<GridBloc>()
-                    .add(GridEvent.moveRow(fromIndex, toIndex));
+              void moveRow() {
+                final toIndex = newIndex > fromIndex ? newIndex - 1 : newIndex;
+                if (fromIndex != toIndex) {
+                  context
+                      .read<GridBloc>()
+                      .add(GridEvent.moveRow(fromIndex, toIndex));
+                }
+              }
+
+              if (state.sorts.isNotEmpty) {
+                showCancelAndDeleteDialog(
+                  context: context,
+                  title: LocaleKeys.grid_sort_sortsActive.tr(
+                    namedArgs: {
+                      'intention':
+                          LocaleKeys.grid_row_reorderRowDescription.tr(),
+                    },
+                  ),
+                  description: LocaleKeys.grid_sort_removeSorting.tr(),
+                  confirmLabel: LocaleKeys.button_remove.tr(),
+                  onDelete: () {
+                    SortBackendService(viewId: widget.viewId).deleteAllSorts();
+                    moveRow();
+                  },
+                );
+              } else {
+                moveRow();
               }
             },
             itemCount: itemCount,
@@ -374,7 +400,6 @@ class _GridRowsState extends State<_GridRows> {
                 return _renderRow(
                   context,
                   state.rowInfos[index].rowId,
-                  isDraggable: state.reorderable,
                   index: index,
                 );
               }
@@ -411,8 +436,7 @@ class _GridRowsState extends State<_GridRows> {
   Widget _renderRow(
     BuildContext context,
     RowId rowId, {
-    int? index,
-    required bool isDraggable,
+    required int index,
     Animation<double>? animation,
   }) {
     final databaseController = context.read<GridBloc>().databaseController;
@@ -436,7 +460,6 @@ class _GridRowsState extends State<_GridRows> {
       rowId: rowId,
       viewId: viewId,
       index: index,
-      isDraggable: isDraggable,
       rowController: rowController,
       cellBuilder: EditableCellBuilder(databaseController: databaseController),
       openDetailPage: (rowDetailContext) {

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/row/row.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/row/row.dart
@@ -1,3 +1,6 @@
+import 'package:appflowy/plugins/database/domain/sort_service.dart';
+import 'package:appflowy/plugins/database/grid/application/grid_bloc.dart';
+import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:flutter/material.dart';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';
@@ -31,8 +34,7 @@ class GridRow extends StatefulWidget {
     required this.rowController,
     required this.cellBuilder,
     required this.openDetailPage,
-    this.index,
-    this.isDraggable = false,
+    required this.index,
   });
 
   final FieldController fieldController;
@@ -41,8 +43,7 @@ class GridRow extends StatefulWidget {
   final RowController rowController;
   final EditableCellBuilder cellBuilder;
   final void Function(BuildContext context) openDetailPage;
-  final int? index;
-  final bool isDraggable;
+  final int index;
 
   @override
   State<GridRow> createState() => _GridRowState();
@@ -62,8 +63,8 @@ class _GridRowState extends State<GridRow> {
         child: Row(
           children: [
             _RowLeading(
+              viewId: widget.viewId,
               index: widget.index,
-              isDraggable: widget.isDraggable,
             ),
             Expanded(
               child: RowContent(
@@ -81,12 +82,12 @@ class _GridRowState extends State<GridRow> {
 
 class _RowLeading extends StatefulWidget {
   const _RowLeading({
-    this.index,
-    this.isDraggable = false,
+    required this.viewId,
+    required this.index,
   });
 
-  final int? index;
-  final bool isDraggable;
+  final String viewId;
+  final int index;
 
   @override
   State<_RowLeading> createState() => _RowLeadingState();
@@ -105,9 +106,12 @@ class _RowLeadingState extends State<_RowLeading> {
       margin: const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
       popupBuilder: (_) {
         final bloc = context.read<RowBloc>();
-        return RowActionMenu(
-          viewId: bloc.viewId,
-          rowId: bloc.rowId,
+        return BlocProvider.value(
+          value: context.read<GridBloc>(),
+          child: RowActionMenu(
+            viewId: bloc.viewId,
+            rowId: bloc.rowId,
+          ),
         );
       },
       child: Consumer<RegionStateNotifier>(
@@ -127,28 +131,25 @@ class _RowLeadingState extends State<_RowLeading> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        const InsertRowButton(),
-        if (isDraggable)
-          ReorderableDragStartListener(
-            index: widget.index!,
-            child: RowMenuButton(
-              isDragEnabled: isDraggable,
-              openMenu: popoverController.show,
-            ),
-          )
-        else
-          RowMenuButton(
+        InsertRowButton(viewId: widget.viewId),
+        ReorderableDragStartListener(
+          index: widget.index,
+          child: RowMenuButton(
             openMenu: popoverController.show,
           ),
+        ),
       ],
     );
   }
-
-  bool get isDraggable => widget.index != null && widget.isDraggable;
 }
 
 class InsertRowButton extends StatelessWidget {
-  const InsertRowButton({super.key});
+  const InsertRowButton({
+    super.key,
+    required this.viewId,
+  });
+
+  final String viewId;
 
   @override
   Widget build(BuildContext context) {
@@ -157,7 +158,27 @@ class InsertRowButton extends StatelessWidget {
       hoverColor: AFThemeExtension.of(context).lightGreyHover,
       width: 20,
       height: 30,
-      onPressed: () => context.read<RowBloc>().add(const RowEvent.createRow()),
+      onPressed: () {
+        final rowBloc = context.read<RowBloc>();
+        if (context.read<GridBloc>().state.sorts.isNotEmpty) {
+          showCancelAndDeleteDialog(
+            context: context,
+            title: LocaleKeys.grid_sort_sortsActive.tr(
+              namedArgs: {
+                'intention': LocaleKeys.grid_row_createRowBelowDescription.tr(),
+              },
+            ),
+            description: LocaleKeys.grid_sort_removeSorting.tr(),
+            confirmLabel: LocaleKeys.button_remove.tr(),
+            onDelete: () {
+              SortBackendService(viewId: viewId).deleteAllSorts();
+              rowBloc.add(const RowEvent.createRow());
+            },
+          );
+        } else {
+          rowBloc.add(const RowEvent.createRow());
+        }
+      },
       iconPadding: const EdgeInsets.all(3),
       icon: FlowySvg(
         FlowySvgs.add_s,
@@ -171,11 +192,9 @@ class RowMenuButton extends StatefulWidget {
   const RowMenuButton({
     super.key,
     required this.openMenu,
-    this.isDragEnabled = false,
   });
 
   final VoidCallback openMenu;
-  final bool isDragEnabled;
 
   @override
   State<RowMenuButton> createState() => _RowMenuButtonState();
@@ -185,22 +204,18 @@ class _RowMenuButtonState extends State<RowMenuButton> {
   @override
   Widget build(BuildContext context) {
     return FlowyIconButton(
-      tooltipText:
-          widget.isDragEnabled ? null : LocaleKeys.tooltip_openMenu.tr(),
-      richTooltipText: widget.isDragEnabled
-          ? TextSpan(
-              children: [
-                TextSpan(
-                  text: '${LocaleKeys.tooltip_dragRow.tr()}\n',
-                  style: context.tooltipTextStyle(),
-                ),
-                TextSpan(
-                  text: LocaleKeys.tooltip_openMenu.tr(),
-                  style: context.tooltipTextStyle(),
-                ),
-              ],
-            )
-          : null,
+      richTooltipText: TextSpan(
+        children: [
+          TextSpan(
+            text: '${LocaleKeys.tooltip_dragRow.tr()}\n',
+            style: context.tooltipTextStyle(),
+          ),
+          TextSpan(
+            text: LocaleKeys.tooltip_openMenu.tr(),
+            style: context.tooltipTextStyle(),
+          ),
+        ],
+      ),
       hoverColor: AFThemeExtension.of(context).lightGreyHover,
       width: 20,
       height: 30,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/shared_widget.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/shared_widget.dart
@@ -323,10 +323,7 @@ class _ConfirmPopupState extends State<ConfirmPopup> {
         }
       },
       child: Container(
-        padding: const EdgeInsets.symmetric(
-          vertical: 20.0,
-          horizontal: 20.0,
-        ),
+        padding: const EdgeInsets.all(20),
         color: UniversalPlatform.isDesktop
             ? null
             : Theme.of(context).colorScheme.surface,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/dialogs.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/dialogs.dart
@@ -530,7 +530,7 @@ Future<void> showCancelAndDeleteDialog({
   required BuildContext context,
   required String title,
   required String description,
-  required Widget Function(BuildContext) builder,
+  Widget Function(BuildContext)? builder,
   VoidCallback? onDelete,
   String? confirmLabel,
 }) {
@@ -550,7 +550,7 @@ Future<void> showCancelAndDeleteDialog({
             closeOnAction: false,
             confirmLabel: confirmLabel,
             confirmButtonColor: Theme.of(context).colorScheme.error,
-            child: builder(context),
+            child: builder?.call(context),
           ),
         ),
       );

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -260,7 +260,7 @@
     "openAsPage": "Open as a Page",
     "addNewRow": "Add a new row",
     "openMenu": "Click to open menu",
-    "dragRow": "Long press to reorder the row",
+    "dragRow": "Drag to reorder the row",
     "viewDataBase": "View database",
     "referencePage": "This {name} is referenced",
     "addBlockBelow": "Add a block below",
@@ -1383,10 +1383,12 @@
       "cannotFindCreatableField": "Cannot find a suitable field to sort by",
       "deleteAllSorts": "Delete all sorts",
       "addSort": "Add new sort",
-      "removeSorting": "Would you like to remove sorting?",
+      "sortsActive": "Cannot {intention} while sorting",
+      "removeSorting": "Would you like to remove all the sorts in this view and continue?",
       "fieldInUse": "You are already sorting by this field"
     },
     "row": {
+      "label": "Row",
       "duplicate": "Duplicate",
       "delete": "Delete",
       "titlePlaceholder": "Untitled",
@@ -1397,12 +1399,15 @@
       "action": "Action",
       "add": "Click add to below",
       "drag": "Drag to move",
-      "deleteRowPrompt": "Are you sure you want to delete this row? This action cannot be undone",
-      "deleteCardPrompt": "Are you sure you want to delete this card? This action cannot be undone",
+      "deleteRowPrompt": "Are you sure you want to delete this row? This action cannot be undone.",
+      "deleteCardPrompt": "Are you sure you want to delete this card? This action cannot be undone.",
       "dragAndClick": "Drag to move, click to open menu",
       "insertRecordAbove": "Insert record above",
       "insertRecordBelow": "Insert record below",
-      "noContent": "No content"
+      "noContent": "No content",
+      "reorderRowDescription": "reorder row",
+      "createRowAboveDescription": "create a row above",
+      "createRowBelowDescription": "insert a row below"
     },
     "selectOption": {
       "create": "Create",


### PR DESCRIPTION
Inform the user why inserting a new row before or after a row, or reordering rows is not allowed when there are sorts configured for the current grid view; and give an option to remove sorting in order to continue.

![Screenshot 2024-09-14 at 9 56 27 AM](https://github.com/user-attachments/assets/bd033ca3-b5dd-47f3-9aad-9ce63c503ddb)


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
