### PR TITLE
fix: hide editing rows from groups when filters are applied

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/grid/application/filter/filter_editor_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/application/filter/filter_editor_bloc.dart
@@ -222,7 +222,7 @@ class FilterEditorState with _$FilterEditorState {
 List<FieldInfo> _getCreatableFilter(List<FieldInfo> fieldInfos) {
   final List<FieldInfo> creatableFields = List.from(fieldInfos);
   creatableFields.retainWhere(
-    (field) => field.fieldType.canCreateFilter,
+    (field) => field.fieldType.canCreateFilter && !field.isGroupField,
   );
   return creatableFields;
 }


### PR DESCRIPTION


https://github.com/user-attachments/assets/bf0b0e74-5489-443b-b34b-4e7b3999365f


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
