### PR TITLE
feat: keep link format when converting preview block to text

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
 
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/block_menu/block_menu_button.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/copy_and_paste/clipboard_service.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/link_preview/custom_link_preview.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -311,13 +315,42 @@ void main() {
     'auto convert url to link preview block',
     (tester) async {
       const url = 'https://appflowy.io';
-      await tester.pasteContent(plainText: url, (editorState) {
+      await tester.pasteContent(plainText: url, (editorState) async {
         // the second one is the paragraph node
         expect(editorState.document.root.children.length, 2);
         final node = editorState.getNodeAtPath([0])!;
         expect(node.type, LinkPreviewBlockKeys.type);
         expect(node.attributes[LinkPreviewBlockKeys.url], url);
       });
+
+      // hover on the link preview block
+      // click the more button
+      // and select convert to link
+      await tester.hoverOnWidget(
+        find.byType(CustomLinkPreviewWidget),
+        onHover: () async {
+          final convertToLinkButton = find.byWidgetPredicate((widget) {
+            return widget is MenuBlockButton &&
+                widget.tooltip ==
+                    LocaleKeys.document_plugins_urlPreview_convertToLink.tr();
+          });
+          expect(convertToLinkButton, findsOneWidget);
+          await tester.tap(convertToLinkButton);
+          await tester.pumpAndSettle();
+        },
+      );
+
+      await tester.pumpAndSettle();
+
+      final editorState = tester.editor.getCurrentEditorState();
+      final textNode = editorState.getNodeAtPath([0])!;
+      expect(textNode.type, ParagraphBlockKeys.type);
+      expect(textNode.delta!.toJson(), [
+        {
+          'insert': url,
+          'attributes': {'href': url},
+        }
+      ]);
     },
   );
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/bottom_sheet_block_action_widget.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/bottom_sheet_block_action_widget.dart
@@ -49,7 +49,13 @@ class BlockActionBottomSheet extends StatelessWidget {
         FlowyOptionTile.text(
           showTopBorder: false,
           text: LocaleKeys.button_duplicate.tr(),
-          leftIcon: const FlowySvg(FlowySvgs.m_duplicate_s),
+          leftIcon: const Padding(
+            padding: EdgeInsets.all(2),
+            child: FlowySvg(
+              FlowySvgs.copy_s,
+              size: Size.square(16),
+            ),
+          ),
           onTap: () => onAction(BlockActionBottomSheetType.duplicate),
         ),
 
@@ -59,7 +65,8 @@ class BlockActionBottomSheet extends StatelessWidget {
           showTopBorder: false,
           text: LocaleKeys.button_delete.tr(),
           leftIcon: FlowySvg(
-            FlowySvgs.m_delete_s,
+            FlowySvgs.trash_s,
+            size: const Size.square(18),
             color: Theme.of(context).colorScheme.error,
           ),
           textColor: Theme.of(context).colorScheme.error,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
@@ -155,19 +155,21 @@ Future<bool> _pasteAsLinkPreview(
   );
 
   final linkPreviewTransaction = editorState.transaction;
-  linkPreviewTransaction
-    ..insertNode(
-      selection.start.path,
-      linkPreviewNode(url: text),
-    )
-    ..deleteNode(
-      node,
-    );
-  final nextNode = node.next;
-  if (nextNode != null) {
-    linkPreviewTransaction.afterSelection =
-        Selection.collapsed(Position(path: nextNode.path));
-  }
+  final insertedNodes = [
+    linkPreviewNode(url: text),
+    // if the next node is null, insert a empty paragraph node
+    if (node.next == null) paragraphNode(),
+  ];
+  linkPreviewTransaction.insertNodes(
+    selection.start.path,
+    insertedNodes,
+  );
+  linkPreviewTransaction.deleteNode(node);
+  linkPreviewTransaction.afterSelection = Selection.collapsed(
+    Position(
+      path: node.path.next,
+    ),
+  );
   await editorState.apply(linkPreviewTransaction);
 
   return true;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/custom_link_preview.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/custom_link_preview.dart
@@ -123,7 +123,10 @@ class CustomLinkPreviewWidget extends StatelessWidget {
       node: node,
       editorState: context.read<EditorState>(),
       extendActionWidgets: _buildExtendActionWidgets(context),
-      child: child,
+      child: GestureDetector(
+        onTap: () => afLaunchUrlString(url),
+        child: child,
+      ),
     );
   }
 
@@ -134,8 +137,8 @@ class CustomLinkPreviewWidget extends StatelessWidget {
         showTopBorder: false,
         text: LocaleKeys.document_plugins_urlPreview_convertToLink.tr(),
         leftIcon: const FlowySvg(
-          FlowySvgs.m_aa_link_s,
-          size: Size.square(20),
+          FlowySvgs.m_toolbar_link_m,
+          size: Size.square(18),
         ),
         onTap: () {
           context.pop();

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/block_menu/block_menu_button.dart';
@@ -10,6 +7,8 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../image/custom_image_block_component/custom_image_block_component.dart';
@@ -50,8 +49,8 @@ class _LinkPreviewMenuState extends State<LinkPreviewMenu> {
           const HSpace(4),
           MenuBlockButton(
             tooltip: LocaleKeys.document_plugins_urlPreview_convertToLink.tr(),
-            iconData: FlowySvgs.m_aa_link_s,
-            onTap: () => convertUrlPreviewNodeToLink(
+            iconData: FlowySvgs.m_toolbar_link_m,
+            onTap: () async => convertUrlPreviewNodeToLink(
               context.read<EditorState>(),
               widget.node,
             ),
@@ -65,7 +64,7 @@ class _LinkPreviewMenuState extends State<LinkPreviewMenu> {
           const _Divider(),
           MenuBlockButton(
             tooltip: LocaleKeys.button_delete.tr(),
-            iconData: FlowySvgs.delete_s,
+            iconData: FlowySvgs.trash_s,
             onTap: deleteLinkPreviewNode,
           ),
           const HSpace(4),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
@@ -2,7 +2,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/block_menu/block_menu_button.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/link_preview/shared.dart';
-import 'package:appflowy/workspace/presentation/home/toast.dart';
+import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -77,9 +77,9 @@ class _LinkPreviewMenuState extends State<LinkPreviewMenu> {
     final url = widget.node.attributes[CustomImageBlockKeys.url];
     if (url != null) {
       Clipboard.setData(ClipboardData(text: url));
-      showSnackBarMessage(
+      showToastNotification(
         context,
-        LocaleKeys.document_plugins_urlPreview_copiedToPasteBoard.tr(),
+        message: LocaleKeys.document_plugins_urlPreview_copiedToPasteBoard.tr(),
       );
     }
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
@@ -2,23 +2,24 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 
 Future<void> convertUrlPreviewNodeToLink(
-    EditorState editorState, Node node) async {
-  assert(node.type == LinkPreviewBlockKeys.type);
+  EditorState editorState,
+  Node node,
+) async {
+  if (node.type != LinkPreviewBlockKeys.type) {
+    return;
+  }
+
   final url = node.attributes[ImageBlockKeys.url];
+  final delta = Delta()
+    ..insert(
+      url,
+      attributes: {
+        AppFlowyRichTextKeys.href: url,
+      },
+    );
   final transaction = editorState.transaction;
   transaction
-    ..insertNode(
-      node.path,
-      paragraphNode(
-        delta: Delta()
-          ..insert(
-            url,
-            attributes: {
-              AppFlowyRichTextKeys.href: url,
-            },
-          ),
-      ),
-    )
+    ..insertNode(node.path, paragraphNode(delta: delta))
     ..deleteNode(node);
   transaction.afterSelection = Selection.collapsed(
     Position(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
@@ -1,7 +1,8 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 
-void convertUrlPreviewNodeToLink(EditorState editorState, Node node) {
+Future<void> convertUrlPreviewNodeToLink(
+    EditorState editorState, Node node) async {
   assert(node.type == LinkPreviewBlockKeys.type);
   final url = node.attributes[ImageBlockKeys.url];
   final transaction = editorState.transaction;
@@ -25,5 +26,5 @@ void convertUrlPreviewNodeToLink(EditorState editorState, Node node) {
       offset: url.length,
     ),
   );
-  editorState.apply(transaction);
+  return editorState.apply(transaction);
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/shared.dart
@@ -6,7 +6,18 @@ void convertUrlPreviewNodeToLink(EditorState editorState, Node node) {
   final url = node.attributes[ImageBlockKeys.url];
   final transaction = editorState.transaction;
   transaction
-    ..insertNode(node.path, paragraphNode(text: url))
+    ..insertNode(
+      node.path,
+      paragraphNode(
+        delta: Delta()
+          ..insert(
+            url,
+            attributes: {
+              AppFlowyRichTextKeys.href: url,
+            },
+          ),
+      ),
+    )
     ..deleteNode(node);
   transaction.afterSelection = Selection.collapsed(
     Position(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/5426

- [x] unable to open preview block on mobile
- [x] keep link format when converting preview block to text
- [x] replace the icons in 'more actions' bottom sheet.
- [x] add test

<img width="519" alt="Screenshot 2024-09-30 at 17 54 34" src="https://github.com/user-attachments/assets/50b135f6-7c87-4907-9cbe-87dfa4f1c2a1">

<img width="469" alt="Screenshot 2024-09-30 at 18 15 14" src="https://github.com/user-attachments/assets/5c579e65-8f37-43f3-bc3d-401ab047ce3e">

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
