### PR TITLE
fix(flutter_desktop): glitchy kanban card editing

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/board/board_row_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/board/board_row_test.dart
@@ -6,6 +6,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:time/time.dart';
 
 import '../../shared/database_test_op.dart';
 import '../../shared/util.dart';
@@ -14,6 +15,31 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('board row test', () {
+    testWidgets('edit item in ToDo card', (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Board);
+      const name = 'Card 1';
+      final card1 = find.ancestor(
+        matching: find.byType(RowCard),
+        of: find.text(name),
+      );
+      await tester.hoverOnWidget(
+        card1,
+        onHover: () async {
+          final editCard = find.byType(EditCardAccessory);
+          await tester.tapButton(editCard);
+        },
+      );
+      await tester.showKeyboard(card1);
+      tester.testTextInput.enterText("");
+      await tester.pump(300.milliseconds);
+      tester.testTextInput.enterText("a");
+      await tester.pump(300.milliseconds);
+      expect(find.text('a'), findsOneWidget);
+    });
+
     testWidgets('delete item in ToDo card', (tester) async {
       await tester.initializeAppFlowy();
       await tester.tapAnonymousSignInButton();


### PR DESCRIPTION
taking the most stripped-down steps to reproduce:

1. user types in 'a'
2. onChanged callback starts a 300ms debounce timer to update the cell in the backend with 'a'
3. immediately after 300ms and before the backend notifies the frontend of the cell change, user types in 'b'. The text controller's value is now 'ab'
4. cell controller gets the cell-did-update notification from backend, data is 'a'
5. cell controller updates the text controller's value with 'a'
6. The user observes that b disppears

I had previously checked whether the cell has focus in step 5, which fixed this issue. The problem is that if another user edits the same cell, those changes don't get reflected.

Solution now is don't listen to onChanged callbacks, only when the user finishes ediiting it.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
