### PR TITLE
chore(mobile): remove autoscrolling sample questions on mobile

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_welcome_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_welcome_page.dart
@@ -1,14 +1,11 @@
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
-import 'package:appflowy/util/debounce.dart';
 import 'package:appflowy/util/theme_extension.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:time/time.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 class ChatWelcomePage extends StatelessWidget {
@@ -183,7 +180,7 @@ class WelcomeSampleQuestion extends StatelessWidget {
   }
 }
 
-class _AutoScrollingSampleQuestions extends StatefulWidget {
+class _AutoScrollingSampleQuestions extends StatelessWidget {
   const _AutoScrollingSampleQuestions({
     super.key,
     required this.questions,
@@ -198,92 +195,21 @@ class _AutoScrollingSampleQuestions extends StatefulWidget {
   final bool reverse;
 
   @override
-  State<_AutoScrollingSampleQuestions> createState() =>
-      _AutoScrollingSampleQuestionsState();
-}
-
-class _AutoScrollingSampleQuestionsState
-    extends State<_AutoScrollingSampleQuestions> {
-  final restartAutoScrollDebounce = Debounce(duration: 3.seconds);
-  late final ScrollController scrollController;
-
-  bool userIntervened = false;
-
-  @override
-  void initState() {
-    super.initState();
-    scrollController = ScrollController(
-      onAttach: (_) => startScroll(),
-      initialScrollOffset: widget.offset,
-    );
-  }
-
-  @override
-  void dispose() {
-    scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return NotificationListener<ScrollNotification>(
-      onNotification: (notification) {
-        if (notification is ScrollUpdateNotification) {
-          return false;
-        }
-        if (notification is ScrollEndNotification && !userIntervened) {
-          startScroll();
-        } else if (notification is UserScrollNotification &&
-            notification.direction == ScrollDirection.idle) {
-          scheduleRestart();
-        }
-        return false;
-      },
-      child: SizedBox(
-        height: 36,
-        child: Stack(
-          children: [
-            InfiniteScrollView(
-              centerKey: UniqueKey(),
-              scrollController: scrollController,
-              itemCount: widget.questions.length,
-              itemBuilder: (context, index) {
-                return WelcomeSampleQuestion(
-                  question: widget.questions[index],
-                  onSelected: widget.onSelected,
-                );
-              },
-              separatorBuilder: (context, index) => const HSpace(8),
-            ),
-            Listener(
-              behavior: HitTestBehavior.translucent,
-              onPointerDown: (event) {
-                userIntervened = true;
-                scrollController.jumpTo(scrollController.offset);
-              },
-            ),
-          ],
-        ),
+    return SizedBox(
+      height: 36,
+      child: InfiniteScrollView(
+        centerKey: UniqueKey(),
+        itemCount: questions.length,
+        itemBuilder: (context, index) {
+          return WelcomeSampleQuestion(
+            question: questions[index],
+            onSelected: onSelected,
+          );
+        },
+        separatorBuilder: (context, index) => const HSpace(8),
       ),
     );
-  }
-
-  void startScroll() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final delta = widget.reverse ? -250 : 250;
-      scrollController.animateTo(
-        scrollController.offset + delta,
-        duration: 20.seconds,
-        curve: Curves.linear,
-      );
-    });
-  }
-
-  void scheduleRestart() {
-    restartAutoScrollDebounce.call(() {
-      userIntervened = false;
-      startScroll();
-    });
   }
 }
 


### PR DESCRIPTION
When I call `scrollController.animateTo`, the first user drag or click will always interrupt that in-progress scroll, and the hit test doesn't get to the actual button that's inside the custom scroll view. When a second tap occurs, since the scrolling has stopped, the button inside can now receive the pointer event.

Since this may cause bad UX, we are completely removing the autoscrolling behavior on mobile.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
