### PR TITLE
chore: set standard visual density for entire app

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
@@ -437,7 +437,6 @@ class _UnscheduledEventsButtonState extends State<UnscheduledEventsButton> {
                 ),
                 side: BorderSide(color: Theme.of(context).dividerColor),
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                visualDensity: VisualDensity.compact,
               ),
               onPressed: () {
                 if (state.unscheduleEvents.isNotEmpty) {

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_grid/desktop_grid_text_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/desktop_grid/desktop_grid_text_cell.dart
@@ -38,7 +38,6 @@ class DesktopGridTextCellSkin extends IEditableTextCellSkin {
                         : null,
                   ),
               decoration: const InputDecoration(
-                contentPadding: EdgeInsets.only(top: 4),
                 border: InputBorder.none,
                 focusedBorder: InputBorder.none,
                 enabledBorder: InputBorder.none,

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/desktop_appearance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/desktop_appearance.dart
@@ -48,6 +48,7 @@ class DesktopAppearance extends BaseAppearance {
 
     // Due to Desktop version has multiple themes, it relies on the current theme to build the ThemeData
     return ThemeData(
+      visualDensity: VisualDensity.standard,
       useMaterial3: false,
       brightness: brightness,
       dialogBackgroundColor: theme.surface,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_dropdown.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_dropdown.dart
@@ -69,7 +69,6 @@ class _SettingsDropdownState<T> extends State<SettingsDropdown<T>> {
                 EdgeInsets.symmetric(horizontal: 6, vertical: 8),
               ),
               alignment: Alignment.bottomLeft,
-              visualDensity: VisualDensity.compact,
             ),
             inputDecorationTheme: InputDecorationTheme(
               contentPadding: const EdgeInsets.symmetric(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_menu.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/settings_menu.dart
@@ -36,9 +36,9 @@ class SettingsMenu extends StatelessWidget {
                 const EdgeInsets.only(left: 8, right: 4),
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(8),
-                bottomLeft: Radius.circular(8),
+              borderRadius: const BorderRadiusDirectional.only(
+                topStart: Radius.circular(8),
+                bottomStart: Radius.circular(8),
               ),
             ),
             child: SingleChildScrollView(

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/button.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/button.dart
@@ -528,7 +528,6 @@ class FlowyRichTextButton extends StatelessWidget {
     );
 
     child = RawMaterialButton(
-      visualDensity: VisualDensity.compact,
       hoverElevation: 0,
       highlightElevation: 0,
       shape: RoundedRectangleBorder(borderRadius: radius ?? Corners.s6Border),

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/icon_button.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/icon_button.dart
@@ -86,7 +86,6 @@ class FlowyIconButton extends StatelessWidget {
         richMessage: richTooltipText,
         child: RawMaterialButton(
           clipBehavior: Clip.antiAlias,
-          visualDensity: VisualDensity.compact,
           hoverElevation: 0,
           highlightElevation: 0,
           shape:


### PR DESCRIPTION
The compact visual density which Flutter automatically sets for desktop platforms makes implementing the pixel-perfect UI difficult because the decreased spacing is unexpected.

```dart
/// Returns a [VisualDensity] that is adaptive based on the given [platform].
///
/// For desktop platforms, this returns [compact], and for other platforms, it
/// returns a default-constructed [VisualDensity].
static VisualDensity defaultDensityForPlatform(TargetPlatform platform) {
  return switch (platform) {
    TargetPlatform.android || TargetPlatform.iOS || TargetPlatform.fuchsia => standard,
    TargetPlatform.linux || TargetPlatform.macOS || TargetPlatform.windows => compact,
  };
}
```

An example would be the "Text" and "TextField" widgets when provided with the same padding/content padding. Check this dartpad and toggle the visual density parameter. 

https://dartpad.dev/?id=d402ab47c0494afa536548ce10aeb763

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
