### PR TITLE
fix: don't process on every view while only handling one view

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/grid/grid_row_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/grid/grid_row_test.dart
@@ -189,15 +189,46 @@ void main() {
 
       await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Grid);
       await tester.hoverOnFirstRowOfGrid(() async {
-        // Open the row menu and then click the delete
+        // Open the row menu and click the delete button
         await tester.tapRowMenuButtonInGrid();
-        await tester.pumpAndSettle();
         await tester.tapDeleteOnRowMenu();
-        await tester.pumpAndSettle();
-
-        // 3 initial rows - 1 deleted
-        tester.assertNumberOfRowsInGridPage(2);
       });
+      expect(find.byType(ConfirmPopup), findsOneWidget);
+      await tester.tapButtonWithName(LocaleKeys.button_delete.tr());
+
+      tester.assertNumberOfRowsInGridPage(2);
+    });
+
+    testWidgets('delete row in two views', (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Grid);
+      await tester.renameLinkedView(
+        tester.findTabBarLinkViewByViewLayout(ViewLayoutPB.Grid),
+        'grid 1',
+      );
+      tester.assertNumberOfRowsInGridPage(3);
+
+      await tester.tapCreateLinkedDatabaseViewButton(DatabaseLayoutPB.Grid);
+      await tester.renameLinkedView(
+        tester.findTabBarLinkViewByViewLayout(ViewLayoutPB.Grid).at(1),
+        'grid 2',
+      );
+      tester.assertNumberOfRowsInGridPage(3);
+
+      await tester.hoverOnFirstRowOfGrid(() async {
+        // Open the row menu and click the delete button
+        await tester.tapRowMenuButtonInGrid();
+        await tester.tapDeleteOnRowMenu();
+      });
+      expect(find.byType(ConfirmPopup), findsOneWidget);
+      await tester.tapButtonWithName(LocaleKeys.button_delete.tr());
+      // 3 initial rows - 1 deleted
+      tester.assertNumberOfRowsInGridPage(2);
+
+      await tester.tapTabBarLinkedViewByViewName('grid 1');
+      tester.assertNumberOfRowsInGridPage(2);
     });
   });
 }

--- a/frontend/appflowy_flutter/test/bloc_test/grid_test/field/field_editor_bloc_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/grid_test/field/field_editor_bloc_test.dart
@@ -119,7 +119,6 @@ void main() {
       );
 
       editorBloc.add(const FieldEditorEvent.insertLeft());
-      // TODO(RS): Shouldn't need to wait here!?
       await gridResponseFuture();
       editorBloc.add(const FieldEditorEvent.insertRight());
       await gridResponseFuture();


### PR DESCRIPTION
The database row observe should only edit one view when handling one databaseviewchange. Otherwise, we have a bug like the following

https://github.com/user-attachments/assets/4185313c-182f-49d2-9d4b-c1c5a18723d7


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
