### PR TITLE
fix: crash on delete button press caused by GoRouter

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
@@ -9,7 +9,6 @@ import 'package:appflowy/plugins/shared/share/constants.dart';
 import 'package:appflowy/plugins/shared/share/publish_name_generator.dart';
 import 'package:appflowy/plugins/shared/share/share_bloc.dart';
 import 'package:appflowy/startup/startup.dart';
-import 'package:appflowy/util/navigator_context_exntesion.dart';
 import 'package:appflowy/workspace/application/favorite/favorite_bloc.dart';
 import 'package:appflowy/workspace/application/view/prelude.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
@@ -24,69 +23,74 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
   const MobileViewPageMoreBottomSheet({super.key, required this.view});
 
   final ViewPB view;
-
   @override
   Widget build(BuildContext context) {
-    return ViewPageBottomSheet(
-      view: view,
-      onAction: (action) async {
-        switch (action) {
-          case MobileViewBottomSheetBodyAction.duplicate:
-            context.read<ViewBloc>().add(const ViewEvent.duplicate());
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.delete:
-            context.read<ViewBloc>().add(const ViewEvent.delete());
-            context.popToHome();
-            break;
-          case MobileViewBottomSheetBodyAction.addToFavorites:
-          case MobileViewBottomSheetBodyAction.removeFromFavorites:
-            context.read<FavoriteBloc>().add(FavoriteEvent.toggle(view));
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.undo:
-            EditorNotification.undo().post();
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.redo:
-            EditorNotification.redo().post();
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.helpCenter:
-            // unimplemented
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.publish:
-            await _publish(context);
-            if (context.mounted) {
-              context.pop();
-            }
-            break;
-          case MobileViewBottomSheetBodyAction.unpublish:
-            _unpublish(context);
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.copyPublishLink:
-            _copyPublishLink(context);
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.visitSite:
-            _visitPublishedSite(context);
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.copyShareLink:
-            _copyShareLink(context);
-            context.pop();
-            break;
-          case MobileViewBottomSheetBodyAction.rename:
-            // no need to implement, rename is handled by the onRename callback.
-            throw UnimplementedError();
+    return BlocListener<ViewBloc, ViewState>(
+      listener: (context, state) {
+        if (state.successOrFailure.isSuccess && state.isDeleted) {
+          context.go('/home');
         }
       },
-      onRename: (name) {
-        _onRename(context, name);
-        context.pop();
-      },
+      child: ViewPageBottomSheet(
+        view: view,
+        onAction: (action) async {
+          switch (action) {
+            case MobileViewBottomSheetBodyAction.duplicate:
+              context.read<ViewBloc>().add(const ViewEvent.duplicate());
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.delete:
+              context.read<ViewBloc>().add(const ViewEvent.delete());
+              break;
+            case MobileViewBottomSheetBodyAction.addToFavorites:
+            case MobileViewBottomSheetBodyAction.removeFromFavorites:
+              context.read<FavoriteBloc>().add(FavoriteEvent.toggle(view));
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.undo:
+              EditorNotification.undo().post();
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.redo:
+              EditorNotification.redo().post();
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.helpCenter:
+              // unimplemented
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.publish:
+              await _publish(context);
+              if (context.mounted) {
+                context.pop();
+              }
+              break;
+            case MobileViewBottomSheetBodyAction.unpublish:
+              _unpublish(context);
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.copyPublishLink:
+              _copyPublishLink(context);
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.visitSite:
+              _visitPublishedSite(context);
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.copyShareLink:
+              _copyShareLink(context);
+              context.pop();
+              break;
+            case MobileViewBottomSheetBodyAction.rename:
+              // no need to implement, rename is handled by the onRename callback.
+              throw UnimplementedError();
+          }
+        },
+        onRename: (name) {
+          _onRename(context, name);
+          context.pop();
+        },
+      ),
     );
   }
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
@@ -41,6 +41,7 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
               break;
             case MobileViewBottomSheetBodyAction.delete:
               context.read<ViewBloc>().add(const ViewEvent.delete());
+              context.pop();
               break;
             case MobileViewBottomSheetBodyAction.addToFavorites:
             case MobileViewBottomSheetBodyAction.removeFromFavorites:

--- a/frontend/appflowy_flutter/lib/workspace/application/view/view_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/view/view_bloc.dart
@@ -154,6 +154,7 @@ class ViewBloc extends Bloc<ViewEvent, ViewState> {
                 (l) {
                   return state.copyWith(
                     successOrFailure: FlowyResult.success(null),
+                    isDeleted: true,
                   );
                 },
                 (error) => state.copyWith(
@@ -478,6 +479,7 @@ class ViewState with _$ViewState {
     required bool isEditing,
     required bool isExpanded,
     required FlowyResult<void, FlowyError> successOrFailure,
+    @Default(false) bool isDeleted,
     @Default(true) bool isLoading,
     @Default(null) ViewPB? lastCreatedView,
   }) = _ViewState;


### PR DESCRIPTION
I identified an issue where the iOS app would crash due to a GoRouter error when attempting to return to the home screen after deleting a workspace. This pull request includes a fix for the bloc to handle the navigation correctly, ensuring a smooth transition back to the home screen without errors.

IOS app is being released and needs to be resolved as soon as possible!

https://github.com/user-attachments/assets/2b3c793f-5033-4c84-946f-6cf4d24bb42c


```sh
FlutterError (Looking up a deactivated widget's ancestor is unsafe.
At this point the state of the widget's element tree is no longer stable.
To safely refer to a widget's ancestor in its dispose() method, save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() in the widget's didChangeDependencies() method.)
```


## Fixes:

https://github.com/user-attachments/assets/16c0cb45-1549-44f8-83fd-75b244241bd8


Resolved GoRouter crash by updating the bloc logic to manage navigation properly upon workspace deletion.

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
