### PR TITLE
fix(flutter_desktop): incorrect row meta in row detail page

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
@@ -454,11 +454,6 @@ class _GridRowsState extends State<_GridRows> {
       Log.warn('RowMeta is null for rowId: $rowId');
       return const SizedBox.shrink();
     }
-    final rowController = RowController(
-      viewId: viewId,
-      rowMeta: rowMeta,
-      rowCache: rowCache,
-    );
 
     final child = GridRow(
       key: ValueKey(rowId),
@@ -466,18 +461,31 @@ class _GridRowsState extends State<_GridRows> {
       rowId: rowId,
       viewId: viewId,
       index: index,
-      rowController: rowController,
+      rowController: RowController(
+        viewId: viewId,
+        rowMeta: rowMeta,
+        rowCache: rowCache,
+      ),
       cellBuilder: EditableCellBuilder(databaseController: databaseController),
       openDetailPage: (rowDetailContext) => FlowyOverlay.show(
         context: rowDetailContext,
-        builder: (_) => BlocProvider.value(
-          value: context.read<ViewBloc>(),
-          child: RowDetailPage(
-            rowController: rowController,
-            databaseController: databaseController,
-            userProfile: context.read<GridBloc>().userProfile,
-          ),
-        ),
+        builder: (_) {
+          final rowMeta = rowCache.getRow(rowId)?.rowMeta;
+          return rowMeta == null
+              ? const SizedBox.shrink()
+              : BlocProvider.value(
+                  value: context.read<ViewBloc>(),
+                  child: RowDetailPage(
+                    rowController: RowController(
+                      viewId: viewId,
+                      rowMeta: rowMeta,
+                      rowCache: rowCache,
+                    ),
+                    databaseController: databaseController,
+                    userProfile: context.read<GridBloc>().userProfile,
+                  ),
+                );
+        },
       ),
     );
 


### PR DESCRIPTION
We keep using the old rowMeta even though it's been updated. Please refer to screen recording below to reproduce.

https://github.com/user-attachments/assets/2c26f99a-1fd6-4e60-b9c9-4a481e2174b5


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
