### PR TITLE
fix: tabs lr 0.7.6

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
@@ -4,6 +4,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/presentation/home/tabs/flowy_tab.dart';
 import 'package:appflowy/workspace/presentation/home/tabs/tabs_manager.dart';
+import 'package:appflowy/workspace/presentation/widgets/tab_bar_item.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/gestures.dart';
@@ -233,5 +234,127 @@ void main() {
       expect(secondTabFinder, findsOneWidget);
       expect(thirdTabFinder, findsNothing);
     });
+
+    testWidgets('pin/unpin tabs proper order', (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      expect(
+        find.descendant(
+          of: find.byType(TabsManager),
+          matching: find.byType(TabBar),
+        ),
+        findsNothing,
+      );
+
+      await tester.createNewPageWithNameUnderParent(name: _documentName);
+      await tester.createNewPageWithNameUnderParent(name: _documentTwoName);
+
+      // Open second menu item in a new tab
+      await tester.openAppInNewTab(gettingStarted, ViewLayoutPB.Document);
+
+      // Open third menu item in a new tab
+      await tester.openAppInNewTab(_documentName, ViewLayoutPB.Document);
+
+      expect(
+        find.descendant(
+          of: find.byType(TabsManager),
+          matching: find.byType(FlowyTab),
+        ),
+        findsNWidgets(3),
+      );
+
+      const firstTabName = _documentTwoName;
+      const secondTabName = gettingStarted;
+      const thirdTabName = _documentName;
+
+      // Expect correct order
+      expect(tester.isTabAtIndex(firstTabName, 0), isTrue);
+      expect(tester.isTabAtIndex(secondTabName, 1), isTrue);
+      expect(tester.isTabAtIndex(thirdTabName, 2), isTrue);
+
+      // Pin second tab
+      await tester.openTabMenu(secondTabName);
+      await tester.tap(find.text(LocaleKeys.tabMenu_pinTab.tr()));
+      await tester.pumpAndSettle();
+
+      expect(tester.isTabPinned(secondTabName), isTrue);
+
+      // Expect correct order
+      expect(tester.isTabAtIndex(secondTabName, 0), isTrue);
+      expect(tester.isTabAtIndex(firstTabName, 1), isTrue);
+      expect(tester.isTabAtIndex(thirdTabName, 2), isTrue);
+
+      // Pin new second tab (first tab)
+      await tester.openTabMenu(firstTabName);
+      await tester.tap(find.text(LocaleKeys.tabMenu_pinTab.tr()));
+      await tester.pumpAndSettle();
+
+      expect(tester.isTabPinned(firstTabName), isTrue);
+      expect(tester.isTabPinned(secondTabName), isTrue);
+      expect(tester.isTabPinned(thirdTabName), isFalse);
+
+      expect(tester.isTabAtIndex(secondTabName, 0), isTrue);
+      expect(tester.isTabAtIndex(firstTabName, 1), isTrue);
+      expect(tester.isTabAtIndex(thirdTabName, 2), isTrue);
+
+      // Unpin second tab
+      await tester.openTabMenu(secondTabName);
+      await tester.tap(find.text(LocaleKeys.tabMenu_unpinTab.tr()));
+      await tester.pumpAndSettle();
+
+      expect(tester.isTabPinned(firstTabName), isTrue);
+      expect(tester.isTabPinned(secondTabName), isFalse);
+      expect(tester.isTabPinned(thirdTabName), isFalse);
+
+      expect(tester.isTabAtIndex(firstTabName, 0), isTrue);
+      expect(tester.isTabAtIndex(secondTabName, 1), isTrue);
+      expect(tester.isTabAtIndex(thirdTabName, 2), isTrue);
+    });
   });
