### PR TITLE
fix(desktop): resize sidebar menu regression

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/home/home_setting_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/home/home_setting_bloc.dart
@@ -86,7 +86,7 @@ class HomeSettingBloc extends Bloc<HomeSettingEvent, HomeSettingState> {
           },
           editPanelResized: (_EditPanelResized e) {
             final newPosition =
-                (e.offset + state.resizeStart).clamp(-50, 200).toDouble();
+                (state.resizeStart + e.offset).clamp(0, 200).toDouble();
             if (state.resizeOffset != newPosition) {
               emit(state.copyWith(resizeOffset: newPosition));
             }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_layout.dart
@@ -14,10 +14,11 @@ class HomeLayout {
   HomeLayout(BuildContext context) {
     final homeSetting = context.read<HomeSettingBloc>().state;
     showEditPanel = homeSetting.panelContext != null;
-    menuWidth = Sizes.sideBarWidth;
-    menuWidth += homeSetting.resizeOffset;
 
-    menuWidth = max(menuWidth, HomeSizes.minimumSidebarWidth);
+    menuWidth = max(
+      HomeSizes.minimumSidebarWidth + homeSetting.resizeOffset,
+      HomeSizes.minimumSidebarWidth,
+    );
 
     final screenWidthPx = context.widthPx;
     context

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/size.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/size.dart
@@ -57,8 +57,6 @@ class Sizes {
   static double get hit => 40 * hitScale;
 
   static double get iconMed => 20;
-
-  static double get sideBarWidth => 250 * hitScale;
 }
 
 class Corners {


### PR DESCRIPTION
illustration of bug:

https://github.com/user-attachments/assets/afe00f43-cbb2-4ed4-9732-497f3000810d

cause: negative resize offsets are no longer allowed

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
