### PR TITLE
fix: owner can delete spaces created by other users

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
@@ -3,10 +3,12 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/shared/icon_emoji_picker/flowy_icon_emoji_picker.dart';
 import 'package:appflowy/shared/icon_emoji_picker/tab.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
+import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
 import 'package:appflowy/workspace/presentation/home/menu/sidebar/space/space_action_type.dart';
 import 'package:appflowy/workspace/presentation/widgets/pop_up_action.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/workspace.pb.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
@@ -148,13 +150,19 @@ class SpaceMoreActionTypeWrapper extends CustomActionCell {
     final spaces = spaceBloc.state.spaces;
     final currentSpace = spaceBloc.state.currentSpace;
 
+    final workspaceBloc = context.read<UserWorkspaceBloc>();
+    final currentWorkspaceMember =
+        workspaceBloc.state.currentWorkspaceMember;
+
     bool disable = false;
     var message = '';
+
     if (inner == SpaceMoreActionType.delete) {
       if (spaces.length <= 1) {
         disable = true;
         message = LocaleKeys.space_unableToDeleteLastSpace.tr();
-      } else if (currentSpace?.createdBy != context.read<UserProfilePB>().id) {
+      } else if (currentWorkspaceMember?.role != AFRolePB.Owner &&
+          currentSpace?.createdBy != context.read<UserProfilePB>().id) {
         disable = true;
         message = LocaleKeys.space_unableToDeleteSpaceNotCreatedByYou.tr();
       }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
@@ -150,7 +150,28 @@ class SpaceMoreActionTypeWrapper extends CustomActionCell {
     final spaces = spaceBloc.state.spaces;
     final currentSpace = spaceBloc.state.currentSpace;
 
-    final workspaceBloc = context.read<UserWorkspaceBloc>();
+    final isOwner = context
+            .read<UserWorkspaceBloc?>()
+            ?.state
+            .currentWorkspaceMember
+            ?.role
+            .isOwner ??
+        false;
+    final isPageCreator =
+        currentSpace?.createdBy == context.read<UserProfilePB>().id;
+    final allowToDelete = isOwner || isPageCreator;
+
+    bool disable = false;
+    var message = '';
+    if (inner == SpaceMoreActionType.delete) {
+      if (spaces.length <= 1) {
+        disable = true;
+        message = LocaleKeys.space_unableToDeleteLastSpace.tr();
+      } else if (!allowToDelete) {
+        disable = true;
+        message = LocaleKeys.space_unableToDeleteSpaceNotCreatedByYou.tr();
+      }
+    }
     final currentWorkspaceMember =
         workspaceBloc.state.currentWorkspaceMember;
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/space/space_more_popup.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/shared/af_role_pb_extension.dart';
 import 'package:appflowy/shared/icon_emoji_picker/flowy_icon_emoji_picker.dart';
 import 'package:appflowy/shared/icon_emoji_picker/tab.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
@@ -8,7 +9,6 @@ import 'package:appflowy/workspace/presentation/home/menu/sidebar/space/space_ac
 import 'package:appflowy/workspace/presentation/widgets/pop_up_action.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
-import 'package:appflowy_backend/protobuf/flowy-user/workspace.pb.dart';
 import 'package:appflowy_popover/appflowy_popover.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
@@ -168,22 +168,6 @@ class SpaceMoreActionTypeWrapper extends CustomActionCell {
         disable = true;
         message = LocaleKeys.space_unableToDeleteLastSpace.tr();
       } else if (!allowToDelete) {
-        disable = true;
-        message = LocaleKeys.space_unableToDeleteSpaceNotCreatedByYou.tr();
-      }
-    }
-    final currentWorkspaceMember =
-        workspaceBloc.state.currentWorkspaceMember;
-
-    bool disable = false;
-    var message = '';
-
-    if (inner == SpaceMoreActionType.delete) {
-      if (spaces.length <= 1) {
-        disable = true;
-        message = LocaleKeys.space_unableToDeleteLastSpace.tr();
-      } else if (currentWorkspaceMember?.role != AFRolePB.Owner &&
-          currentSpace?.createdBy != context.read<UserProfilePB>().id) {
         disable = true;
         message = LocaleKeys.space_unableToDeleteSpaceNotCreatedByYou.tr();
       }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

closes: #6444 

### Feature Preview

I added condition which check if the current user is owner of the workspace then, the owner is eligible to delete spaces created by any of the members, but members only have permission to delete the spaces created by them.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
