### PR TITLE
fix: display paragraph mark only if the block content is empty

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_page_block.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_page_block.dart
@@ -445,9 +445,10 @@ class _MentionPageBlockContent extends StatelessWidget {
       view.id,
       content,
     );
+    final isBlockContentEmpty = content == null || content.isEmpty;
 
     // if the block is from the same doc, display the paragraph mark icon '¶'
-    if (isSameDocument) {
+    if (isSameDocument && !isBlockContentEmpty) {
       return [
         const HSpace(2),
         FlowySvg(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

before
<img width="651" alt="Screenshot 2024-10-21 at 19 42 17" src="https://github.com/user-attachments/assets/68eb6c46-5ca5-461b-8056-522afdb04c47">

after
<img width="618" alt="Screenshot 2024-10-21 at 19 56 04" src="https://github.com/user-attachments/assets/1bdc1fe8-2325-4195-8c1d-83a2ec2dc188">

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
