### PR TITLE
fix: the index error when deleting text and then using the up or down arrow key

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/code_block_language_selector_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/code_block_language_selector_test.dart
@@ -1,6 +1,5 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart';
-
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -45,8 +44,10 @@ void main() {
     await onKey(tester, LogicalKeyboardKey.enter);
 
     final editorState = tester.editor.getCurrentEditorState();
-    final language =
-        editorState.getNodeAtPath([0])!.attributes['language'].toString();
+    String language = editorState
+        .getNodeAtPath([0])!
+        .attributes[CodeBlockKeys.language]
+        .toString();
     expect(
       language.toLowerCase(),
       defaultCodeBlockSupportedLanguages.first.toLowerCase(),
@@ -58,14 +59,29 @@ void main() {
     await onKey(tester, LogicalKeyboardKey.arrowUp);
     await onKey(tester, LogicalKeyboardKey.enter);
 
+    language = editorState
+        .getNodeAtPath([0])!
+        .attributes[CodeBlockKeys.language]
+        .toString();
     expect(
-      editorState
-          .getNodeAtPath([0])!
-          .attributes['language']
-          .toString()
-          .toLowerCase(),
+      language.toLowerCase(),
       defaultCodeBlockSupportedLanguages.last.toLowerCase(),
     );
+
+    await tester.hoverOnWidget(find.byType(CodeBlockComponentWidget));
+    await tester.tapButtonWithName(language);
+    tester.testTextInput.enterText("rust");
+    await onKey(tester, LogicalKeyboardKey.delete);
+    await onKey(tester, LogicalKeyboardKey.delete);
+    await onKey(tester, LogicalKeyboardKey.arrowDown);
+    tester.testTextInput.enterText("st");
+    await onKey(tester, LogicalKeyboardKey.arrowDown);
+    await onKey(tester, LogicalKeyboardKey.enter);
+    language = editorState
+        .getNodeAtPath([0])!
+        .attributes[CodeBlockKeys.language]
+        .toString();
+    expect(language.toLowerCase(), 'rust');
   });
 }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/selectable_item_list_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/selectable_item_list_menu.dart
@@ -29,6 +29,7 @@ class SelectableItemListMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScrollablePositionedList.builder(
+      physics: const ClampingScrollPhysics(),
       shrinkWrap: shrinkWrap,
       itemCount: items.length,
       itemScrollController: controller,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_language_selector.dart
@@ -222,6 +222,9 @@ class _LanguageSelectionPopoverState extends State<_LanguageSelectionPopover> {
   void onArrowKey(AxisDirection direction) {
     if (filteredLanguages.isEmpty) return;
     final isUp = direction == AxisDirection.up;
+    if (selectedIndex < 0) {
+      selectedIndex = isUp ? 0 : -1;
+    }
     final length = filteredLanguages.length;
     setState(() {
       if (isUp) {
@@ -232,6 +235,7 @@ class _LanguageSelectionPopoverState extends State<_LanguageSelectionPopover> {
     });
     languageListController.scrollTo(
       index: selectedIndex,
+      alignment: 0.5,
       duration: const Duration(milliseconds: 300),
     );
   }


### PR DESCRIPTION

---

- Using `ClampingScrollPhysics` to standardize the scroll animation when selecting language with arrow keys
- Fix the index error when deleting text and then using the up or down arrow key

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
