### PR TITLE
chore: add loose restrictions to date time text field

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_time_text_field.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_time_text_field.dart
@@ -278,13 +278,6 @@ class _DateTimeTextFieldState extends State<DateTimeTextField> {
                         key: const ValueKey('date_time_text_field_date'),
                         focusNode: dateFocusNode,
                         controller: dateTextController,
-                        maxLength: 12,
-                        inputFormatters: [
-                          // We can be more restrictive according to the DateFormatPB
-                          FilteringTextInputFormatter.allow(
-                            RegExp('[0-9.-/ ]'),
-                          ),
-                        ],
                         style: Theme.of(context).textTheme.bodyMedium,
                         decoration: getInputDecoration(
                           const EdgeInsetsDirectional.fromSTEB(12, 6, 6, 6),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_time_text_field.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_time_text_field.dart
@@ -278,6 +278,13 @@ class _DateTimeTextFieldState extends State<DateTimeTextField> {
                         key: const ValueKey('date_time_text_field_date'),
                         focusNode: dateFocusNode,
                         controller: dateTextController,
+                        maxLength: 12,
+                        inputFormatters: [
+                          // We can be more restrictive according to the DateFormatPB
+                          FilteringTextInputFormatter.allow(
+                            RegExp('[0-9.-/ ]'),
+                          ),
+                        ],
                         style: Theme.of(context).textTheme.bodyMedium,
                         decoration: getInputDecoration(
                           const EdgeInsetsDirectional.fromSTEB(12, 6, 6, 6),
@@ -301,6 +308,14 @@ class _DateTimeTextFieldState extends State<DateTimeTextField> {
                         focusNode: timeFocusNode,
                         controller: timeTextController,
                         style: Theme.of(context).textTheme.bodyMedium,
+                        maxLength: widget.timeFormat == TimeFormatPB.TwelveHour
+                            ? 8 // 12:34 PM = 8 characters
+                            : 5, // 12:34 = 5 characters
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(
+                            RegExp('[0-9:AaPpMm]'),
+                          ),
+                        ],
                         decoration: getInputDecoration(
                           const EdgeInsetsDirectional.fromSTEB(6, 6, 12, 6),
                           timeFormat.format(hintDate),
@@ -359,6 +374,7 @@ class _DateTimeTextFieldState extends State<DateTimeTextField> {
       isCollapsed: true,
       isDense: true,
       hintText: widget.showHint ? hintText : null,
+      counterText: "",
       hintStyle: Theme.of(context)
           .textTheme
           .bodyMedium


### PR DESCRIPTION
Closes: #6788 

This just adds some loose restrictions to the Date and Time text fields in the Date Picker.

This is done to help the user write the correct format. It's not completely enforced according to the date format, but does limit the user a bit more.

24-hours - Can only enter 5 characters (12:34) and only enter numbers and `:`
12-hours - Can enter `AM` and `PM` as well (12:34 AM) 8 characters

Date field - Can only enter 12 characters (Unsure if should limit it to 10) and allows `.`, `-`, and `/` characters other than numbers.

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
