### PR TITLE
feat: able to select language for the code block by arrow keys (#6905)

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/code_block_language_selector_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/code_block_language_selector_test.dart
@@ -1,0 +1,75 @@
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart';
+
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../shared/base.dart';
+import '../../shared/common_operations.dart';
+import '../../shared/document_test_operations.dart';
+import '../document/document_codeblock_paste_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Code Block Language Selector Test', (tester) async {
+    await tester.initializeAppFlowy();
+    await tester.tapAnonymousSignInButton();
+
+    /// create a new document
+    await tester.createNewPageWithNameUnderParent();
+
+    /// tap editor to get focus
+    await tester.tapButton(find.byType(AppFlowyEditor));
+
+    expect(find.byType(CodeBlockLanguageSelector), findsNothing);
+    await insertCodeBlockInDocument(tester);
+
+    ///tap button
+    await tester.hoverOnWidget(find.byType(CodeBlockComponentWidget));
+    await tester
+        .tapButtonWithName(LocaleKeys.document_codeBlock_language_auto.tr());
+    expect(find.byType(CodeBlockLanguageSelector), findsOneWidget);
+
+    for (var i = 0; i < 3; ++i) {
+      await onKey(tester, LogicalKeyboardKey.arrowDown);
+    }
+    for (var i = 0; i < 2; ++i) {
+      await onKey(tester, LogicalKeyboardKey.arrowUp);
+    }
+
+    await onKey(tester, LogicalKeyboardKey.enter);
+
+    final editorState = tester.editor.getCurrentEditorState();
+    final language =
+        editorState.getNodeAtPath([0])!.attributes['language'].toString();
+    expect(
+      language.toLowerCase(),
+      defaultCodeBlockSupportedLanguages.first.toLowerCase(),
+    );
+
+    await tester.hoverOnWidget(find.byType(CodeBlockComponentWidget));
+    await tester.tapButtonWithName(language);
+
+    await onKey(tester, LogicalKeyboardKey.arrowUp);
+    await onKey(tester, LogicalKeyboardKey.enter);
+
+    expect(
+      editorState
+          .getNodeAtPath([0])!
+          .attributes['language']
+          .toString()
+          .toLowerCase(),
+      defaultCodeBlockSupportedLanguages.last.toLowerCase(),
+    );
+  });
+}
+
+Future<void> onKey(WidgetTester tester, LogicalKeyboardKey key) async {
+  await tester.simulateKeyEvent(key);
+  await tester.pumpAndSettle();
+}

--- a/frontend/appflowy_flutter/integration_test/desktop_runner_9.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop_runner_9.dart
@@ -1,6 +1,8 @@
 import 'package:integration_test/integration_test.dart';
 
 import 'desktop/uncategorized/tabs_test.dart' as tabs_test;
