### PR TITLE
fix: use drop path rather than node

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_drop_handler.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_drop_handler.dart
@@ -91,19 +91,13 @@ class EditorDropHandler extends StatelessWidget {
           return;
         }
 
-        final node = editorState.getNodeAtPath(dropPath);
-
-        if (node == null) {
-          return;
-        }
-
         for (final file in details.files) {
           final fileName = file.name.toLowerCase();
           if (file.mimeType?.startsWith('image/') ??
               false || imgExtensionRegex.hasMatch(fileName)) {
-            await editorState.dropImages(node, [file], viewId, isLocalMode);
+            await editorState.dropImages(dropPath, [file], viewId, isLocalMode);
           } else {
-            await editorState.dropFiles(node, [file], viewId, isLocalMode);
+            await editorState.dropFiles(dropPath, [file], viewId, isLocalMode);
           }
         }
       }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_file.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_file.dart
@@ -5,7 +5,7 @@ import 'package:cross_file/cross_file.dart';
 
 extension PasteFromFile on EditorState {
   Future<void> dropFiles(
-    Node dropNode,
+    List<int> dropPath,
     List<XFile> files,
     String documentId,
     bool isLocalMode,
@@ -27,7 +27,7 @@ extension PasteFromFile on EditorState {
 
       final t = transaction
         ..insertNode(
-          dropNode.path,
+          dropPath,
           fileNode(
             url: path,
             type: type,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
@@ -22,7 +22,7 @@ import 'package:universal_platform/universal_platform.dart';
 
 extension PasteFromImage on EditorState {
   Future<void> dropImages(
-    Node dropNode,
+    List<int> dropPath,
     List<XFile> files,
     String documentId,
     bool isLocalMode,
@@ -50,7 +50,7 @@ extension PasteFromImage on EditorState {
 
       final t = transaction
         ..insertNode(
-          dropNode.path,
+          dropPath,
           customImageNode(url: path, type: type),
         );
       await apply(t);


### PR DESCRIPTION
If the path doesn't exist (because it's dropped after the last node), the `getNodeAtPath` will return null, but we should still insert the dropped images/files.

We can create a unit tests for the `dropFiles` and `dropImages` methods to cover this functionality.

#### PR Checklist

- [ x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
