### PR TITLE
fix: edge case for text filters

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_filter.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/field/type_options/text_type_option/text_filter.rs
@@ -8,7 +8,18 @@ impl TextFilterPB {
   pub fn is_visible<T: AsRef<str>>(&self, cell_data: T) -> bool {
     let cell_data = cell_data.as_ref().to_lowercase();
     let content = &self.content.to_lowercase();
+
     match self.condition {
+      TextFilterConditionPB::TextIs
+      | TextFilterConditionPB::TextIsNot
+      | TextFilterConditionPB::TextContains
+      | TextFilterConditionPB::TextDoesNotContain
+      | TextFilterConditionPB::TextStartsWith
+      | TextFilterConditionPB::TextEndsWith
+        if content.is_empty() =>
+      {
+        true
+      },
       TextFilterConditionPB::TextIs => &cell_data == content,
       TextFilterConditionPB::TextIsNot => &cell_data != content,
       TextFilterConditionPB::TextContains => cell_data.contains(content),
@@ -53,10 +64,22 @@ mod tests {
       content: "appflowy".to_owned(),
     };
 
-    assert!(text_filter.is_visible("AppFlowy"));
+    assert_eq!(text_filter.is_visible("AppFlowy"), true);
     assert_eq!(text_filter.is_visible("appflowy"), true);
     assert_eq!(text_filter.is_visible("Appflowy"), true);
     assert_eq!(text_filter.is_visible("AppFlowy.io"), false);
+    assert_eq!(text_filter.is_visible(""), false);
+
+    let text_filter = TextFilterPB {
+      condition: TextFilterConditionPB::TextIs,
+      content: "".to_owned(),
+    };
+
+    assert_eq!(text_filter.is_visible("AppFlowy"), true);
+    assert_eq!(text_filter.is_visible("appflowy"), true);
+    assert_eq!(text_filter.is_visible("Appflowy"), true);
+    assert_eq!(text_filter.is_visible("AppFlowy.io"), true);
+    assert_eq!(text_filter.is_visible(""), true);
   }
   #[test]
   fn text_filter_start_with_test() {
@@ -68,6 +91,17 @@ mod tests {
     assert_eq!(text_filter.is_visible("AppFlowy.io"), true);
     assert_eq!(text_filter.is_visible(""), false);
     assert_eq!(text_filter.is_visible("https"), false);
+    assert_eq!(text_filter.is_visible(""), false);
+
+    let text_filter = TextFilterPB {
+      condition: TextFilterConditionPB::TextStartsWith,
+      content: "".to_owned(),
+    };
+
+    assert_eq!(text_filter.is_visible("AppFlowy.io"), true);
+    assert_eq!(text_filter.is_visible(""), true);
+    assert_eq!(text_filter.is_visible("https"), true);
+    assert_eq!(text_filter.is_visible(""), true);
   }
 
   #[test]
@@ -80,12 +114,31 @@ mod tests {
     assert_eq!(text_filter.is_visible("https://github.com/appflowy"), true);
     assert_eq!(text_filter.is_visible("App"), false);
     assert_eq!(text_filter.is_visible("appflowy.io"), false);
+    assert_eq!(text_filter.is_visible(""), false);
+
+    let text_filter = TextFilterPB {
+      condition: TextFilterConditionPB::TextEndsWith,
+      content: "".to_owned(),
+    };
+
+    assert_eq!(text_filter.is_visible("https://github.com/appflowy"), true);
+    assert_eq!(text_filter.is_visible("App"), true);
+    assert_eq!(text_filter.is_visible("appflowy.io"), true);
+    assert_eq!(text_filter.is_visible(""), true);
   }
   #[test]
   fn text_filter_empty_test() {
     let text_filter = TextFilterPB {
       condition: TextFilterConditionPB::TextIsEmpty,
       content: "appflowy".to_owned(),
+    };
+
+    assert_eq!(text_filter.is_visible(""), true);
+    assert_eq!(text_filter.is_visible("App"), false);
+
+    let text_filter = TextFilterPB {
+      condition: TextFilterConditionPB::TextIsEmpty,
+      content: "".to_owned(),
     };
 
     assert_eq!(text_filter.is_visible(""), true);
@@ -103,5 +156,16 @@ mod tests {
     assert_eq!(text_filter.is_visible("App"), false);
     assert_eq!(text_filter.is_visible(""), false);
     assert_eq!(text_filter.is_visible("github"), false);
+
+    let text_filter = TextFilterPB {
+      condition: TextFilterConditionPB::TextContains,
+      content: "".to_owned(),
+    };
+
+    assert_eq!(text_filter.is_visible("https://github.com/appflowy"), true);
+    assert_eq!(text_filter.is_visible("AppFlowy"), true);
+    assert_eq!(text_filter.is_visible("App"), true);
+    assert_eq!(text_filter.is_visible(""), true);
+    assert_eq!(text_filter.is_visible("github"), true);
   }
 }


### PR DESCRIPTION
handle the case where the condition is something other than empty and not-empty, and content is empty.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
