### PR TITLE
feat: support click to create content inside empty toggle list

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_with_toggle_list_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_with_toggle_list_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -262,6 +264,25 @@ void main() {
       expect(node.type, ToggleListBlockKeys.type);
       expect(node.attributes[ToggleListBlockKeys.level], 3);
       expect(node.delta!.toPlainText(), 'Hello');
+    });
+
+    testWidgets('click the toggle list to create a new paragraph',
+        (tester) async {
+      await prepareToggleHeadingBlock(tester, '> # Hello');
+      final emptyHintText = find.text(
+        LocaleKeys.document_plugins_emptyToggleHeading.tr(
+          args: ['1'],
+        ),
+      );
+      expect(emptyHintText, findsOneWidget);
+
+      await tester.tapButton(emptyHintText);
+      await tester.pumpAndSettle();
+
+      // check the new paragraph is created
+      final editorState = tester.editor.getCurrentEditorState();
+      final node = editorState.getNodeAtPath([0, 0])!;
+      expect(node.type, ParagraphBlockKeys.type);
     });
   });
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/document_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/document_page.dart
@@ -163,7 +163,11 @@ class _DocumentPageState extends State<DocumentPage>
     return Provider(
       create: (_) {
         final context = SharedEditorContext();
-        if (widget.view.name.isEmpty) {
+        final children = editorState.document.root.children;
+        final firstDelta = children.firstOrNull?.delta;
+        final isEmptyDocument =
+            children.length == 1 && (firstDelta == null || firstDelta.isEmpty);
+        if (widget.view.name.isEmpty && isEmptyDocument) {
           context.requestCoverTitleFocus = true;
         }
         return context;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/cover_title.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/cover_title.dart
@@ -163,6 +163,10 @@ class _InnerCoverTitleState extends State<_InnerCoverTitle> {
   bool _shouldFocus(ViewPB view, ViewState? state) {
     final name = state?.view.name ?? view.name;
 
+    if (editorState.document.root.children.isNotEmpty) {
+      return false;
+    }
+
     // if the view's name is empty, focus on the title
     if (name.isEmpty) {
       return true;
@@ -180,6 +184,15 @@ class _InnerCoverTitleState extends State<_InnerCoverTitle> {
 
   void _onFocusChanged() {
     if (titleFocusNode.hasFocus) {
+      // if the document is empty, disable the keyboard service
+      final children = editorState.document.root.children;
+      final firstDelta = children.firstOrNull?.delta;
+      final isEmptyDocument =
+          children.length == 1 && (firstDelta == null || firstDelta.isEmpty);
+      if (!isEmptyDocument) {
+        return;
+      }
+
       if (editorState.selection != null) {
         Log.info('cover title got focus, clear the editor selection');
         editorState.selection = null;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
@@ -1,6 +1,6 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
-import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -251,13 +251,16 @@ class _ToggleListBlockComponentWidgetState
     final textDirection = calculateTextDirection(
       layoutDirection: Directionality.maybeOf(context),
     );
+    final crossAxisAlignment = textDirection == TextDirection.ltr
+        ? CrossAxisAlignment.start
+        : CrossAxisAlignment.end;
 
     return Container(
       width: double.infinity,
       alignment: alignment,
       child: Column(
         mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: crossAxisAlignment,
         children: [
           Row(
             mainAxisSize: MainAxisSize.min,
@@ -335,6 +338,9 @@ class _ToggleListBlockComponentWidgetState
 
   Widget _buildExpandIcon() {
     double buttonHeight = UniversalPlatform.isDesktop ? 22.0 : 26.0;
+    final textDirection = calculateTextDirection(
+      layoutDirection: Directionality.maybeOf(context),
+    );
 
     if (level != null) {
       // top padding * 2 + button height = height of the heading text
@@ -347,23 +353,27 @@ class _ToggleListBlockComponentWidgetState
       }
     }
 
+    final turns = switch (textDirection) {
+      TextDirection.ltr => collapsed ? 0.0 : 0.25,
+      TextDirection.rtl => collapsed ? -0.5 : -0.75,
+    };
+
     return Container(
       constraints: BoxConstraints(
         minWidth: 26,
         minHeight: buttonHeight,
       ),
-      child: FlowyIconButton(
-        width: 20.0,
-        onPressed: onCollapsed,
-        icon: Container(
-          padding: const EdgeInsets.only(right: 4.0),
-          child: AnimatedRotation(
-            turns: collapsed ? 0.0 : 0.25,
-            duration: const Duration(milliseconds: 200),
-            child: const Icon(
-              Icons.arrow_right,
-              size: 18.0,
-            ),
+      alignment: Alignment.center,
+      child: FlowyButton(
+        margin: const EdgeInsets.all(2.0),
+        useIntrinsicWidth: true,
+        onTap: onCollapsed,
+        text: AnimatedRotation(
+          turns: turns,
+          duration: const Duration(milliseconds: 200),
+          child: const Icon(
+            Icons.arrow_right,
+            size: 18.0,
           ),
         ),
       ),

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -1704,6 +1704,8 @@
       "insertDate": "Insert date",
       "emoji": "Emoji",
       "toggleList": "Toggle list",
+      "emptyToggleHeading": "Empty toggle heading {}. Click to add content",
+      "emptyToggleList": "Empty toggle list. Click to add content",
       "quoteList": "Quote list",
       "numberedList": "Numbered list",
       "bulletedList": "Bulleted list",


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes #6776
closes #6737 

- [x] support click to create content inside empty toggle list
- [x] test
- [x]  reverse the expand icon in RTL mode (no test required)

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