+}
+
+extension _TabsTester on WidgetTester {
+  bool isTabPinned(String tabName) {
+    final tabFinder = find.ancestor(
+      of: find.byWidgetPredicate(
+        (w) => w is ViewTabBarItem && w.view.name == tabName,
+      ),
+      matching: find.byType(FlowyTab),
+    );
+
+    final FlowyTab tabWidget = widget(tabFinder);
+    return tabWidget.pageManager.isPinned;
+  }
+
+  bool isTabAtIndex(String tabName, int index) {
+    final tabFinder = find.ancestor(
+      of: find.byWidgetPredicate(
+        (w) => w is ViewTabBarItem && w.view.name == tabName,
+      ),
+      matching: find.byType(FlowyTab),
+    );
+
+    final pluginId = (widget(tabFinder) as FlowyTab).pageManager.plugin.id;
+
+    final pluginIds = find
+        .byType(FlowyTab)
+        .evaluate()
+        .map((e) => (e.widget as FlowyTab).pageManager.plugin.id);
+
+    return pluginIds.elementAt(index) == pluginId;
+  }
+
+  Future<void> openTabMenu(String tabName) async {
+    await tap(
+      buttons: kSecondaryButton,
+      find.ancestor(
+        of: find.byWidgetPredicate(
+          (w) => w is ViewTabBarItem && w.view.name == tabName,
+        ),
+        matching: find.byType(FlowyTab),
+      ),
+    );
+    await pumpAndSettle();
+  }
 }

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/tabs_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/workspace/presentation/home/tabs/flowy_tab.dart';
 import 'package:appflowy/workspace/presentation/home/tabs/tabs_manager.dart';
@@ -177,62 +176,37 @@ void main() {
         findsNWidgets(3),
       );
 
-      final firstTabFinder = find.descendant(
-        of: find.byType(FlowyTab),
-        matching: find.text(_documentTwoName),
-      );
-      final secondTabFinder = find.descendant(
-        of: find.byType(FlowyTab),
-        matching: find.text(gettingStarted),
-      );
-      final thirdTabFinder = find.descendant(
-        of: find.byType(FlowyTab),
-        matching: find.text(_documentName),
-      );
+      const firstTab = _documentTwoName;
+      const secondTab = gettingStarted;
+      const thirdTab = _documentName;
 
-      expect(firstTabFinder, findsOneWidget);
-      expect(secondTabFinder, findsOneWidget);
-      expect(thirdTabFinder, findsOneWidget);
+      expect(tester.isTabAtIndex(firstTab, 0), isTrue);
+      expect(tester.isTabAtIndex(secondTab, 1), isTrue);
+      expect(tester.isTabAtIndex(thirdTab, 2), isTrue);
 
-      // We expect not to see the pinned svg
-      expect(find.byFlowySvg(FlowySvgs.pinned_s), findsNothing);
+      expect(tester.isTabPinned(gettingStarted), isFalse);
 
       // Right click on second tab
-      await tester.tap(
-        buttons: kSecondaryButton,
-        find.descendant(
-          of: find.byType(FlowyTab),
-          matching: find.text(gettingStarted),
-        ),
-      );
-      await tester.pumpAndSettle();
+      await tester.openTabMenu(gettingStarted);
       expect(find.byType(TabMenu), findsOneWidget);
 
       // Pin second tab
       await tester.tap(find.text(LocaleKeys.tabMenu_pinTab.tr()));
       await tester.pumpAndSettle();
 
-      // We expect to see the pinned svg
-      expect(find.byFlowySvg(FlowySvgs.pinned_s), findsOneWidget);
+      expect(tester.isTabPinned(gettingStarted), isTrue);
 
-      /// Right click on first tab
-      await tester.tap(
-        buttons: kSecondaryButton,
-        find.descendant(
-          of: find.byType(FlowyTab),
-          matching: find.text(_documentTwoName),
-        ),
-      );
-      await tester.pumpAndSettle();
+      /// Right click on first unpinned tab (second tab)
+      await tester.openTabMenu(_documentTwoName);
 
