### PR TITLE
fix: inline grid launch review

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
@@ -385,17 +385,22 @@ class _GridRowsState extends State<_GridRows> {
   Widget build(BuildContext context) {
     Widget child;
     if (widget.shrinkWrap) {
-      child = SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
+      child = Scrollbar(
         controller: widget.scrollController.horizontalController,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxWidth: GridLayout.headerWidth(
-              context.read<DatabasePluginWidgetBuilderSize>().horizontalPadding,
-              context.read<GridBloc>().state.fields,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          controller: widget.scrollController.horizontalController,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: GridLayout.headerWidth(
+                context
+                    .read<DatabasePluginWidgetBuilderSize>()
+                    .horizontalPadding,
+                context.read<GridBloc>().state.fields,
+              ),
             ),
+            child: _renderList(context),
           ),
-          child: _renderList(context),
         ),
       );
     } else {

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/grid_header.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/grid_header.dart
@@ -7,7 +7,6 @@ import 'package:appflowy/plugins/database/grid/application/grid_header_bloc.dart
 import 'package:appflowy/plugins/database/tab_bar/tab_bar_view.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flowy_infra/size.dart';
 import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
@@ -154,11 +153,8 @@ class _CellTrailing extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      constraints: BoxConstraints(
-        maxWidth: GridSize.newPropertyButtonWidth,
-        minHeight: GridSize.headerHeight,
-      ),
-      margin: EdgeInsets.only(right: GridSize.scrollBarSize + Insets.m),
+      width: GridSize.newPropertyButtonWidth,
+      height: GridSize.headerHeight,
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(color: AFThemeExtension.of(context).borderColor),


### PR DESCRIPTION
Relates: #3503 - I fixed an issue related to this as well, resizing window shouldn't displace the two scrollviews anymore, not sure if this solves the bug described in 3503 though.

Added scrollbar to the inline grid

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
