### PR TITLE
fix: semi-transparent colors being forced to full opacity in FlowySvg

### DIFF
--- a/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
+++ b/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
@@ -79,8 +79,8 @@ class FlowySvg extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Color? iconColor = color ?? Theme.of(context).iconTheme.color;
-    if (opacity != null && iconColor != null) {
-      iconColor = iconColor.withOpacity(opacity!);
+    if (opacity != null) {
+      iconColor = iconColor?.withOpacity(opacity!);
     }
 
     final textScaleFactor = MediaQuery.textScalerOf(context).scale(1);

--- a/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
+++ b/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
@@ -73,7 +73,7 @@ class FlowySvg extends StatelessWidget {
 
   /// The opacity of the svg
   ///
-  /// The default value is 1.0
+  /// if null then use the opacity of the iconColor
   final double? opacity;
 
   @override

--- a/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
+++ b/frontend/appflowy_flutter/packages/flowy_svg/lib/src/flowy_svg.dart
@@ -23,7 +23,7 @@ class FlowySvg extends StatelessWidget {
     this.size,
     this.color,
     this.blendMode = BlendMode.srcIn,
-    this.opacity = 1.0,
+    this.opacity,
     this.svgString,
   });
 
@@ -34,7 +34,7 @@ class FlowySvg extends StatelessWidget {
     Size? size,
     Color? color,
     BlendMode? blendMode = BlendMode.srcIn,
-    double opacity = 1.0,
+    double? opacity,
   }) {
     return FlowySvg(
       const FlowySvgData(''),
@@ -74,12 +74,15 @@ class FlowySvg extends StatelessWidget {
   /// The opacity of the svg
   ///
   /// The default value is 1.0
-  final double opacity;
+  final double? opacity;
 
   @override
   Widget build(BuildContext context) {
-    final iconColor =
-        (color ?? Theme.of(context).iconTheme.color)?.withOpacity(opacity);
+    Color? iconColor = color ?? Theme.of(context).iconTheme.color;
+    if (opacity != null && iconColor != null) {
+      iconColor = iconColor.withOpacity(opacity!);
+    }
+
     final textScaleFactor = MediaQuery.textScalerOf(context).scale(1);
 
     final Widget svg;


### PR DESCRIPTION
As an example, hintColor on mobile is not a fully-opaque gray color, but black with its opacity toned down. When passed to FlowySvg, this color's opacity is cranked back up to 1.0. In the sort panel, both the "no active sorts" text and the sort icon specify this hint color but look completely different. In the second example, notice the plus sign next to the words "new row".

Before:
![Screenshot 2024-09-21 at 10 07 41 PM](https://github.com/user-attachments/assets/d35f98b8-2707-4a5c-abc6-1a3684b108d2)

![Screenshot 2024-09-21 at 10 08 20 PM](https://github.com/user-attachments/assets/fee9be92-93fe-4678-855a-108f0ac812cd)


After:
![Screenshot 2024-09-21 at 10 07 01 PM](https://github.com/user-attachments/assets/dc98457f-d04c-49b6-918e-650805522d46)

![Screenshot 2024-09-21 at 10 08 53 PM](https://github.com/user-attachments/assets/d5da10e3-0f3f-454d-b894-81cf606165cc)




### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
