### PR TITLE
chore: inno setup ignore version on .exe

### DIFF
--- a/frontend/scripts/windows_installer/inno_setup_config.iss
+++ b/frontend/scripts/windows_installer/inno_setup_config.iss
@@ -14,7 +14,7 @@ VersionInfoVersion={#AppVersion}
 UsePreviousAppDir=no
 
 [Files]
-Source: "AppFlowy\AppFlowy.exe";DestDir: "{app}";DestName: "AppFlowy.exe"
+Source: "AppFlowy\AppFlowy.exe"; DestDir: "{app}"; DestName: "AppFlowy.exe"; Flags: ignoreversion
 Source: "AppFlowy\*";DestDir: "{app}"
 Source: "AppFlowy\data\*";DestDir: "{app}\data\"; Flags: recursesubdirs
 


### PR DESCRIPTION
The reason windows users see wrong version number, is because our installer doesn't override the .exe file (which has the wrong version number).