### PR TITLE
fix: hide line numbers in code block

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
 import 'package:appflowy/plugins/document/application/document_bloc.dart';
@@ -12,8 +15,6 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flowy_infra/theme_extension.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:universal_platform/universal_platform.dart';
 
@@ -221,6 +222,7 @@ Map<String, BlockComponentBuilder> getEditorBuilderMap({
       padding: const EdgeInsets.only(left: 20, right: 30, bottom: 34),
       languagePickerBuilder: codeBlockLanguagePickerBuilder,
       copyButtonBuilder: codeBlockCopyBuilder,
+      showLineNumbers: false,
     ),
     AutoCompletionBlockKeys.type: AutoCompletionBlockComponentBuilder(),
     SmartEditBlockKeys.type: SmartEditBlockComponentBuilder(),


### PR DESCRIPTION
I haven't been able to reproduce the issues with line numbers shifting vertically compared to the lines. Right now the way we have built the Code Block using the Markdown makes the layout of the line numbers reliant on having the same font size and line height as the text to the right of it, I'm assuming the issue might be related to accessibility or something else that shifts the font size.

This PR simply hides line numbers in a code block.

### Feature Preview

![Screenshot 2024-09-18 at 23 55 03](https://github.com/user-attachments/assets/4a22762b-5e57-4798-9954-5cbab7b6ddef)

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