+import 'desktop/uncategorized/code_block_language_selector_test.dart'
+    as code_language_selector;
 import 'desktop/first_test/first_test.dart' as first_test;
 
 Future<void> main() async {
@@ -11,6 +13,6 @@ Future<void> runIntegration9OnDesktop() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   first_test.main();
-
   tabs_test.main();
+  code_language_selector.main();
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/selectable_item_list_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/selectable_item_list_menu.dart
@@ -1,7 +1,9 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
-import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class SelectableItemListMenu extends StatelessWidget {
   const SelectableItemListMenu({
@@ -10,11 +12,13 @@ class SelectableItemListMenu extends StatelessWidget {
     required this.selectedIndex,
     required this.onSelected,
     this.shrinkWrap = false,
+    this.controller,
   });
 
   final List<String> items;
   final int selectedIndex;
   final void Function(int) onSelected;
+  final ItemScrollController? controller;
 
   /// shrinkWrapping is useful in cases where you have a list of
   /// limited amount of items. It will make the list take the minimum
@@ -24,9 +28,11 @@ class SelectableItemListMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
+    return ScrollablePositionedList.builder(
       shrinkWrap: shrinkWrap,
       itemCount: items.length,
+      itemScrollController: controller,
+      initialScrollIndex: max(0, selectedIndex),
       itemBuilder: (context, index) => SelectableItem(
         isSelected: index == selectedIndex,
         item: items[index],
@@ -57,7 +63,7 @@ class SelectableItem extends StatelessWidget {
           item,
           lineHeight: 1.0,
         ),
-        rightIcon: isSelected ? const FlowySvg(FlowySvgs.check_s) : null,
+        isSelected: isSelected,
         onTap: onTap,
       ),
     );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart
@@ -8,7 +8,9 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 CodeBlockLanguagePickerBuilder codeBlockLanguagePickerBuilder = (
@@ -19,7 +21,7 @@ CodeBlockLanguagePickerBuilder codeBlockLanguagePickerBuilder = (
   onMenuClose,
   onMenuOpen,
 }) =>
-    _CodeBlockLanguageSelector(
+    CodeBlockLanguageSelector(
       editorState: editorState,
       language: selectedLanguage,
       supportedLanguages: supportedLanguages,
@@ -28,8 +30,9 @@ CodeBlockLanguagePickerBuilder codeBlockLanguagePickerBuilder = (
       onMenuOpen: onMenuOpen,
     );
 
-class _CodeBlockLanguageSelector extends StatefulWidget {
-  const _CodeBlockLanguageSelector({
+class CodeBlockLanguageSelector extends StatefulWidget {
+  const CodeBlockLanguageSelector({
+    super.key,
     required this.editorState,
     required this.supportedLanguages,
     this.language,
@@ -46,12 +49,11 @@ class _CodeBlockLanguageSelector extends StatefulWidget {
   final VoidCallback? onMenuClose;
 
   @override
-  State<_CodeBlockLanguageSelector> createState() =>
+  State<CodeBlockLanguageSelector> createState() =>
       _CodeBlockLanguageSelectorState();
 }
 
-class _CodeBlockLanguageSelectorState
-    extends State<_CodeBlockLanguageSelector> {
+class _CodeBlockLanguageSelectorState extends State<CodeBlockLanguageSelector> {
   final controller = PopoverController();
 
   @override
@@ -136,7 +138,8 @@ class _LanguageSelectionPopoverState extends State<_LanguageSelectionPopover> {
   late List<String> filteredLanguages =
       widget.supportedLanguages.map((e) => e.capitalize()).toList();
   late int selectedIndex =
-      widget.supportedLanguages.indexOf(widget.language ?? '');
+      widget.supportedLanguages.indexOf(widget.language?.toLowerCase() ?? '');
+  final ItemScrollController languageListController = ItemScrollController();
 
   @override
   void initState() {
@@ -160,34 +163,87 @@ class _LanguageSelectionPopoverState extends State<_LanguageSelectionPopover> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        FlowyTextField(
-          focusNode: focusNode,
-          autoFocus: false,
-          controller: searchController,
-          hintText: LocaleKeys.document_codeBlock_searchLanguageHint.tr(),
-          onChanged: (_) => setState(() {
-            filteredLanguages = widget.supportedLanguages
-                .where((e) => e.contains(searchController.text.toLowerCase()))
-                .map((e) => e.capitalize())
-                .toList();
-            selectedIndex =
-                widget.supportedLanguages.indexOf(widget.language ?? '');
-          }),
-        ),
-        const VSpace(8),
-        Flexible(
-          child: SelectableItemListMenu(
-            shrinkWrap: true,
-            items: filteredLanguages,
-            selectedIndex: selectedIndex,
-            onSelected: (index) =>
-                widget.onLanguageSelected(filteredLanguages[index]),
+    return Shortcuts(
+      shortcuts: const {
+        SingleActivator(LogicalKeyboardKey.arrowUp):
+            _DirectionIntent(AxisDirection.up),
+        SingleActivator(LogicalKeyboardKey.arrowDown):
+            _DirectionIntent(AxisDirection.down),
+        SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+      },
+      child: Actions(
+        actions: {
+          _DirectionIntent: CallbackAction<_DirectionIntent>(
+            onInvoke: (intent) => onArrowKey(intent.direction),
           ),
+          ActivateIntent: CallbackAction<ActivateIntent>(
+            onInvoke: (intent) {
+              if (selectedIndex < 0) return;
+              selectLanguage(selectedIndex);
+              return null;
+            },
+          ),
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FlowyTextField(
+              focusNode: focusNode,
+              autoFocus: false,
+              controller: searchController,
+              hintText: LocaleKeys.document_codeBlock_searchLanguageHint.tr(),
+              onChanged: (_) => setState(() {
+                filteredLanguages = widget.supportedLanguages
+                    .where(
+                      (e) => e.contains(searchController.text.toLowerCase()),
+                    )
+                    .map((e) => e.capitalize())
+                    .toList();
+                selectedIndex =
+                    widget.supportedLanguages.indexOf(widget.language ?? '');
+              }),
+            ),
+            const VSpace(8),
+            Flexible(
+              child: SelectableItemListMenu(
+                controller: languageListController,
+                shrinkWrap: true,
+                items: filteredLanguages,
+                selectedIndex: selectedIndex,
+                onSelected: selectLanguage,
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
+
+  void onArrowKey(AxisDirection direction) {
+    if (filteredLanguages.isEmpty) return;
+    final isUp = direction == AxisDirection.up;
+    final length = filteredLanguages.length;
+    setState(() {
+      if (isUp) {
+        selectedIndex = selectedIndex == 0 ? length - 1 : selectedIndex - 1;
+      } else {
+        selectedIndex = selectedIndex == length - 1 ? 0 : selectedIndex + 1;
+      }
+    });
+    languageListController.scrollTo(
+      index: selectedIndex,
+      duration: const Duration(milliseconds: 300),
+    );
+  }
+
+  void selectLanguage(int index) {
+    widget.onLanguageSelected(filteredLanguages[index]);
+  }
+}
+
+/// [ScrollIntent] is not working, so using this custom Intent
+class _DirectionIntent extends Intent {
+  const _DirectionIntent(this.direction);
+
+  final AxisDirection direction;
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

solves #6905

### Feature Preview

- [x] Arrow down to switch language, supports head-tail cycling
- [x] Arrow up to switch language, supports head-tail cycling
- [x] Enter to confirm language



https://github.com/user-attachments/assets/8efcba00-211e-4977-98b4-840de312af9e



<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
