### PR TITLE
fix: row cover improvements

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/database/database_row_cover_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/database/database_row_cover_test.dart
@@ -8,6 +8,7 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database/widgets/card/card.dart';
 import 'package:appflowy/plugins/database/widgets/cell_editor/media_cell_editor.dart';
 import 'package:appflowy/plugins/database/widgets/row/row_banner.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart';
 import 'package:appflowy/shared/af_image.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/field_entities.pbenum.dart';
@@ -77,13 +78,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Expect a cover to be shown
-      expect(find.byType(BannerCover), findsOneWidget);
+      expect(find.byType(RowCover), findsOneWidget);
 
       // Remove the temp file
       await Future.wait([file.delete()]);
     });
 
-    testWidgets('upload and remove cover from Row Detail Card', (tester) async {
+    testWidgets('add and remove cover from Row Detail Card', (tester) async {
       await tester.initializeAppFlowy();
       await tester.tapAnonymousSignInButton();
 
@@ -93,8 +94,8 @@ void main() {
       await tester.openFirstRowDetailPage();
       await tester.pumpAndSettle();
 
-      // Expect no cover (BannerCover is always in the Widget tree - thus check AFImage)
-      expect(find.byType(AFImage), findsNothing);
+      // Expect no cover
+      expect(find.byType(RowCover), findsNothing);
 
       // Hover on RowBanner to show Add Cover button
       await tester.hoverRowBanner();
@@ -102,56 +103,39 @@ void main() {
       // Click on Add Cover button
       await tester.tapAddCoverButton();
 
-      // Prepare image for upload from local
-      final image = await rootBundle.load('assets/test/images/sample.jpeg');
-      final tempDirectory = await getTemporaryDirectory();
-      final imagePath = p.join(tempDirectory.path, 'sample.jpeg');
-      final file = File(imagePath)
-        ..writeAsBytesSync(image.buffer.asUint8List());
-
-      mockPickFilePaths(paths: [imagePath]);
-      await getIt<KeyValueStorage>().set(KVKeys.kCloudType, '0');
-
-      // Tap on the upload image button
-      await tester.tapButtonWithName(
-        LocaleKeys.document_imageBlock_upload_placeholder.tr(),
-      );
-      await tester.pumpAndSettle();
-
-      // Expect a cover to be shown
-      expect(find.byType(AFImage), findsOneWidget);
+      // Expect a cover to be shown - the default asset cover
+      expect(find.byType(RowCover), findsOneWidget);
 
       // Tap on the delete cover button
-      await tester.tapButtonWithName(
-        LocaleKeys.document_plugins_cover_removeCover.tr(),
-      );
+      await tester.tapButton(find.byType(DeleteCoverButton));
       await tester.pumpAndSettle();
 
       // Expect no cover to be shown
       expect(find.byType(AFImage), findsNothing);
-
-      // Remove the temp file
-      await Future.wait([file.delete()]);
     });
 
-    testWidgets('upload cover and check in Board', (tester) async {
+    testWidgets('add and change cover and check in Board', (tester) async {
       await tester.initializeAppFlowy();
       await tester.tapAnonymousSignInButton();
 
       await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Board);
-
-      // Open "Card 1"
-      await tester.tap(find.text('Card 1'));
       await tester.pumpAndSettle();
 
-      // Expect no cover (BannerCover is always in the Widget tree - thus check AFImage)
-      expect(find.byType(AFImage), findsNothing);
+      // Open "Card 1"
+      await tester.tap(find.text('Card 1'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      // Expect no cover
+      expect(find.byType(RowCover), findsNothing);
 
       // Hover on RowBanner to show Add Cover button
       await tester.hoverRowBanner();
 
       // Click on Add Cover button
       await tester.tapAddCoverButton();
+
+      // Expect default cover to be shown
+      expect(find.byType(RowCover), findsOneWidget);
 
       // Prepare image for upload from local
       final image = await rootBundle.load('assets/test/images/sample.jpeg');
@@ -163,11 +147,30 @@ void main() {
       mockPickFilePaths(paths: [imagePath]);
       await getIt<KeyValueStorage>().set(KVKeys.kCloudType, '0');
 
-      // Tap on the upload image button
+      // Hover on RowBanner to show Change Cover button
+      await tester.hoverRowBanner();
+
+      // Tap on the change cover button
+      await tester.tapButtonWithName(
+        LocaleKeys.document_plugins_cover_changeCover.tr(),
+      );
+      await tester.pumpAndSettle();
+
+      // Change tab to Upload tab
+      await tester.tapButtonWithName(
+        LocaleKeys.document_imageBlock_upload_label.tr(),
+      );
+
+      // Tab on the upload button
       await tester.tapButtonWithName(
         LocaleKeys.document_imageBlock_upload_placeholder.tr(),
       );
-      await tester.pumpAndSettle();
+
+      // Expect one cover
+      expect(find.byType(RowCover), findsOneWidget);
+
+      // Expect the cover to be shown both in RowCover and in CardCover
+      expect(find.byType(AFImage), findsNWidgets(2));
 
       // Dismiss Row Detail Page
       await tester.dismissRowDetailPage();

--- a/frontend/appflowy_flutter/integration_test/desktop/database/database_row_page_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/database/database_row_page_test.dart
@@ -1,12 +1,14 @@
-import 'package:appflowy/plugins/database/grid/presentation/widgets/header/desktop_field_cell.dart';
-import 'package:appflowy/plugins/database/widgets/row/row_detail.dart';
-import 'package:appflowy/util/field_type_extension.dart';
 import 'package:flutter/material.dart';
 
-import 'package:appflowy/plugins/database/widgets/row/row_banner.dart';
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/plugins/database/grid/presentation/widgets/header/desktop_field_cell.dart';
+import 'package:appflowy/plugins/database/widgets/row/row_detail.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart';
+import 'package:appflowy/util/field_type_extension.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/field_entities.pbenum.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/style_widget/text.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -36,26 +38,7 @@ void main() {
       await tester.assertDocumentExistInRowDetailPage();
     });
 
-    testWidgets('add emoji', (tester) async {
-      await tester.initializeAppFlowy();
-      await tester.tapAnonymousSignInButton();
-
-      // Create a new grid
-      await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Grid);
-
-      // Hover first row and then open the row page
-      await tester.openFirstRowDetailPage();
-
-      await tester.hoverRowBanner();
-
-      await tester.openEmojiPicker();
-      await tester.tapEmoji('😀');
-
-      // After select the emoji, the EmojiButton will show up
-      await tester.tapButton(find.byType(EmojiButton));
-    });
-
-    testWidgets('update emoji', (tester) async {
+    testWidgets('add and update emoji', (tester) async {
       await tester.initializeAppFlowy();
       await tester.tapAnonymousSignInButton();
 
@@ -68,8 +51,18 @@ void main() {
       await tester.openEmojiPicker();
       await tester.tapEmoji('😀');
 
-      // Update existing selected emoji
-      await tester.tapButton(find.byType(EmojiButton));
+      // expect to find the emoji selected
+      final firstEmojiFinder = find.byWidgetPredicate(
+        (w) => w is FlowyText && w.text == '😀',
+      );
+
+      // There are 2 eomjis - one in the row banner and another in the primary cell
+      expect(firstEmojiFinder, findsNWidgets(2));
+
+      // Update existing selected emoji - tap on it to update
+      await tester.tapButton(find.byType(EmojiIconWidget));
+      await tester.pumpAndSettle();
+
       await tester.tapEmoji('😅');
 
       // The emoji already displayed in the row banner
@@ -96,7 +89,9 @@ void main() {
       await tester.tapEmoji('😀');
 
       // Remove the emoji
-      await tester.tapButton(find.byType(RemoveEmojiButton));
+      await tester.tapButton(find.byType(EmojiIconWidget));
+      await tester.tapButton(find.text(LocaleKeys.button_remove.tr()));
+
       final emojiText = find.byWidgetPredicate(
         (widget) => widget is FlowyText && widget.text == '😀',
       );

--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_with_cover_image_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_with_cover_image_test.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_emoji_mart/flutter_emoji_mart.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/frontend/appflowy_flutter/integration_test/shared/database_test_op.dart
+++ b/frontend/appflowy_flutter/integration_test/shared/database_test_op.dart
@@ -70,7 +70,6 @@ import 'package:appflowy/plugins/database/widgets/setting/database_setting_actio
 import 'package:appflowy/plugins/database/widgets/setting/database_settings_list.dart';
 import 'package:appflowy/plugins/database/widgets/setting/setting_button.dart';
 import 'package:appflowy/plugins/database/widgets/setting/setting_property_list.dart';
-import 'package:appflowy/plugins/document/presentation/editor_plugins/image/upload_image_menu/upload_image_menu.dart';
 import 'package:appflowy/util/field_type_extension.dart';
 import 'package:appflowy/workspace/presentation/widgets/date_picker/widgets/clear_date_button.dart';
 import 'package:appflowy/workspace/presentation/widgets/date_picker/widgets/date_type_option_button.dart';
@@ -579,11 +578,10 @@ extension AppFlowyDatabaseTest on WidgetTester {
       LocaleKeys.document_plugins_cover_addCover.tr(),
     );
     await pumpAndSettle();
-    expect(find.byType(UploadImageMenu), findsOneWidget);
   }
 
   Future<void> openEmojiPicker() async =>
-      tapButton(find.byType(AddEmojiButton));
+      tapButton(find.text(LocaleKeys.document_plugins_cover_addIcon.tr()));
 
   Future<void> tapDateCellInRowDetailPage() async {
     final findDateCell = find.byType(EditableDateCell);

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/board/mobile_board_page.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/board/mobile_board_page.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/database/board/board.dart';
@@ -17,7 +19,6 @@ import 'package:appflowy_board/appflowy_board.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
@@ -235,29 +236,33 @@ class _BoardContentState extends State<_BoardContent> {
       key: ValueKey(groupItemId),
       margin: cardMargin,
       decoration: _makeBoxDecoration(context),
-      child: RowCard(
-        fieldController: boardBloc.fieldController,
-        rowMeta: rowMeta,
-        viewId: boardBloc.viewId,
-        rowCache: boardBloc.rowCache,
-        groupingFieldId: groupItem.fieldInfo.id,
-        isEditing: false,
-        cellBuilder: cellBuilder,
-        onTap: (context) {
-          context.push(
-            MobileRowDetailPage.routeName,
-            extra: {
-              MobileRowDetailPage.argRowId: rowMeta.id,
-              MobileRowDetailPage.argDatabaseController:
-                  context.read<BoardBloc>().databaseController,
-            },
-          );
-        },
-        onStartEditing: () {},
-        onEndEditing: () {},
-        styleConfiguration: RowCardStyleConfiguration(
-          cellStyleMap: mobileBoardCardCellStyleMap(context),
-          showAccessory: false,
+      child: BlocProvider.value(
+        value: boardBloc,
+        child: RowCard(
+          fieldController: boardBloc.fieldController,
+          rowMeta: rowMeta,
+          viewId: boardBloc.viewId,
+          rowCache: boardBloc.rowCache,
+          groupingFieldId: groupItem.fieldInfo.id,
+          isEditing: false,
+          cellBuilder: cellBuilder,
+          onTap: (context) {
+            context.push(
+              MobileRowDetailPage.routeName,
+              extra: {
+                MobileRowDetailPage.argRowId: rowMeta.id,
+                MobileRowDetailPage.argDatabaseController:
+                    context.read<BoardBloc>().databaseController,
+              },
+            );
+          },
+          onStartEditing: () {},
+          onEndEditing: () {},
+          styleConfiguration: RowCardStyleConfiguration(
+            cellStyleMap: mobileBoardCardCellStyleMap(context),
+            showAccessory: false,
+          ),
+          userProfile: boardBloc.userProfile,
         ),
       ),
     );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/mobile_card_detail_screen.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/mobile_card_detail_screen.dart
@@ -182,10 +182,11 @@ class _MobileRowDetailPageState extends State<MobileRowDetailPage> {
                         _bloc.add(
                           MobileRowDetailEvent.addCover(
                             RowCoverPB(
-                              url: path,
+                              data: path,
                               uploadType: isLocalMode
                                   ? FileUploadTypePB.LocalFile
                                   : FileUploadTypePB.CloudFile,
+                              coverType: CoverTypePB.FileCover,
                             ),
                           ),
                         );
@@ -258,8 +259,9 @@ class _MobileRowDetailPageState extends State<MobileRowDetailPage> {
     _bloc.add(
       MobileRowDetailEvent.addCover(
         RowCoverPB(
-          url: url,
+          data: url,
           uploadType: FileUploadTypePB.NetworkFile,
+          coverType: CoverTypePB.FileCover,
         ),
       ),
     );
@@ -410,7 +412,7 @@ class MobileRowDetailPageContentState
       child: BlocBuilder<RowDetailBloc, RowDetailState>(
         builder: (context, rowDetailState) => Column(
           children: [
-            if (rowDetailState.rowMeta.cover.url.isNotEmpty) ...[
+            if (rowDetailState.rowMeta.cover.data.isNotEmpty) ...[
               GestureDetector(
                 onTap: () => showMobileBottomSheet(
                   context,
@@ -443,7 +445,7 @@ class MobileRowDetailPageContentState
                       color: Theme.of(context).colorScheme.surface,
                     ),
                     child: AFImage(
-                      url: rowDetailState.rowMeta.cover.url,
+                      url: rowDetailState.rowMeta.cover.data,
                       uploadType: widget.rowMeta.cover.uploadType,
                       userProfile:
                           context.read<MobileRowDetailBloc>().userProfile,

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/mobile_card_content.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/mobile_card_content.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 
-import 'package:appflowy/plugins/database/board/application/board_bloc.dart';
 import 'package:appflowy/plugins/database/widgets/card/card.dart';
 import 'package:appflowy/plugins/database/widgets/card/card_bloc.dart';
 import 'package:appflowy/plugins/database/widgets/cell/card_cell_builder.dart';
 import 'package:appflowy/plugins/database/widgets/cell/card_cell_style_maps/mobile_board_card_cell_style.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
 
 class MobileCardContent extends StatelessWidget {
   const MobileCardContent({
@@ -15,23 +14,22 @@ class MobileCardContent extends StatelessWidget {
     required this.cellBuilder,
     required this.cells,
     required this.styleConfiguration,
+    required this.userProfile,
   });
 
   final RowMetaPB rowMeta;
   final CardCellBuilder cellBuilder;
   final List<CellMeta> cells;
   final RowCardStyleConfiguration styleConfiguration;
+  final UserProfilePB? userProfile;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (rowMeta.cover.url.isNotEmpty) ...[
-          CardCover(
-            cover: rowMeta.cover,
-            userProfile: context.read<BoardBloc>().userProfile,
-          ),
+        if (rowMeta.cover.data.isNotEmpty) ...[
+          CardCover(cover: rowMeta.cover, userProfile: userProfile),
         ],
         Padding(
           padding: styleConfiguration.cardPadding,

--- a/frontend/appflowy_flutter/lib/plugins/database/application/row/related_row_detail_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/row/related_row_detail_bloc.dart
@@ -1,11 +1,14 @@
 import 'package:appflowy/workspace/application/view/view_service.dart';
 import 'package:appflowy_backend/dispatch/dispatch.dart';
+import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
 import 'package:appflowy_result/appflowy_result.dart';
 import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../database_controller.dart';
+
 import 'row_controller.dart';
 
 part 'related_row_detail_bloc.freezed.dart';
@@ -20,6 +23,9 @@ class RelatedRowDetailPageBloc
     _init(databaseId, initialRowId);
   }
 
+  UserProfilePB? _userProfile;
+  UserProfilePB? get userProfile => _userProfile;
+
   @override
   Future<void> close() {
     state.whenOrNull(
@@ -33,11 +39,17 @@ class RelatedRowDetailPageBloc
 
   void _dispatch() {
     on<RelatedRowDetailPageEvent>((event, emit) async {
-      event.when(
-        didInitialize: (databaseController, rowController) {
-          rowController.initialize();
+      await event.when(
+        didInitialize: (databaseController, rowController) async {
+          final response = await UserEventGetUserProfile().send();
+          response.fold(
+            (userProfile) => _userProfile = userProfile,
+            (err) => Log.error(err),
+          );
 
-          state.maybeWhen(
+          await rowController.initialize();
+
+          await state.maybeWhen(
             ready: (_, oldRowController) async {
               await oldRowController.dispose();
               emit(

--- a/frontend/appflowy_flutter/lib/plugins/database/application/row/row_banner_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/row/row_banner_bloc.dart
@@ -34,7 +34,7 @@ class RowBannerBloc extends Bloc<RowBannerEvent, RowBannerState> {
   UserProfilePB? _userProfile;
   UserProfilePB? get userProfile => _userProfile;
 
-  bool get hasCover => state.rowMeta.cover.url.isNotEmpty;
+  bool get hasCover => state.rowMeta.cover.data.isNotEmpty;
 
   @override
   Future<void> close() async {
@@ -152,7 +152,7 @@ class RowBannerState extends Equatable with _$RowBannerState {
 
   @override
   List<Object?> get props => [
-        rowMeta.cover.url,
+        rowMeta.cover.data,
         rowMeta.icon,
         primaryField,
         loadingState,

--- a/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_event_card.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_event_card.dart
@@ -171,12 +171,14 @@ class _EventCardState extends State<EventCard> {
           ),
         );
       },
-      child: Material(
-        color: Colors.transparent,
-        child: Container(
-          padding: widget.padding,
-          decoration: decoration,
-          child: card,
+      child: Padding(
+        padding: widget.padding,
+        child: Material(
+          color: Colors.transparent,
+          child: DecoratedBox(
+            decoration: decoration,
+            child: card,
+          ),
         ),
       ),
     );

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_detail_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_detail_bloc.dart
@@ -22,6 +22,7 @@ class RowDetailBloc extends Bloc<RowDetailEvent, RowDetailState> {
     required this.fieldController,
     required this.rowController,
   })  : _metaListener = RowMetaListener(rowController.rowId),
+        _rowService = RowBackendService(viewId: rowController.viewId),
         super(RowDetailState.initial(rowController.rowMeta)) {
     _dispatch();
     _startListening();
@@ -33,7 +34,7 @@ class RowDetailBloc extends Bloc<RowDetailEvent, RowDetailState> {
   final FieldController fieldController;
   final RowController rowController;
   final RowMetaListener _metaListener;
-
+  final RowBackendService _rowService;
   final List<CellContext> allCells = [];
 
   @override
@@ -99,10 +100,9 @@ class RowDetailBloc extends Bloc<RowDetailEvent, RowDetailState> {
           endEditingField: () {
             emit(state.copyWith(editingFieldId: "", newFieldId: ""));
           },
-          removeCover: () {
-            RowBackendService(viewId: rowController.viewId)
-                .removeCover(rowController.rowId);
-          },
+          removeCover: () => _rowService.removeCover(rowController.rowId),
+          setCover: (cover) =>
+              _rowService.updateMeta(rowId: rowController.rowId, cover: cover),
           didReceiveRowMeta: (rowMeta) {
             emit(state.copyWith(rowMeta: rowMeta));
           },
@@ -263,6 +263,8 @@ class RowDetailEvent with _$RowDetailEvent {
   const factory RowDetailEvent.endEditingField() = _EndEditingField;
 
   const factory RowDetailEvent.removeCover() = _RemoveCover;
+
+  const factory RowDetailEvent.setCover(RowCoverPB cover) = _SetCover;
 
   const factory RowDetailEvent.didReceiveRowMeta(RowMetaPB rowMeta) =
       _DidReceiveRowMeta;

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/card/card.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/card/card.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';
+import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
 import 'package:appflowy/mobile/presentation/database/card/card.dart';
 import 'package:appflowy/plugins/database/application/field/field_controller.dart';
 import 'package:appflowy/plugins/database/application/row/row_cache.dart';
 import 'package:appflowy/plugins/database/application/row/row_controller.dart';
 import 'package:appflowy/plugins/database/grid/presentation/widgets/row/action.dart';
 import 'package:appflowy/shared/af_image.dart';
+import 'package:appflowy/shared/flowy_gradient_colors.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:collection/collection.dart';
+import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -40,7 +44,7 @@ class RowCard extends StatefulWidget {
     this.onShiftTap,
     this.groupingFieldId,
     this.groupId,
-    this.userProfile,
+    required this.userProfile,
     this.isCompact = false,
   });
 
@@ -140,6 +144,7 @@ class _RowCardState extends State<RowCard> {
       onTap: () => widget.onTap(context),
       behavior: HitTestBehavior.opaque,
       child: MobileCardContent(
+        userProfile: widget.userProfile,
         rowMeta: state.rowMeta,
         cellBuilder: widget.cellBuilder,
         styleConfiguration: widget.styleConfiguration,
@@ -282,7 +287,7 @@ class CardCover extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (cover == null ||
-        cover!.url.isEmpty ||
+        cover!.data.isEmpty ||
         cover!.uploadType == FileUploadTypePB.CloudFile &&
             userProfile == null) {
       return const SizedBox.shrink();
@@ -299,17 +304,59 @@ class CardCover extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Expanded(
-            child: AFImage(
-              url: cover!.url,
-              uploadType: cover!.uploadType,
-              userProfile: userProfile,
-              height: isCompact ? 50 : 100,
-            ),
-          ),
+          Expanded(child: _renderCover(context, cover!)),
         ],
       ),
     );
+  }
+
+  Widget _renderCover(BuildContext context, RowCoverPB cover) {
+    final height = isCompact ? 50.0 : 100.0;
+
+    if (cover.coverType == CoverTypePB.FileCover) {
+      return SizedBox(
+        height: height,
+        width: double.infinity,
+        child: AFImage(
+          url: cover.data,
+          uploadType: cover.uploadType,
+          userProfile: userProfile,
+        ),
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.AssetCover) {
+      return SizedBox(
+        height: height,
+        width: double.infinity,
+        child: Image.asset(
+          PageStyleCoverImageType.builtInImagePath(cover.data),
+          fit: BoxFit.cover,
+        ),
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.ColorCover) {
+      final color = FlowyTint.fromId(cover.data)?.color(context) ??
+          cover.data.tryToColor();
+      return Container(
+        height: height,
+        width: double.infinity,
+        color: color,
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.GradientCover) {
+      return Container(
+        height: height,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          gradient: FlowyGradientColor.fromId(cover.data).linear,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
   }
 }
 

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_media_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_media_cell.dart
@@ -33,11 +33,9 @@ const _defaultFilesToDisplay = 5;
 
 class DekstopRowDetailMediaCellSkin extends IEditableMediaCellSkin {
   final mutex = PopoverMutex();
-  final addFileController = PopoverController();
 
   @override
   void dispose() {
-    addFileController.close();
     mutex.dispose();
   }
 
@@ -67,7 +65,7 @@ class DekstopRowDetailMediaCellSkin extends IEditableMediaCellSkin {
                 builder: (context, constraints) {
                   if (state.files.isEmpty) {
                     return _AddFileButton(
-                      controller: addFileController,
+                      controller: popoverController,
                       direction: PopoverDirection.bottomWithLeftAligned,
                       mutex: mutex,
                       child: FlowyHover(
@@ -76,12 +74,12 @@ class DekstopRowDetailMediaCellSkin extends IEditableMediaCellSkin {
                               AFThemeExtension.of(context).lightGreyHover,
                         ),
                         child: GestureDetector(
-                          onTap: addFileController.show,
+                          onTap: popoverController.show,
                           behavior: HitTestBehavior.translucent,
                           child: Padding(
                             padding: const EdgeInsets.symmetric(
                               horizontal: 8,
-                              vertical: 6,
+                              vertical: 5,
                             ),
                             child: FlowyText.medium(
                               LocaleKeys.grid_row_textPlaceholder.tr(),
@@ -114,12 +112,12 @@ class DekstopRowDetailMediaCellSkin extends IEditableMediaCellSkin {
                         width: size,
                         height: size / 2,
                         child: _AddFileButton(
-                          controller: addFileController,
+                          controller: popoverController,
                           mutex: mutex,
                           child: FlowyHover(
                             resetHoverOnRebuild: false,
                             child: GestureDetector(
-                              onTap: addFileController.show,
+                              onTap: popoverController.show,
                               behavior: HitTestBehavior.translucent,
                               child: Padding(
                                 padding: const EdgeInsets.all(8.0),
@@ -176,6 +174,7 @@ class _AddFileButton extends StatelessWidget {
       mutex: mutex,
       offset: const Offset(0, 10),
       direction: direction,
+      constraints: const BoxConstraints(maxWidth: 350),
       popupBuilder: (_) => FileUploadMenu(
         allowMultipleFiles: true,
         onInsertLocalFile: (files) => insertLocalFiles(

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_media_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_row_detail/desktop_row_detail_media_cell.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database/application/cell/bloc/media_cell_bloc.dart';
+import 'package:appflowy/plugins/database/grid/application/row/row_detail_bloc.dart';
 import 'package:appflowy/plugins/database/widgets/cell/editable_cell_skeleton/media.dart';
 import 'package:appflowy/plugins/database/widgets/cell_editor/media_cell_editor.dart';
 import 'package:appflowy/plugins/database/widgets/media_file_type_ext.dart';
@@ -17,8 +18,7 @@ import 'package:appflowy/util/xfile_ext.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy/workspace/presentation/widgets/image_viewer/image_provider.dart';
 import 'package:appflowy/workspace/presentation/widgets/image_viewer/interactive_image_viewer.dart';
-import 'package:appflowy_backend/protobuf/flowy-database2/file_entities.pbenum.dart';
-import 'package:appflowy_backend/protobuf/flowy-database2/media_entities.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:collection/collection.dart';
 import 'package:cross_file/cross_file.dart';
@@ -79,7 +79,7 @@ class DekstopRowDetailMediaCellSkin extends IEditableMediaCellSkin {
                           child: Padding(
                             padding: const EdgeInsets.symmetric(
                               horizontal: 8,
-                              vertical: 5,
+                              vertical: 6,
                             ),
                             child: FlowyText.medium(
                               LocaleKeys.grid_row_textPlaceholder.tr(),
@@ -318,7 +318,7 @@ class _FilePreviewRenderState extends State<_FilePreviewRender> {
 
     return AppFlowyPopover(
       controller: controller,
-      constraints: const BoxConstraints(maxWidth: 150),
+      constraints: const BoxConstraints(maxWidth: 165),
       offset: const Offset(0, 5),
       onClose: () => setState(() => isSelected = false),
       popupBuilder: (_) => SeparatedColumn(
@@ -359,6 +359,31 @@ class _FilePreviewRenderState extends State<_FilePreviewRender> {
               ),
               text: FlowyText.regular(
                 LocaleKeys.settings_files_open.tr(),
+                color: AFThemeExtension.of(context).textColor,
+              ),
+              leftIconSize: const Size(18, 18),
+              hoverColor: AFThemeExtension.of(context).lightGreyHover,
+            ),
+            FlowyButton(
+              onTap: () {
+                controller.close();
+                context.read<RowDetailBloc>().add(
+                      RowDetailEvent.setCover(
+                        RowCoverPB(
+                          data: file.url,
+                          uploadType: file.uploadType,
+                          coverType: CoverTypePB.FileCover,
+                        ),
+                      ),
+                    );
+              },
+              leftIcon: FlowySvg(
+                FlowySvgs.add_cover_s,
+                color: Theme.of(context).iconTheme.color,
+                size: const Size.square(18),
+              ),
+              text: FlowyText.regular(
+                LocaleKeys.grid_media_setAsCover.tr(),
                 color: AFThemeExtension.of(context).textColor,
               ),
               leftIconSize: const Size(18, 18),

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
@@ -3,28 +3,45 @@ import 'package:flutter/services.dart';
 
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
+import 'package:appflowy/plugins/base/emoji/emoji_picker_screen.dart';
 import 'package:appflowy/plugins/database/application/cell/bloc/text_cell_bloc.dart';
 import 'package:appflowy/plugins/database/application/cell/cell_controller.dart';
 import 'package:appflowy/plugins/database/application/database_controller.dart';
 import 'package:appflowy/plugins/database/application/row/row_banner_bloc.dart';
 import 'package:appflowy/plugins/database/application/row/row_controller.dart';
+import 'package:appflowy/plugins/database/grid/presentation/layout/sizes.dart';
 import 'package:appflowy/plugins/database/widgets/cell/card_cell_skeleton/text_card_cell.dart';
 import 'package:appflowy/plugins/database/widgets/cell/editable_cell_builder.dart';
 import 'package:appflowy/plugins/database/widgets/cell/editable_cell_skeleton/text.dart';
 import 'package:appflowy/plugins/database/widgets/row/cells/cell_container.dart';
 import 'package:appflowy/plugins/database/widgets/row/row_action.dart';
-import 'package:appflowy/plugins/document/presentation/editor_plugins/file/file_util.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/image/image_util.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/image/upload_image_menu/upload_image_menu.dart';
+import 'package:appflowy/plugins/shared/cover_type_ext.dart';
 import 'package:appflowy/shared/af_image.dart';
-import 'package:appflowy/workspace/presentation/settings/widgets/emoji_picker/emoji_picker.dart';
+import 'package:appflowy/shared/flowy_gradient_colors.dart';
+import 'package:appflowy/shared/icon_emoji_picker/flowy_icon_emoji_picker.dart';
 import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/auth.pbenum.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
+import 'package:appflowy_editor/appflowy_editor.dart' hide UploadImageMenu;
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flowy_infra_ui/widget/rounded_button.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:string_validator/string_validator.dart';
+import 'package:universal_platform/universal_platform.dart';
 
-const _kBannerActionHeight = 40.0;
+import '../../../document/presentation/editor_plugins/plugins.dart';
+
+const _coverHeight = 250.0;
+const _iconHeight = 60.0;
+const _toolbarHeight = 40.0;
 
 class RowBanner extends StatefulWidget {
   const RowBanner({
@@ -48,7 +65,9 @@ class RowBanner extends StatefulWidget {
 
 class _RowBannerState extends State<RowBanner> {
   final _isHovering = ValueNotifier(false);
-  final popoverController = PopoverController();
+  late final isLocalMode =
+      (widget.userProfile?.authenticator ?? AuthenticatorPB.Local) ==
+          AuthenticatorPB.Local;
 
   @override
   void dispose() {
@@ -64,43 +83,447 @@ class _RowBannerState extends State<RowBanner> {
         fieldController: widget.databaseController.fieldController,
         rowMeta: widget.rowController.rowMeta,
       )..add(const RowBannerEvent.initial()),
-      child: Builder(
-        builder: (context) => MouseRegion(
-          onEnter: (event) => _isHovering.value = true,
-          onExit: (event) => _isHovering.value = false,
-          child: Padding(
-            padding: EdgeInsets.zero,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                BannerCover(userProfile: widget.userProfile),
-                Padding(
-                  padding: EdgeInsets.fromLTRB(
-                    60,
-                    context.watch<RowBannerBloc>().hasCover ? 4 : 34,
-                    60,
-                    0,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+      child: BlocBuilder<RowBannerBloc, RowBannerState>(
+        builder: (context, state) {
+          final hasCover = state.rowMeta.cover.data.isNotEmpty;
+          final hasIcon = state.rowMeta.icon.isNotEmpty;
+
+          return Column(
+            children: [
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  return Stack(
                     children: [
                       SizedBox(
-                        height: 30,
-                        child: _BannerAction(
-                          rowId: widget.rowController.rowId,
-                          isHovering: _isHovering,
-                          popoverController: popoverController,
+                        height: _calculateOverallHeight(hasIcon, hasCover),
+                        width: constraints.maxWidth,
+                        child: RowHeaderToolbar(
+                          offset: GridSize.horizontalHeaderPadding + 20,
+                          hasIcon: hasIcon,
+                          hasCover: hasCover,
+                          onIconChanged: (icon) {
+                            if (icon != null) {
+                              context
+                                  .read<RowBannerBloc>()
+                                  .add(RowBannerEvent.setIcon(icon));
+                            }
+                          },
+                          onCoverChanged: (cover) {
+                            if (cover != null) {
+                              context
+                                  .read<RowBannerBloc>()
+                                  .add(RowBannerEvent.setCover(cover));
+                            }
+                          },
                         ),
                       ),
-                      const VSpace(8),
-                      _BannerTitle(
-                        cellBuilder: widget.cellBuilder,
-                        popoverController: popoverController,
-                        rowController: widget.rowController,
-                      ),
+                      if (hasCover)
+                        RowCover(
+                          rowId: widget.rowController.rowId,
+                          cover: state.rowMeta.cover,
+                          userProfile: widget.userProfile,
+                          onCoverChanged: (type, details, uploadType) {
+                            if (details != null) {
+                              context.read<RowBannerBloc>().add(
+                                    RowBannerEvent.setCover(
+                                      RowCoverPB(
+                                        data: details,
+                                        uploadType: uploadType,
+                                        coverType: type.into(),
+                                      ),
+                                    ),
+                                  );
+                            } else {
+                              context
+                                  .read<RowBannerBloc>()
+                                  .add(const RowBannerEvent.removeCover());
+                            }
+                          },
+                          isLocalMode: isLocalMode,
+                        ),
+                      if (hasIcon)
+                        Positioned(
+                          left: GridSize.horizontalHeaderPadding + 20,
+                          bottom: hasCover
+                              ? _toolbarHeight - _iconHeight / 2
+                              : _toolbarHeight,
+                          child: RowIcon(
+                            icon: state.rowMeta.icon,
+                            onIconChanged: (icon) {
+                              if (icon == null || icon.isEmpty) {
+                                context
+                                    .read<RowBannerBloc>()
+                                    .add(const RowBannerEvent.setIcon(""));
+                              } else {
+                                context
+                                    .read<RowBannerBloc>()
+                                    .add(RowBannerEvent.setIcon(icon));
+                              }
+                            },
+                          ),
+                        ),
                     ],
+                  );
+                },
+              ),
+              const VSpace(8),
+              _BannerTitle(
+                cellBuilder: widget.cellBuilder,
+                rowController: widget.rowController,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  double _calculateOverallHeight(bool hasIcon, bool hasCover) {
+    switch ((hasIcon, hasCover)) {
+      case (true, true):
+        return _coverHeight + _toolbarHeight;
+      case (true, false):
+        return 50 + _iconHeight + _toolbarHeight;
+      case (false, true):
+        return _coverHeight + _toolbarHeight;
+      case (false, false):
+        return _toolbarHeight;
+    }
+  }
+}
+
+class RowCover extends StatefulWidget {
+  const RowCover({
+    super.key,
+    required this.rowId,
+    required this.cover,
+    this.userProfile,
+    required this.onCoverChanged,
+    this.isLocalMode = true,
+  });
+
+  final String rowId;
+  final RowCoverPB cover;
+  final UserProfilePB? userProfile;
+  final void Function(
+    CoverType type,
+    String? details,
+    FileUploadTypePB? uploadType,
+  ) onCoverChanged;
+  final bool isLocalMode;
+
+  @override
+  State<RowCover> createState() => _RowCoverState();
+}
+
+class _RowCoverState extends State<RowCover> {
+  final popoverController = PopoverController();
+  bool isOverlayButtonsHidden = true;
+  bool isPopoverOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: _coverHeight,
+      child: MouseRegion(
+        onEnter: (_) => setState(() => isOverlayButtonsHidden = false),
+        onExit: (_) => setState(() => isOverlayButtonsHidden = true),
+        child: Stack(
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: DesktopRowCover(
+                cover: widget.cover,
+                userProfile: widget.userProfile,
+              ),
+            ),
+            if (!isOverlayButtonsHidden || isPopoverOpen)
+              _buildCoverOverlayButtons(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCoverOverlayButtons(BuildContext context) {
+    return Positioned(
+      bottom: 20,
+      right: 50,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppFlowyPopover(
+            controller: popoverController,
+            triggerActions: PopoverTriggerFlags.none,
+            offset: const Offset(0, 8),
+            direction: PopoverDirection.bottomWithCenterAligned,
+            constraints: const BoxConstraints(
+              maxWidth: 540,
+              maxHeight: 360,
+              minHeight: 80,
+            ),
+            margin: EdgeInsets.zero,
+            onClose: () => setState(() => isPopoverOpen = false),
+            child: IntrinsicWidth(
+              child: RoundedTextButton(
+                height: 28.0,
+                onPressed: () => popoverController.show(),
+                hoverColor: Theme.of(context).colorScheme.surface,
+                textColor: Theme.of(context).colorScheme.tertiary,
+                fillColor:
+                    Theme.of(context).colorScheme.surface.withOpacity(0.5),
+                title: LocaleKeys.document_plugins_cover_changeCover.tr(),
+              ),
+            ),
+            popupBuilder: (BuildContext popoverContext) {
+              isPopoverOpen = true;
+
+              return UploadImageMenu(
+                limitMaximumImageSize: !widget.isLocalMode,
+                supportTypes: const [
+                  UploadImageType.color,
+                  UploadImageType.local,
+                  UploadImageType.url,
+                  UploadImageType.unsplash,
+                ],
+                onSelectedAIImage: (_) => throw UnimplementedError(),
+                onSelectedLocalImages: (files) {
+                  popoverController.close();
+                  if (files.isEmpty) {
+                    return;
+                  }
+
+                  final item = files.map((file) => file.path).first;
+                  onCoverChanged(
+                    CoverType.file,
+                    item,
+                    widget.isLocalMode
+                        ? FileUploadTypePB.LocalFile
+                        : FileUploadTypePB.CloudFile,
+                  );
+                },
+                onSelectedNetworkImage: (url) {
+                  popoverController.close();
+                  onCoverChanged(
+                    CoverType.file,
+                    url,
+                    FileUploadTypePB.NetworkFile,
+                  );
+                },
+                onSelectedColor: (color) {
+                  popoverController.close();
+                  onCoverChanged(
+                    CoverType.color,
+                    color,
+                    FileUploadTypePB.LocalFile,
+                  );
+                },
+              );
+            },
+          ),
+          const HSpace(10),
+          DeleteCoverButton(
+            onTap: () => widget.onCoverChanged(CoverType.none, null, null),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> onCoverChanged(
+    CoverType type,
+    String? details,
+    FileUploadTypePB? uploadType,
+  ) async {
+    if (type == CoverType.file && details != null && !isURL(details)) {
+      if (widget.isLocalMode) {
+        details = await saveImageToLocalStorage(details);
+      } else {
+        // else we should save the image to cloud storage
+        (details, _) = await saveImageToCloudStorage(details, widget.rowId);
+      }
+    }
+    widget.onCoverChanged(type, details, uploadType);
+  }
+}
+
+class DesktopRowCover extends StatefulWidget {
+  const DesktopRowCover({super.key, required this.cover, this.userProfile});
+
+  final RowCoverPB cover;
+  final UserProfilePB? userProfile;
+
+  @override
+  State<DesktopRowCover> createState() => _DesktopRowCoverState();
+}
+
+class _DesktopRowCoverState extends State<DesktopRowCover> {
+  RowCoverPB get cover => widget.cover;
+
+  @override
+  Widget build(BuildContext context) {
+    if (cover.coverType == CoverTypePB.FileCover) {
+      return SizedBox(
+        height: _coverHeight,
+        width: double.infinity,
+        child: AFImage(
+          url: cover.data,
+          uploadType: cover.uploadType,
+          userProfile: widget.userProfile,
+        ),
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.AssetCover) {
+      return SizedBox(
+        height: _coverHeight,
+        width: double.infinity,
+        child: Image.asset(
+          PageStyleCoverImageType.builtInImagePath(cover.data),
+          fit: BoxFit.cover,
+        ),
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.ColorCover) {
+      final color = FlowyTint.fromId(cover.data)?.color(context) ??
+          cover.data.tryToColor();
+      return Container(
+        height: _coverHeight,
+        width: double.infinity,
+        color: color,
+      );
+    }
+
+    if (cover.coverType == CoverTypePB.GradientCover) {
+      return Container(
+        height: _coverHeight,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          gradient: FlowyGradientColor.fromId(cover.data).linear,
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+}
+
+class RowHeaderToolbar extends StatefulWidget {
+  const RowHeaderToolbar({
+    super.key,
+    required this.offset,
+    required this.hasIcon,
+    required this.hasCover,
+    required this.onIconChanged,
+    required this.onCoverChanged,
+  });
+
+  final double offset;
+  final bool hasIcon;
+  final bool hasCover;
+
+  /// Returns null if the icon is removed.
+  ///
+  final void Function(String? icon) onIconChanged;
+
+  /// Returns null if the cover is removed.
+  ///
+  final void Function(RowCoverPB? cover) onCoverChanged;
+
+  @override
+  State<RowHeaderToolbar> createState() => _RowHeaderToolbarState();
+}
+
+class _RowHeaderToolbarState extends State<RowHeaderToolbar> {
+  final popoverController = PopoverController();
+  final bool isDesktop = UniversalPlatform.isDesktopOrWeb;
+
+  bool isHidden = UniversalPlatform.isDesktopOrWeb;
+  bool isPopoverOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isDesktop) {
+      return const SizedBox.shrink();
+    }
+
+    return MouseRegion(
+      opaque: false,
+      onEnter: (_) => setState(() => isHidden = false),
+      onExit: isPopoverOpen ? null : (_) => setState(() => isHidden = true),
+      child: Container(
+        alignment: Alignment.bottomLeft,
+        width: double.infinity,
+        padding: EdgeInsets.symmetric(horizontal: widget.offset),
+        child: SizedBox(
+          height: 28,
+          child: Visibility(
+            visible: !isHidden || isPopoverOpen,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (!widget.hasCover)
+                  FlowyButton(
+                    resetHoverOnRebuild: false,
+                    useIntrinsicWidth: true,
+                    leftIconSize: const Size.square(18),
+                    leftIcon: const FlowySvg(FlowySvgs.add_cover_s),
+                    text: FlowyText.small(
+                      LocaleKeys.document_plugins_cover_addCover.tr(),
+                    ),
+                    onTap: () => widget.onCoverChanged(
+                      RowCoverPB(
+                        data: isDesktop ? '1' : '0xffe8e0ff',
+                        uploadType: FileUploadTypePB.LocalFile,
+                        coverType: isDesktop
+                            ? CoverTypePB.AssetCover
+                            : CoverTypePB.ColorCover,
+                      ),
+                    ),
                   ),
-                ),
+                if (!widget.hasIcon)
+                  AppFlowyPopover(
+                    controller: popoverController,
+                    onClose: () => setState(() => isPopoverOpen = false),
+                    offset: const Offset(0, 8),
+                    direction: PopoverDirection.bottomWithCenterAligned,
+                    constraints: BoxConstraints.loose(const Size(360, 380)),
+                    margin: EdgeInsets.zero,
+                    triggerActions: PopoverTriggerFlags.none,
+                    popupBuilder: (_) {
+                      isPopoverOpen = true;
+                      return FlowyIconEmojiPicker(
+                        onSelectedEmoji: (result) {
+                          widget.onIconChanged(result.emoji);
+                          popoverController.close();
+                        },
+                      );
+                    },
+                    child: FlowyButton(
+                      useIntrinsicWidth: true,
+                      leftIconSize: const Size.square(18),
+                      leftIcon: const FlowySvg(FlowySvgs.add_icon_s),
+                      text: FlowyText.small(
+                        widget.hasIcon
+                            ? LocaleKeys.document_plugins_cover_removeIcon.tr()
+                            : LocaleKeys.document_plugins_cover_addIcon.tr(),
+                      ),
+                      onTap: () async {
+                        if (!isDesktop) {
+                          final result = await context.push<EmojiPickerResult>(
+                            MobileEmojiPickerScreen.routeName,
+                          );
+
+                          if (result != null) {
+                            widget.onIconChanged(result.emoji);
+                          }
+                        } else {
+                          popoverController.show();
+                        }
+                      },
+                    ),
+                  ),
               ],
             ),
           ),
@@ -110,74 +533,42 @@ class _RowBannerState extends State<RowBanner> {
   }
 }
 
-class _BannerAction extends StatefulWidget {
-  const _BannerAction({
-    required this.isHovering,
-    required this.popoverController,
-    required this.rowId,
+class RowIcon extends StatefulWidget {
+  const RowIcon({
+    super.key,
+    required this.icon,
+    required this.onIconChanged,
   });
 
-  final ValueNotifier<bool> isHovering;
-  final PopoverController popoverController;
-  final String rowId;
+  final String icon;
+  final void Function(String?) onIconChanged;
 
   @override
-  State<_BannerAction> createState() => _BannerActionState();
+  State<RowIcon> createState() => _RowIconState();
 }
 
-class _BannerActionState extends State<_BannerAction> {
-  bool isSelected = false;
+class _RowIconState extends State<RowIcon> {
+  final controller = PopoverController();
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: _kBannerActionHeight,
-      child: ValueListenableBuilder(
-        valueListenable: widget.isHovering,
-        builder: (BuildContext context, bool isHovering, Widget? child) {
-          if (!isHovering && !isSelected) {
-            return const SizedBox.shrink();
-          }
+    if (widget.icon.isEmpty) {
+      return const SizedBox.shrink();
+    }
 
-          return BlocBuilder<RowBannerBloc, RowBannerState>(
-            builder: (context, state) {
-              return Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (state.rowMeta.icon.isEmpty)
-                    AddEmojiButton(
-                      onTap: () => widget.popoverController.show(),
-                    )
-                  else
-                    RemoveEmojiButton(
-                      onTap: () => context
-                          .read<RowBannerBloc>()
-                          .add(const RowBannerEvent.setIcon('')),
-                    ),
-                  const HSpace(8),
-                  if (state.rowMeta.cover.url.isEmpty)
-                    AddCoverButton(
-                      rowId: widget.rowId,
-                      onPopoverChanged: (isShowing) {
-                        isSelected = isShowing;
-
-                        if (!isShowing) {
-                          setState(() {});
-                        }
-                      },
-                    )
-                  else
-                    RemoveCoverButton(
-                      onTap: () => context
-                          .read<RowBannerBloc>()
-                          .add(const RowBannerEvent.removeCover()),
-                    ),
-                ],
-              );
-            },
-          );
+    return AppFlowyPopover(
+      controller: controller,
+      offset: const Offset(0, 8),
+      direction: PopoverDirection.bottomWithCenterAligned,
+      constraints: BoxConstraints.loose(const Size(360, 380)),
+      margin: EdgeInsets.zero,
+      popupBuilder: (_) => FlowyIconEmojiPicker(
+        onSelectedEmoji: (result) {
+          controller.close();
+          widget.onIconChanged(result.emoji);
         },
       ),
+      child: EmojiIconWidget(emoji: widget.icon),
     );
   }
 }
@@ -185,25 +576,17 @@ class _BannerActionState extends State<_BannerAction> {
 class _BannerTitle extends StatelessWidget {
   const _BannerTitle({
     required this.cellBuilder,
-    required this.popoverController,
     required this.rowController,
   });
 
   final EditableCellBuilder cellBuilder;
-  final PopoverController popoverController;
   final RowController rowController;
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<RowBannerBloc, RowBannerState>(
       builder: (context, state) {
-        final children = <Widget>[
-          if (state.rowMeta.icon.isNotEmpty)
-            EmojiButton(
-              emoji: state.rowMeta.icon,
-              showEmojiPicker: () => popoverController.show(),
-            ),
-          const HSpace(4),
+        final children = [
           if (state.primaryField != null)
             Expanded(
               child: cellBuilder.buildCustom(
@@ -216,263 +599,11 @@ class _BannerTitle extends StatelessWidget {
             ),
         ];
 
-        return AppFlowyPopover(
-          controller: popoverController,
-          triggerActions: PopoverTriggerFlags.none,
-          direction: PopoverDirection.bottomWithLeftAligned,
-          constraints: const BoxConstraints(maxWidth: 380, maxHeight: 300),
-          popupBuilder: (popoverContext) => EmojiSelectionMenu(
-            onSubmitted: (emoji) {
-              popoverController.close();
-              context.read<RowBannerBloc>().add(RowBannerEvent.setIcon(emoji));
-            },
-            onExit: () {},
-          ),
+        return Padding(
+          padding: const EdgeInsets.only(left: 60),
           child: Row(children: children),
         );
       },
-    );
-  }
-}
-
-@visibleForTesting
-class BannerCover extends StatelessWidget {
-  const BannerCover({super.key, required this.userProfile});
-
-  final UserProfilePB? userProfile;
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<RowBannerBloc, RowBannerState>(
-      buildWhen: (prev, curr) =>
-          prev.rowMeta.cover.url != curr.rowMeta.cover.url,
-      builder: (context, state) {
-        final cover = state.rowMeta.cover;
-        if (cover.url.isEmpty) {
-          return const SizedBox.shrink();
-        }
-
-        return Row(
-          children: [
-            Expanded(
-              child: SizedBox(
-                height: 250,
-                child: Container(
-                  clipBehavior: Clip.antiAlias,
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surface,
-                  ),
-                  child: AFImage(
-                    url: cover.url,
-                    uploadType: cover.uploadType,
-                    userProfile: userProfile,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class EmojiButton extends StatelessWidget {
-  const EmojiButton({
-    super.key,
-    required this.emoji,
-    required this.showEmojiPicker,
-  });
-
-  final String emoji;
-  final VoidCallback showEmojiPicker;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: _kBannerActionHeight,
-      child: FlowyButton(
-        margin: EdgeInsets.zero,
-        text: FlowyText.medium(
-          emoji,
-          fontSize: 30,
-          textAlign: TextAlign.center,
-        ),
-        onTap: showEmojiPicker,
-      ),
-    );
-  }
-}
-
-class AddCoverButton extends StatelessWidget {
-  const AddCoverButton({
-    super.key,
-    required this.rowId,
-    required this.onPopoverChanged,
-  });
-
-  final String rowId;
-  final void Function(bool) onPopoverChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return AppFlowyPopover(
-      direction: PopoverDirection.bottomWithCenterAligned,
-      offset: const Offset(0, 5),
-      onOpen: () => onPopoverChanged(true),
-      onClose: () => onPopoverChanged(false),
-      popupBuilder: (_) => BlocProvider.value(
-        value: context.read<RowBannerBloc>(),
-        child: Builder(
-          builder: (context) {
-            return UploadImageMenu(
-              supportTypes: const [UploadImageType.local, UploadImageType.url],
-              onSelectedLocalImages: (images) async {
-                if (images.isEmpty) {
-                  return;
-                }
-
-                final image = images.first;
-                await insertLocalFile(
-                  context,
-                  image,
-                  userProfile: context.read<RowBannerBloc>().userProfile,
-                  documentId: rowId,
-                  onUploadSuccess: (url, isLocalMode) {
-                    context.read<RowBannerBloc>().add(
-                          RowBannerEvent.setCover(
-                            RowCoverPB(
-                              url: url,
-                              uploadType: isLocalMode
-                                  ? FileUploadTypePB.LocalFile
-                                  : FileUploadTypePB.CloudFile,
-                            ),
-                          ),
-                        );
-                  },
-                );
-                onPopoverChanged(false);
-              },
-              onSelectedNetworkImage: (String url) {
-                context.read<RowBannerBloc>().add(
-                      RowBannerEvent.setCover(
-                        RowCoverPB(
-                          url: url,
-                          uploadType: FileUploadTypePB.NetworkFile,
-                        ),
-                      ),
-                    );
-                onPopoverChanged(false);
-              },
-              onSelectedAIImage: (_) {},
-            );
-          },
-        ),
-      ),
-      child: SizedBox(
-        height: 26,
-        child: FlowyButton(
-          useIntrinsicWidth: true,
-          text: FlowyText.medium(
-            lineHeight: 1.0,
-            LocaleKeys.document_plugins_cover_addCover.tr(),
-          ),
-          leftIcon: const FlowySvg(FlowySvgs.image_s),
-          margin: const EdgeInsets.all(4),
-        ),
-      ),
-    );
-  }
-}
-
-class AddEmojiButton extends StatelessWidget {
-  const AddEmojiButton({super.key, required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 26,
-      child: FlowyButton(
-        useIntrinsicWidth: true,
-        text: FlowyText.medium(
-          lineHeight: 1.0,
-          LocaleKeys.document_plugins_cover_addIcon.tr(),
-        ),
-        leftIcon: const FlowySvg(FlowySvgs.emoji_s),
-        onTap: onTap,
-        margin: const EdgeInsets.all(4),
-      ),
-    );
-  }
-}
-
-class RemoveCoverButton extends StatelessWidget {
-  const RemoveCoverButton({super.key, required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 26,
-      child: FlowyButton(
-        useIntrinsicWidth: true,
-        text: FlowyText.medium(
-          lineHeight: 1.0,
-          LocaleKeys.document_plugins_cover_removeCover.tr(),
-        ),
-        leftIcon: const FlowySvg(FlowySvgs.image_s),
-        onTap: onTap,
-        margin: const EdgeInsets.all(4),
-      ),
-    );
-  }
-}
-
-class RemoveEmojiButton extends StatelessWidget {
-  const RemoveEmojiButton({super.key, required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      height: 26,
-      child: FlowyButton(
-        useIntrinsicWidth: true,
-        text: FlowyText.medium(
-          lineHeight: 1.0,
-          LocaleKeys.document_plugins_cover_removeIcon.tr(),
-        ),
-        leftIcon: const FlowySvg(FlowySvgs.emoji_s),
-        onTap: onTap,
-        margin: const EdgeInsets.all(4),
-      ),
-    );
-  }
-}
-
-class RowActionButton extends StatelessWidget {
-  const RowActionButton({super.key, required this.rowController});
-
-  final RowController rowController;
-
-  @override
-  Widget build(BuildContext context) {
-    return AppFlowyPopover(
-      direction: PopoverDirection.bottomWithLeftAligned,
-      popupBuilder: (context) => RowActionList(rowController: rowController),
-      child: FlowyTooltip(
-        message: LocaleKeys.grid_rowPage_moreRowActions.tr(),
-        child: FlowyIconButton(
-          width: 20,
-          height: 20,
-          icon: const FlowySvg(FlowySvgs.details_horizontal_s),
-          iconColorOnHover: Theme.of(context).colorScheme.onSurface,
-        ),
-      ),
     );
   }
 }
@@ -513,6 +644,29 @@ class _TitleSkin extends IEditableTextCellSkin {
         onEditingComplete: () {
           bloc.add(TextCellEvent.updateText(textEditingController.text));
         },
+      ),
+    );
+  }
+}
+
+class RowActionButton extends StatelessWidget {
+  const RowActionButton({super.key, required this.rowController});
+
+  final RowController rowController;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppFlowyPopover(
+      direction: PopoverDirection.bottomWithLeftAligned,
+      popupBuilder: (context) => RowActionList(rowController: rowController),
+      child: FlowyTooltip(
+        message: LocaleKeys.grid_rowPage_moreRowActions.tr(),
+        child: FlowyIconButton(
+          width: 20,
+          height: 20,
+          icon: const FlowySvg(FlowySvgs.details_horizontal_s),
+          iconColorOnHover: Theme.of(context).colorScheme.onSurface,
+        ),
       ),
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/row/row_banner.dart
@@ -459,7 +459,9 @@ class _RowHeaderToolbarState extends State<RowHeaderToolbar> {
         child: SizedBox(
           height: 28,
           child: Visibility(
-            visible: !isHidden || isPopoverOpen,
+            visible: !isHidden ||
+                isPopoverOpen ||
+                (!widget.hasIcon || !widget.hasCover),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/frontend/appflowy_flutter/lib/plugins/database_document/database_document_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_document/database_document_page.dart
@@ -1,7 +1,10 @@
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/plugins/database/application/row/related_row_detail_bloc.dart';
 import 'package:appflowy/plugins/database/grid/application/row/row_detail_bloc.dart';
 import 'package:appflowy/plugins/database/grid/presentation/widgets/common/type_option_separator.dart';
 import 'package:appflowy/plugins/database/widgets/cell/editable_cell_builder.dart';
+import 'package:appflowy/plugins/database/widgets/row/row_banner.dart';
 import 'package:appflowy/plugins/database/widgets/row/row_property.dart';
 import 'package:appflowy/plugins/document/application/document_bloc.dart';
 import 'package:appflowy/plugins/document/presentation/banner.dart';
@@ -15,7 +18,6 @@ import 'package:appflowy/workspace/application/action_navigation/navigation_acti
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 // This widget is largely copied from `plugins/document/document_page.dart` intentionally instead of opting for an abstraction. We can make an abstraction after the view refactor is done and there's more clarity in that department.
@@ -142,24 +144,33 @@ class _DatabaseDocumentPageState extends State<DatabaseDocumentPage> {
                   fieldController: databaseController.fieldController,
                   rowController: rowController,
                 ),
-                child: Padding(
-                  padding: EdgeInsets.only(
-                    top: 24,
-                    left: padding.left + 22,
-                    right: padding.right,
-                  ),
-                  child: Column(
-                    children: [
-                      RowPropertyList(
+                child: Column(
+                  children: [
+                    RowBanner(
+                      databaseController: databaseController,
+                      rowController: rowController,
+                      cellBuilder: EditableCellBuilder(
+                        databaseController: databaseController,
+                      ),
+                      userProfile:
+                          context.read<RelatedRowDetailPageBloc>().userProfile,
+                    ),
+                    Padding(
+                      padding: EdgeInsets.only(
+                        top: 24,
+                        left: padding.left,
+                        right: padding.right,
+                      ),
+                      child: RowPropertyList(
                         viewId: databaseController.viewId,
                         fieldController: databaseController.fieldController,
                         cellBuilder: EditableCellBuilder(
                           databaseController: databaseController,
                         ),
                       ),
-                      const TypeOptionSeparator(spacing: 24.0),
-                    ],
-                  ),
+                    ),
+                    const TypeOptionSeparator(spacing: 24.0),
+                  ],
                 ),
               );
             },

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/desktop_cover.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/desktop_cover.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
 import 'package:appflowy/plugins/document/application/prelude.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/cover/document_immersive_cover_bloc.dart';
@@ -9,7 +11,6 @@ import 'package:appflowy/shared/flowy_gradient_colors.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flowy_infra/theme_extension.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:string_validator/string_validator.dart';
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/material.dart';
+
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
@@ -25,7 +27,6 @@ import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/rounded_button.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:string_validator/string_validator.dart';
@@ -106,16 +107,13 @@ class _DocumentCoverWidgetState extends State<DocumentCoverWidget> {
     cover = widget.view.cover;
     view = widget.view;
     widget.node.addListener(_reload);
-    viewListener = ViewListener(
-      viewId: widget.view.id,
-    )..start(
-        onViewUpdated: (p0) {
-          setState(() {
-            viewIcon = p0.icon.value;
-            cover = p0.cover;
-            view = p0;
-          });
-        },
+    viewListener = ViewListener(viewId: widget.view.id)
+      ..start(
+        onViewUpdated: (view) => setState(() {
+          viewIcon = view.icon.value;
+          cover = view.cover;
+          view = view;
+        }),
       );
   }
 
@@ -283,17 +281,10 @@ class DocumentHeaderToolbar extends StatefulWidget {
 }
 
 class _DocumentHeaderToolbarState extends State<DocumentHeaderToolbar> {
-  bool isHidden = true;
+  final _popoverController = PopoverController();
+
+  bool isHidden = UniversalPlatform.isDesktopOrWeb;
   bool isPopoverOpen = false;
-
-  final PopoverController _popoverController = PopoverController();
-
-  @override
-  void initState() {
-    super.initState();
-
-    isHidden = UniversalPlatform.isDesktopOrWeb;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -313,11 +304,7 @@ class _DocumentHeaderToolbarState extends State<DocumentHeaderToolbar> {
     if (UniversalPlatform.isDesktopOrWeb) {
       child = MouseRegion(
         onEnter: (event) => setHidden(false),
-        onExit: (event) {
-          if (!isPopoverOpen) {
-            setHidden(true);
-          }
-        },
+        onExit: isPopoverOpen ? null : (event) => setHidden(true),
         opaque: false,
         child: child,
       );
@@ -444,9 +431,10 @@ class DocumentCover extends StatefulWidget {
 }
 
 class DocumentCoverState extends State<DocumentCover> {
+  final popoverController = PopoverController();
+
   bool isOverlayButtonsHidden = true;
   bool isPopoverOpen = false;
-  final PopoverController popoverController = PopoverController();
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_header_node_widget.dart
@@ -294,18 +294,21 @@ class _DocumentHeaderToolbarState extends State<DocumentHeaderToolbar> {
       padding: EdgeInsets.symmetric(horizontal: widget.offset),
       child: SizedBox(
         height: 28,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: buildRowChildren(),
+        child: Visibility(
+          visible: !isHidden || isPopoverOpen,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: buildRowChildren(),
+          ),
         ),
       ),
     );
 
     if (UniversalPlatform.isDesktopOrWeb) {
       child = MouseRegion(
-        onEnter: (event) => setHidden(false),
-        onExit: isPopoverOpen ? null : (event) => setHidden(true),
         opaque: false,
+        onEnter: (event) => setHidden(false),
+        onExit: isPopoverOpen ? null : (_) => setHidden(true),
         child: child,
       );
     }
@@ -314,9 +317,10 @@ class _DocumentHeaderToolbarState extends State<DocumentHeaderToolbar> {
   }
 
   List<Widget> buildRowChildren() {
-    if (isHidden || widget.hasCover && widget.hasIcon) {
+    if (widget.hasCover && widget.hasIcon) {
       return [];
     }
+
     final List<Widget> children = [];
 
     if (!widget.hasCover) {
@@ -374,7 +378,7 @@ class _DocumentHeaderToolbarState extends State<DocumentHeaderToolbar> {
 
       if (UniversalPlatform.isDesktop) {
         child = AppFlowyPopover(
-          onClose: () => isPopoverOpen = false,
+          onClose: () => setState(() => isPopoverOpen = false),
           controller: _popoverController,
           offset: const Offset(0, 8),
           direction: PopoverDirection.bottomWithCenterAligned,

--- a/frontend/appflowy_flutter/lib/plugins/shared/cover_type_ext.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/cover_type_ext.dart
@@ -1,0 +1,11 @@
+import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
+import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
+
+extension IntoCoverTypePB on CoverType {
+  CoverTypePB into() => switch (this) {
+        CoverType.color => CoverTypePB.ColorCover,
+        CoverType.asset => CoverTypePB.AssetCover,
+        CoverType.file => CoverTypePB.FileCover,
+        _ => CoverTypePB.FileCover,
+      };
+}

--- a/frontend/appflowy_flutter/lib/shared/af_image.dart
+++ b/frontend/appflowy_flutter/lib/shared/af_image.dart
@@ -40,6 +40,9 @@ class AFImage extends StatelessWidget {
         height: height,
         width: width,
         fit: fit,
+        errorBuilder: (context, error, stackTrace) {
+          return const SizedBox.shrink();
+        },
       );
     } else if (uploadType == FileUploadTypePB.LocalFile) {
       child = Image.file(
@@ -47,6 +50,9 @@ class AFImage extends StatelessWidget {
         height: height,
         width: width,
         fit: fit,
+        errorBuilder: (context, error, stackTrace) {
+          return const SizedBox.shrink();
+        },
       );
     } else {
       child = FlowyNetworkImage(
@@ -54,6 +60,9 @@ class AFImage extends StatelessWidget {
         userProfilePB: userProfile,
         height: height,
         width: width,
+        errorWidgetBuilder: (context, url, error) {
+          return const SizedBox.shrink();
+        },
       );
     }
 

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -120,13 +120,13 @@ custom-protocol = ["tauri/custom-protocol"]
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
+collab = { path = "../../AppFlowy-Collab/collab" }
+collab-entity = { path = "../../AppFlowy-Collab/collab-entity" }
+collab-folder = { path = "../../AppFlowy-Collab/collab-folder" }
+collab-document = { path = "../../AppFlowy-Collab/collab-document" }
+collab-database = { path = "../../AppFlowy-Collab/collab-database" }
+collab-plugins = { path = "../../AppFlowy-Collab/collab-plugins" }
+collab-user = { path = "../../AppFlowy-Collab/collab-user" }
 collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
 
 

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -120,13 +120,13 @@ custom-protocol = ["tauri/custom-protocol"]
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { path = "../../AppFlowy-Collab/collab" }
-collab-entity = { path = "../../AppFlowy-Collab/collab-entity" }
-collab-folder = { path = "../../AppFlowy-Collab/collab-folder" }
-collab-document = { path = "../../AppFlowy-Collab/collab-document" }
-collab-database = { path = "../../AppFlowy-Collab/collab-database" }
-collab-plugins = { path = "../../AppFlowy-Collab/collab-plugins" }
-collab-user = { path = "../../AppFlowy-Collab/collab-user" }
+collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
 collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
 
 

--- a/frontend/appflowy_tauri/src-tauri/Cargo.toml
+++ b/frontend/appflowy_tauri/src-tauri/Cargo.toml
@@ -127,7 +127,7 @@ collab-document = { path = "../../AppFlowy-Collab/collab-document" }
 collab-database = { path = "../../AppFlowy-Collab/collab-database" }
 collab-plugins = { path = "../../AppFlowy-Collab/collab-plugins" }
 collab-user = { path = "../../AppFlowy-Collab/collab-user" }
-collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
+collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
 
 
 # Working directory: frontend

--- a/frontend/appflowy_web_app/src-tauri/Cargo.toml
+++ b/frontend/appflowy_web_app/src-tauri/Cargo.toml
@@ -118,14 +118,14 @@ custom-protocol = ["tauri/custom-protocol"]
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
+collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
 
 
 # Working directory: frontend

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -1495,7 +1495,8 @@
       "deleteFileDescription": "Are you sure you want to delete this file? This action is irreversible.",
       "hideFileNames": "Hide file names",
       "downloadSuccess": "Successfully saved file",
-      "downloadFailedToken": "Failed to download file, user token unavailable"
+      "downloadFailedToken": "Failed to download file, user token unavailable",
+      "setAsCover": "Set as cover"
     }
   },
   "document": {

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -956,7 +956,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=2af6d29503e214d957b6ea4fb56846289dbc9d8f#2af6d29503e214d957b6ea4fb56846289dbc9d8f"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=37a48f51c889adf1482a189400c8ce15ed77b25d#37a48f51c889adf1482a189400c8ce15ed77b25d"
 dependencies = [
  "anyhow",
  "collab",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -142,14 +142,14 @@ rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "1710120
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
-collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "2af6d29503e214d957b6ea4fb56846289dbc9d8f" }
+collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
+collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "37a48f51c889adf1482a189400c8ce15ed77b25d" }
 
 # Working directory: frontend
 # To update the commit ID, run:

--- a/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
@@ -7,6 +7,7 @@ use flowy_derive::{ProtoBuf, ProtoBuf_Enum};
 use flowy_error::ErrorCode;
 use lib_infra::validator_fn::required_not_empty_str;
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use validator::Validate;
 
 use crate::entities::parser::NotEmptyStr;
@@ -105,7 +106,7 @@ impl From<RowCover> for RowCoverPB {
   }
 }
 
-#[derive(Debug, Default, Clone, ProtoBuf_Enum, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, ProtoBuf_Enum, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum CoverTypePB {
   #[default]

--- a/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/row_entities.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use collab_database::rows::{Row, RowCover, RowDetail, RowId};
+use collab_database::rows::{CoverType, Row, RowCover, RowDetail, RowId};
 use collab_database::views::RowOrder;
 
-use flowy_derive::ProtoBuf;
+use flowy_derive::{ProtoBuf, ProtoBuf_Enum};
 use flowy_error::ErrorCode;
 use lib_infra::validator_fn::required_not_empty_str;
 use serde::{Deserialize, Serialize};
@@ -76,26 +76,63 @@ pub struct RowMetaPB {
 #[derive(Debug, Default, Clone, ProtoBuf, Serialize, Deserialize)]
 pub struct RowCoverPB {
   #[pb(index = 1)]
-  pub url: String,
+  pub data: String,
 
   #[pb(index = 2)]
   pub upload_type: FileUploadTypePB,
+
+  #[pb(index = 3)]
+  pub cover_type: CoverTypePB,
 }
 
 impl From<RowCoverPB> for RowCover {
-  fn from(data: RowCoverPB) -> Self {
+  fn from(cover: RowCoverPB) -> Self {
     Self {
-      url: data.url,
-      upload_type: data.upload_type.into(),
+      data: cover.data,
+      upload_type: cover.upload_type.into(),
+      cover_type: cover.cover_type.into(),
     }
   }
 }
 
 impl From<RowCover> for RowCoverPB {
-  fn from(data: RowCover) -> Self {
+  fn from(cover: RowCover) -> Self {
     Self {
-      url: data.url,
-      upload_type: data.upload_type.into(),
+      data: cover.data,
+      upload_type: cover.upload_type.into(),
+      cover_type: cover.cover_type.into(),
+    }
+  }
+}
+
+#[derive(Debug, Default, Clone, ProtoBuf_Enum, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum CoverTypePB {
+  #[default]
+  ColorCover = 0,
+  FileCover = 1,
+  AssetCover = 2,
+  GradientCover = 3,
+}
+
+impl From<CoverTypePB> for CoverType {
+  fn from(data: CoverTypePB) -> Self {
+    match data {
+      CoverTypePB::ColorCover => CoverType::ColorCover,
+      CoverTypePB::FileCover => CoverType::FileCover,
+      CoverTypePB::AssetCover => CoverType::AssetCover,
+      CoverTypePB::GradientCover => CoverType::GradientCover,
+    }
+  }
+}
+
+impl From<CoverType> for CoverTypePB {
+  fn from(data: CoverType) -> Self {
+    match data {
+      CoverType::ColorCover => CoverTypePB::ColorCover,
+      CoverType::FileCover => CoverTypePB::FileCover,
+      CoverType::AssetCover => CoverTypePB::AssetCover,
+      CoverType::GradientCover => CoverTypePB::GradientCover,
     }
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/media_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/media_entities.rs
@@ -30,9 +30,6 @@ impl From<MediaCellDataPB> for MediaCellData {
 #[derive(Debug, Clone, Default, ProtoBuf)]
 pub struct MediaTypeOptionPB {
   #[pb(index = 1)]
-  pub files: Vec<MediaFilePB>,
-
-  #[pb(index = 2)]
   pub hide_file_names: bool,
 }
 

--- a/frontend/rust-lib/flowy-database2/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database2/src/event_handler.rs
@@ -1,4 +1,4 @@
-use collab_database::rows::{Cell, RowCover, RowId};
+use collab_database::rows::{Cell, CoverType, RowCover, RowId};
 use lib_infra::box_any::BoxAny;
 use std::sync::{Arc, Weak};
 use tokio::sync::oneshot;
@@ -1359,8 +1359,9 @@ pub(crate) async fn update_media_cell_handler(
         id: cell_id.row_id.clone().into(),
         view_id: cell_id.view_id.clone(),
         cover: Some(RowCover {
-          url: file.url.clone(),
+          data: file.url.clone(),
           upload_type: file.upload_type.into(),
+          cover_type: CoverType::FileCover,
         }),
         ..UpdateRowMetaParams::default()
       };

--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/media_type_option/media_type_option.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/media_type_option/media_type_option.rs
@@ -99,9 +99,6 @@ impl ToString for MediaCellData {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MediaTypeOption {
   #[serde(default)]
-  pub files: Vec<MediaFile>,
-
-  #[serde(default)]
   pub hide_file_names: bool,
 }
 
@@ -131,7 +128,6 @@ impl From<MediaTypeOption> for TypeOptionData {
 impl From<MediaTypeOption> for MediaTypeOptionPB {
   fn from(value: MediaTypeOption) -> Self {
     Self {
-      files: value.files.into_iter().map(Into::into).collect(),
       hide_file_names: value.hide_file_names,
     }
   }
@@ -140,7 +136,6 @@ impl From<MediaTypeOption> for MediaTypeOptionPB {
 impl From<MediaTypeOptionPB> for MediaTypeOption {
   fn from(value: MediaTypeOptionPB) -> Self {
     Self {
-      files: value.files.into_iter().map(Into::into).collect(),
       hide_file_names: value.hide_file_names,
     }
   }

--- a/frontend/rust-lib/flowy-database2/tests/database/mock_data/grid_mock_data.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/mock_data/grid_mock_data.rs
@@ -153,7 +153,6 @@ pub fn make_test_grid() -> DatabaseData {
       },
       FieldType::Media => {
         let type_option = MediaTypeOption {
-          files: vec![],
           hide_file_names: false,
         };
 


### PR DESCRIPTION
Requires: https://github.com/AppFlowy-IO/AppFlowy-Collab/pull/294

- [x] Adjust size of the file upload menu in media cell
- [x] Fix issue where sometimes the upload menu for media wouldn't open
- [x] Use same style for Cover in Document on Row Detail Page
- [x] Show the row cover when opened in full page
- [x] Add ability to change cover after it is added, and adjust behavior so it's the same as the document cover. (Adding a cover will make it into the default asset cover)
- [x] Adjusted tests to the new changes
- [x] Set image from media cell as cover
- [x] Duplicate row meta when duplicating a row (eg. also bring cover, and other meta data in new row)

### Feature Preview

TBD

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