-      // Close others than first tab
+      // Close others
       await tester.tap(find.text(LocaleKeys.tabMenu_closeOthers.tr()));
       await tester.pumpAndSettle();
 
-      // We expect to find 2 tabs, the first tab and the pinned second tab
-      expect(firstTabFinder, findsOneWidget);
-      expect(secondTabFinder, findsOneWidget);
-      expect(thirdTabFinder, findsNothing);
+      // We expect to find 2 tabs, the first pinned tab and the second tab
+      expect(find.byType(FlowyTab), findsNWidgets(2));
+      expect(tester.isTabAtIndex(gettingStarted, 0), isTrue);
+      expect(tester.isTabAtIndex(_documentTwoName, 1), isTrue);
     });
 
     testWidgets('pin/unpin tabs proper order', (tester) async {

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/chat.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/chat.dart
@@ -2,6 +2,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/plugins/ai_chat/chat_page.dart';
 import 'package:appflowy/plugins/util.dart';
 import 'package:appflowy/startup/plugin/plugin.dart';
+import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/application/view_info/view_info_bloc.dart';
 import 'package:appflowy/workspace/presentation/home/home_stack.dart';
 import 'package:appflowy/workspace/presentation/widgets/tab_bar_item.dart';
@@ -86,11 +87,15 @@ class AIChatPagePluginWidgetBuilder extends PluginWidgetBuilder
   int? deletedViewIndex;
 
   @override
+  String? get viewName => notifier.view.nameOrDefault;
+
+  @override
   Widget get leftBarItem =>
       ViewTitleBar(key: ValueKey(notifier.view.id), view: notifier.view);
 
   @override
-  Widget tabBarItem(String pluginId) => ViewTabBarItem(view: notifier.view);
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) =>
+      ViewTabBarItem(view: notifier.view, shortForm: shortForm);
 
   @override
   Widget buildWidget({

--- a/frontend/appflowy_flutter/lib/plugins/blank/blank.dart
+++ b/frontend/appflowy_flutter/lib/plugins/blank/blank.dart
@@ -45,10 +45,13 @@ class BlankPagePlugin extends Plugin {
 class BlankPagePluginWidgetBuilder extends PluginWidgetBuilder
     with NavigationItem {
   @override
+  String? get viewName => LocaleKeys.blankPageTitle.tr();
+
+  @override
   Widget get leftBarItem => FlowyText.medium(LocaleKeys.blankPageTitle.tr());
 
   @override
-  Widget tabBarItem(String pluginId) => leftBarItem;
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) => leftBarItem;
 
   @override
   Widget buildWidget({

--- a/frontend/appflowy_flutter/lib/plugins/database/tab_bar/tab_bar_view.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/tab_bar/tab_bar_view.dart
@@ -258,11 +258,15 @@ class DatabasePluginWidgetBuilder extends PluginWidgetBuilder {
   final String? initialRowId;
 
   @override
+  String? get viewName => notifier.view.nameOrDefault;
+
+  @override
   Widget get leftBarItem =>
       ViewTitleBar(key: ValueKey(notifier.view.id), view: notifier.view);
 
   @override
-  Widget tabBarItem(String pluginId) => ViewTabBarItem(view: notifier.view);
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) =>
+      ViewTabBarItem(view: notifier.view, shortForm: shortForm);
 
   @override
   Widget buildWidget({

--- a/frontend/appflowy_flutter/lib/plugins/database_document/database_document_plugin.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database_document/database_document_plugin.dart
@@ -4,6 +4,7 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/application/document_appearance_cubit.dart';
 import 'package:appflowy/startup/plugin/plugin.dart';
+import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/presentation/home/home_stack.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
@@ -98,6 +99,9 @@ class DatabaseDocumentPluginWidgetBuilder extends PluginWidgetBuilder
   final Selection? initialSelection;
 
   @override
+  String? get viewName => view.nameOrDefault;
+
+  @override
   EdgeInsets get contentPadding => EdgeInsets.zero;
 
   @override
@@ -123,7 +127,8 @@ class DatabaseDocumentPluginWidgetBuilder extends PluginWidgetBuilder
       ViewTitleBarWithRow(view: view, databaseId: databaseId, rowId: rowId);
 
   @override
-  Widget tabBarItem(String pluginId) => const SizedBox.shrink();
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) =>
+      const SizedBox.shrink();
 
   @override
   Widget? get rightBarItem => const SizedBox.shrink();

--- a/frontend/appflowy_flutter/lib/plugins/document/document.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/document.dart
@@ -10,6 +10,7 @@ import 'package:appflowy/plugins/shared/share/share_button.dart';
 import 'package:appflowy/plugins/util.dart';
 import 'package:appflowy/shared/feature_flags.dart';
 import 'package:appflowy/startup/plugin/plugin.dart';
+import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/application/view_info/view_info_bloc.dart';
 import 'package:appflowy/workspace/presentation/home/home_stack.dart';
 import 'package:appflowy/workspace/presentation/widgets/favorite_button.dart';
@@ -146,10 +147,14 @@ class DocumentPluginWidgetBuilder extends PluginWidgetBuilder
   }
 
   @override
+  String? get viewName => notifier.view.nameOrDefault;
+
+  @override
   Widget get leftBarItem => ViewTitleBar(key: ValueKey(view.id), view: view);
 
   @override
-  Widget tabBarItem(String pluginId) => ViewTabBarItem(view: notifier.view);
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) =>
+      ViewTabBarItem(view: notifier.view, shortForm: shortForm);
 
   @override
   Widget? get rightBarItem {

--- a/frontend/appflowy_flutter/lib/plugins/trash/trash.dart
+++ b/frontend/appflowy_flutter/lib/plugins/trash/trash.dart
@@ -54,10 +54,13 @@ class TrashPlugin extends Plugin {
 
 class TrashPluginDisplay extends PluginWidgetBuilder {
   @override
+  String? get viewName => LocaleKeys.trash_text.tr();
+
+  @override
   Widget get leftBarItem => FlowyText.medium(LocaleKeys.trash_text.tr());
 
   @override
-  Widget tabBarItem(String pluginId) => leftBarItem;
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) => leftBarItem;
 
   @override
   Widget? get rightBarItem => null;
@@ -68,9 +71,7 @@ class TrashPluginDisplay extends PluginWidgetBuilder {
     required bool shrinkWrap,
     Map<String, dynamic>? data,
   }) =>
-      const TrashPage(
-        key: ValueKey('TrashPage'),
-      );
+      const TrashPage(key: ValueKey('TrashPage'));
 
   @override
   List<NavigationItem> get navigationItems => [this];

--- a/frontend/appflowy_flutter/lib/workspace/application/tabs/tabs_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/tabs/tabs_bloc.dart
@@ -67,20 +67,28 @@ class TabsBloc extends Bloc<TabsEvent, TabsState> {
             }
           },
           closeOtherTabs: (String pluginId) {
-            final pagesToClose = [
+            final pageManagers = [
               ...state._pageManagers
-                  .where((pm) => pm.plugin.id != pluginId && !pm.isPinned),
+                  .where((pm) => pm.plugin.id == pluginId || pm.isPinned),
             ];
 
-            if (pagesToClose.isEmpty) {
-              return;
+            int newIndex;
+            if (state.currentPageManager.isPinned) {
+              // Retain current index if it's already pinned
+              newIndex = state.currentIndex;
+            } else {
+              final pm = state._pageManagers
+                  .firstWhereOrNull((pm) => pm.plugin.id == pluginId);
+              newIndex = pm != null ? pageManagers.indexOf(pm) : 0;
             }
 
-            final newstate = state;
-            for (final pm in pagesToClose) {
-              newstate.closeView(pm.plugin.id);
-            }
-            emit(newstate.copyWith(currentIndex: 0));
+            emit(
+              state.copyWith(
+                currentIndex: newIndex,
+                pageManagers: pageManagers,
+              ),
+            );
+
             _setLatestOpenView();
           },
           togglePin: (String pluginId) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_stack.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_stack.dart
@@ -58,7 +58,10 @@ class _HomeStackState extends State<HomeStack> {
     return BlocProvider<TabsBloc>.value(
       value: getIt<TabsBloc>(),
       child: BlocBuilder<TabsBloc, TabsState>(
-        buildWhen: (prev, curr) => prev.currentIndex != curr.currentIndex,
+        buildWhen: (prev, curr) =>
+            prev.currentIndex != curr.currentIndex &&
+            prev.currentPageManager.plugin.id !=
+                curr.currentPageManager.plugin.id,
         builder: (context, state) => Column(
           children: [
             if (Platform.isWindows)
@@ -239,9 +242,10 @@ class FadingIndexedStackState extends State<FadingIndexedStack> {
 }
 
 abstract mixin class NavigationItem {
+  String? get viewName;
   Widget get leftBarItem;
   Widget? get rightBarItem => null;
-  Widget tabBarItem(String pluginId);
+  Widget tabBarItem(String pluginId, [bool shortForm = false]);
 
   NavigationCallback get action => (id) => throw UnimplementedError();
 }
@@ -254,8 +258,11 @@ class PageNotifier extends ChangeNotifier {
 
   Widget get titleWidget => _plugin.widgetBuilder.leftBarItem;
 
-  Widget tabBarWidget(String pluginId) =>
-      _plugin.widgetBuilder.tabBarItem(pluginId);
+  Widget tabBarWidget(
+    String pluginId, [
+    bool shortForm = false,
+  ]) =>
+      _plugin.widgetBuilder.tabBarItem(pluginId, shortForm);
 
   /// This is the only place where the plugin is set.
   /// No need compare the old plugin with the new plugin. Just set it.

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/_sidebar_workspace_menu.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/_sidebar_workspace_menu.dart
@@ -298,15 +298,14 @@ class _WorkspaceInfo extends StatelessWidget {
 
   void _openWorkspace(BuildContext context) {
     if (!isSelected) {
-      // close the other tabs before opening another workspace.
-      getIt<TabsBloc>().add(const TabsEvent.closeOtherTabs(''));
-
       Log.info('open workspace: ${workspace.workspaceId}');
-      context.read<UserWorkspaceBloc>().add(
-            UserWorkspaceEvent.openWorkspace(
-              workspace.workspaceId,
-            ),
-          );
+
+      // Persist and close other tabs when switching workspace, restore tabs for new workspace
+      getIt<TabsBloc>().add(TabsEvent.switchWorkspace(workspace.workspaceId));
+
+      context
+          .read<UserWorkspaceBloc>()
+          .add(UserWorkspaceEvent.openWorkspace(workspace.workspaceId));
 
       PopoverContainer.of(context).closeAll();
     }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/navigation.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/navigation.dart
@@ -162,13 +162,13 @@ class EllipsisNaviItem extends NavigationItem {
   final List<NavigationItem> items;
 
   @override
-  Widget get leftBarItem => FlowyText.medium(
-        '...',
-        fontSize: FontSizes.s16,
-      );
+  String? get viewName => null;
 
   @override
-  Widget tabBarItem(String pluginId) => leftBarItem;
+  Widget get leftBarItem => FlowyText.medium('...', fontSize: FontSizes.s16);
+
+  @override
+  Widget tabBarItem(String pluginId, [bool shortForm = false]) => leftBarItem;
 
   @override
   NavigationCallback get action => (id) {};

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/tabs/flowy_tab.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/tabs/flowy_tab.dart
@@ -39,7 +39,7 @@ class _FlowyTabState extends State<FlowyTab> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: widget.pageManager.isPinned ? 52 : null,
+      width: widget.pageManager.isPinned ? 54 : null,
       child: _wrapInTooltip(
         widget.pageManager.plugin.widgetBuilder.viewName,
         child: FlowyHover(
@@ -85,7 +85,7 @@ class _FlowyTabState extends State<FlowyTab> {
                       child: Container(
                         constraints: BoxConstraints(
                           maxWidth: HomeSizes.tabBarWidth,
-                          minWidth: widget.pageManager.isPinned ? 52 : 100,
+                          minWidth: widget.pageManager.isPinned ? 54 : 100,
                         ),
                         height: HomeSizes.tabBarHeight,
                         child: Row(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/tabs/tabs_manager.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/tabs/tabs_manager.dart
@@ -25,6 +25,8 @@ class TabsManager extends StatelessWidget {
               return const SizedBox.shrink();
             }
 
+            final isAllPinned = state.isAllPinned;
+
             return Container(
               alignment: Alignment.bottomLeft,
               height: HomeSizes.tabBarHeight,
@@ -43,6 +45,7 @@ class TabsManager extends StatelessWidget {
                           key: ValueKey('tab-${pm.plugin.id}'),
                           pageManager: pm,
                           isCurrent: state.currentPageManager == pm,
+                          isAllPinned: isAllPinned,
                           onTap: () {
                             if (state.currentPageManager != pm) {
                               final index = state.pageManagers.indexOf(pm);

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/tab_bar_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/tab_bar_item.dart
@@ -46,7 +46,8 @@ class _ViewTabBarItemState extends State<ViewTabBarItem> {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment:
+          widget.shortForm ? MainAxisAlignment.center : MainAxisAlignment.start,
       children: [
         if (widget.view.icon.value.isNotEmpty)
           FlowyText.emoji(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/tab_bar_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/tab_bar_item.dart
@@ -6,9 +6,14 @@ import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 
 class ViewTabBarItem extends StatefulWidget {
-  const ViewTabBarItem({super.key, required this.view});
+  const ViewTabBarItem({
+    super.key,
+    required this.view,
+    this.shortForm = false,
+  });
 
   final ViewPB view;
+  final bool shortForm;
 
   @override
   State<ViewTabBarItem> createState() => _ViewTabBarItemState();
@@ -39,8 +44,27 @@ class _ViewTabBarItemState extends State<ViewTabBarItem> {
   }
 
   @override
-  Widget build(BuildContext context) => FlowyText.medium(
-        view.nameOrDefault,
-        overflow: TextOverflow.ellipsis,
-      );
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.view.icon.value.isNotEmpty)
+          FlowyText.emoji(
+            widget.view.icon.value,
+            fontSize: 16.0,
+            figmaLineHeight: 20.0,
+            optimizeEmojiAlign: true,
+          ),
+        if (!widget.shortForm && view.icon.value.isNotEmpty) const HSpace(6),
+        if (!widget.shortForm || view.icon.value.isEmpty) ...[
+          Flexible(
+            child: FlowyText.medium(
+              view.nameOrDefault,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
 }

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -2887,7 +2887,10 @@
   },
   "tabMenu": {
     "close": "Close",
+    "closeDisabledHint": "Cannot close a pinned tab, please unpin first",
     "closeOthers": "Close other tabs",
+    "closeOthersHint": "This will close all unpinned tabs except this one",
+    "closeOthersDisabledHint": "All tabs are pinned, cannot find any tabs to close",
     "favorite": "Favorite",
     "unfavorite": "Unfavorite",
     "favoriteDisabledHint": "Cannot favorite this view",


### PR DESCRIPTION
- [x] Close tab menu popover when it should be closed
- [x] Make "Close"-option disabled when pinned
- [x] Add tooltips to buttons in Tab menu to explain usage or when they're disabled (why)
- [x] Close tabs when switching workspace
- [x] Move pinned tabs to beginning of tab bar
- [x] Include View Icon in tab
- [x] Pinned tabs are smaller and only show icon if possible 

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
