### PR TITLE
fix: fetch all calendar events

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/calendar/application/unschedule_event_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/calendar/application/unschedule_event_bloc.dart
@@ -42,7 +42,7 @@ class UnscheduleEventsBloc
               state.copyWith(
                 allEvents: events,
                 unscheduleEvents:
-                    events.where((element) => !element.isScheduled).toList(),
+                    events.where((element) => !element.hasTimestamp()).toList(),
               ),
             );
           },
@@ -55,7 +55,7 @@ class UnscheduleEventsBloc
               state.copyWith(
                 allEvents: events,
                 unscheduleEvents:
-                    events.where((element) => !element.isScheduled).toList(),
+                    events.where((element) => !element.hasTimestamp()).toList(),
               ),
             );
           },
@@ -65,7 +65,7 @@ class UnscheduleEventsBloc
               state.copyWith(
                 allEvents: events,
                 unscheduleEvents:
-                    events.where((element) => !element.isScheduled).toList(),
+                    events.where((element) => !element.hasTimestamp()).toList(),
               ),
             );
           },

--- a/frontend/rust-lib/flowy-database2/src/entities/calendar_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/calendar_entities.rs
@@ -108,11 +108,8 @@ pub struct CalendarEventPB {
   #[pb(index = 3)]
   pub title: String,
 
-  #[pb(index = 4)]
-  pub timestamp: i64,
-
-  #[pb(index = 5)]
-  pub is_scheduled: bool,
+  #[pb(index = 4, one_of)]
+  pub timestamp: Option<i64>,
 }
 
 #[derive(Debug, Clone, Default, ProtoBuf)]

--- a/frontend/rust-lib/flowy-database2/tests/database/layout_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/layout_test/script.rs
@@ -132,20 +132,20 @@ impl DatabaseLayoutTest {
         for (index, event) in events.into_iter().enumerate() {
           if index == 0 {
             assert_eq!(event.title, "A");
-            assert_eq!(event.timestamp, 1678090778);
+            assert_eq!(event.timestamp, Some(1678090778));
           }
 
           if index == 1 {
             assert_eq!(event.title, "B");
-            assert_eq!(event.timestamp, 1677917978);
+            assert_eq!(event.timestamp, Some(1677917978));
           }
           if index == 2 {
             assert_eq!(event.title, "C");
-            assert_eq!(event.timestamp, 1679213978);
+            assert_eq!(event.timestamp, Some(1679213978));
           }
           if index == 4 {
             assert_eq!(event.title, "E");
-            assert_eq!(event.timestamp, 1678695578);
+            assert_eq!(event.timestamp, Some(1678695578));
           }
         }
       },

--- a/frontend/rust-lib/flowy-database2/tests/database/layout_test/test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/layout_test/test.rs
@@ -52,7 +52,7 @@ async fn grid_to_calendar_layout_test() {
     UpdateDatabaseLayout {
       layout: DatabaseLayout::Calendar,
     },
-    AssertAllCalendarEventsCount { expected: 0 },
+    AssertAllCalendarEventsCount { expected: 3 },
   ];
   test.run_scripts(scripts).await;
 }


### PR DESCRIPTION
also revert incorrect test modification. The get_all_calendar_events function should return all events, even those that are unscheduled.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
