### PR TITLE
feat: add option to paste plain text

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/services.dart';
-
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/block_menu/block_menu_button.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/copy_and_paste/clipboard_service.dart';
@@ -11,6 +9,7 @@ import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -27,10 +26,13 @@ void main() {
       await tester.pasteContent(
         plainText: List.generate(lines, (index) => 'line $index').join('\n'),
         (editorState) {
-          expect(editorState.document.root.children.length, 3);
+          expect(editorState.document.root.children.length, 1);
+          final text =
+              editorState.document.root.children.first.delta!.toPlainText();
+          final textLines = text.split('\n');
           for (var i = 0; i < lines; i++) {
             expect(
-              editorState.getNodeAtPath([i])!.delta!.toPlainText(),
+              textLines[i],
               'line $i',
             );
           }
@@ -467,6 +469,52 @@ void main() {
       expect(node.attributes[ImageBlockKeys.url], isNotEmpty);
     });
   });
+
+  testWidgets('paste markdowns', (tester) async {
+    await tester.pasteContent(
+      plainText: '''
+# I'm h1
+## I'm h2
+### I'm h3
+#### I'm h4
+##### I'm h5
+###### I'm h6''',
+      (editorState) {
+        final children = editorState.document.root.children;
+        expect(children.length, 6);
+        for (var i = 0; i < children.length; i++) {
+          final text = children[i].delta!.toPlainText();
+          expect(
+            text,
+            'I\'m h${i + 1}',
+          );
+        }
+      },
+    );
+  });
+
+  testWidgets('paste markdowns as plain', (tester) async {
+    const markdown = '''
+# I'm h1
+## I'm h2
+### I'm h3
+#### I'm h4
+##### I'm h5
+###### I'm h6''';
+    await tester.pasteContent(
+      plainText: markdown,
+      pasteAsPlain: true,
+      (editorState) {
+        final children = editorState.document.root.children;
+        expect(children.length, 6);
+        for (var i = 0; i < children.length; i++) {
+          final text = children[i].delta!.toPlainText();
+          final expectText = '${'#' * (i + 1)} I\'m h${i + 1}';
+          expect(text, expectText);
+        }
+      },
+    );
+  });
 }
 
 extension on WidgetTester {
@@ -476,6 +524,7 @@ extension on WidgetTester {
     String? plainText,
     String? html,
     String? inAppJson,
+    bool pasteAsPlain = false,
     (String, Uint8List?)? image,
   }) async {
     await initializeAppFlowy();
@@ -502,6 +551,7 @@ extension on WidgetTester {
     await simulateKeyEvent(
       LogicalKeyboardKey.keyV,
       isControlPressed: Platform.isLinux || Platform.isWindows,
+      isShiftPressed: pasteAsPlain,
       isMetaPressed: Platform.isMacOS,
     );
     await pumpAndSettle();

--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_copy_and_paste_test.dart
@@ -470,46 +470,38 @@ void main() {
     });
   });
 
-  testWidgets('paste markdowns', (tester) async {
-    await tester.pasteContent(
-      plainText: '''
-# I'm h1
-## I'm h2
-### I'm h3
-#### I'm h4
-##### I'm h5
-###### I'm h6''',
-      (editorState) {
-        final children = editorState.document.root.children;
-        expect(children.length, 6);
-        for (var i = 0; i < children.length; i++) {
-          final text = children[i].delta!.toPlainText();
-          expect(
-            text,
-            'I\'m h${i + 1}',
-          );
-        }
-      },
-    );
-  });
-
-  testWidgets('paste markdowns as plain', (tester) async {
-    const markdown = '''
+  const testMarkdownText = '''
 # I'm h1
 ## I'm h2
 ### I'm h3
 #### I'm h4
 ##### I'm h5
 ###### I'm h6''';
+
+  testWidgets('paste markdowns', (tester) async {
     await tester.pasteContent(
-      plainText: markdown,
+      plainText: testMarkdownText,
+      (editorState) {
+        final children = editorState.document.root.children;
+        expect(children.length, 6);
+        for (int i = 1; i <= children.length; i++) {
+          final text = children[i - 1].delta!.toPlainText();
+          expect(text, 'I\'m h$i');
+        }
+      },
+    );
+  });
+
+  testWidgets('paste markdowns as plain', (tester) async {
+    await tester.pasteContent(
+      plainText: testMarkdownText,
       pasteAsPlain: true,
       (editorState) {
         final children = editorState.document.root.children;
         expect(children.length, 6);
-        for (var i = 0; i < children.length; i++) {
-          final text = children[i].delta!.toPlainText();
-          final expectText = '${'#' * (i + 1)} I\'m h${i + 1}';
+        for (int i = 1; i <= children.length; i++) {
+          final text = children[i - 1].delta!.toPlainText();
+          final expectText = '${'#' * i} I\'m h$i';
           expect(text, expectText);
         }
       },

--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_find_menu_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_find_menu_test.dart
@@ -37,12 +37,12 @@ void main() {
 
       // set clipboard data
       final data = [
-        "123456\n",
-        ...List.generate(100, (_) => "${generateRandomString(50)}\n"),
-        "1234567\n",
-        ...List.generate(100, (_) => "${generateRandomString(50)}\n"),
-        "12345678\n",
-        ...List.generate(100, (_) => "${generateRandomString(50)}\n"),
+        "123456\n\n",
+        ...List.generate(100, (_) => "${generateRandomString(50)}\n\n"),
+        "1234567\n\n",
+        ...List.generate(100, (_) => "${generateRandomString(50)}\n\n"),
+        "12345678\n\n",
+        ...List.generate(100, (_) => "${generateRandomString(50)}\n\n"),
       ].join();
       await getIt<ClipboardService>().setData(
         ClipboardServiceData(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/context_menu/custom_context_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/context_menu/custom_context_menu.dart
@@ -14,6 +14,11 @@ final List<List<ContextMenuItem>> customContextMenuItems = [
       onPressed: (editorState) => customPasteCommand.execute(editorState),
     ),
     ContextMenuItem(
+      getName: LocaleKeys.document_plugins_contextMenu_pasteAsPlainText.tr,
+      onPressed: (editorState) =>
+          customPastePlainTextCommand.execute(editorState),
+    ),
+    ContextMenuItem(
       getName: LocaleKeys.document_plugins_contextMenu_cut.tr,
       onPressed: (editorState) => customCutCommand.execute(editorState),
     ),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
@@ -228,8 +228,10 @@ Future<void> doPlainPaste(EditorState editorState) async {
   final plainText = data.plainText;
   if (plainText != null && plainText.isNotEmpty) {
     await editorState.pastePlainText(plainText);
-    return Log.info('Pasted plain text');
+    Log.info('Pasted plain text');
+    return;
   }
 
-  return Log.info('unable to parse the clipboard content');
+  Log.info('unable to parse the clipboard content');
+  return;
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/custom_paste_command.dart
@@ -29,6 +29,14 @@ final CommandShortcutEvent customPasteCommand = CommandShortcutEvent(
   handler: _pasteCommandHandler,
 );
 
+final CommandShortcutEvent customPastePlainTextCommand = CommandShortcutEvent(
+  key: 'paste the plain content',
+  getDescription: () => AppFlowyEditorL10n.current.cmdPasteContent,
+  command: 'ctrl+shift+v',
+  macOSCommand: 'cmd+shift+v',
+  handler: _pastePlainCommandHandler,
+);
+
 CommandShortcutEventHandler _pasteCommandHandler = (editorState) {
   final selection = editorState.selection;
   if (selection == null) {
@@ -36,6 +44,22 @@ CommandShortcutEventHandler _pasteCommandHandler = (editorState) {
   }
 
   doPaste(editorState).then((_) {
+    final context = editorState.document.root.context;
+    if (context != null && context.mounted) {
+      context.read<ClipboardState>().didPaste();
+    }
+  });
+
+  return KeyEventResult.handled;
+};
+
+CommandShortcutEventHandler _pastePlainCommandHandler = (editorState) {
+  final selection = editorState.selection;
+  if (selection == null) {
+    return KeyEventResult.ignored;
+  }
+
+  doPlainPaste(editorState).then((_) {
     final context = editorState.document.root.context;
     if (context != null && context.mounted) {
       context.read<ClipboardState>().didPaste();
@@ -119,7 +143,7 @@ Future<void> doPaste(EditorState editorState) async {
   }
 
   if (plainText != null && plainText.isNotEmpty) {
-    await editorState.pastePlainText(plainText);
+    await editorState.pasteText(plainText);
     return Log.info('Pasted plain text');
   }
 
@@ -189,4 +213,23 @@ Future<bool> _pasteAsLinkPreview(
   await editorState.apply(linkPreviewTransaction);
 
   return true;
+}
+
+Future<void> doPlainPaste(EditorState editorState) async {
+  final selection = editorState.selection;
+  if (selection == null) {
+    return;
+  }
+
+  EditorNotification.paste().post();
+
+  // dispatch the paste event
+  final data = await getIt<ClipboardService>().getData();
+  final plainText = data.plainText;
+  if (plainText != null && plainText.isNotEmpty) {
+    await editorState.pastePlainText(plainText);
+    return Log.info('Pasted plain text');
+  }
+
+  return Log.info('unable to parse the clipboard content');
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/shortcuts/command_shortcuts.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/shortcuts/command_shortcuts.dart
@@ -30,6 +30,7 @@ List<CommandShortcutEvent> commandShortcutEvents = [
 
   customCopyCommand,
   customPasteCommand,
+  customPastePlainTextCommand,
   customCutCommand,
   customUndoCommand,
   customRedoCommand,
@@ -43,6 +44,7 @@ List<CommandShortcutEvent> commandShortcutEvents = [
         copyCommand,
         cutCommand,
         pasteCommand,
+        pasteTextWithoutFormattingCommand,
         toggleTodoListCommand,
         undoCommand,
         redoCommand,

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -1841,7 +1841,8 @@
       "contextMenu": {
         "copy": "Copy",
         "cut": "Cut",
-        "paste": "Paste"
+        "paste": "Paste",
+        "pasteAsPlainText": "Paste as plain text"
       },
       "action": "Actions",
       "database": {


### PR DESCRIPTION
To fix #7023 

### Feature Preview

- add `Paste as plain text` item to ContextMenu
- pasting the original Markdown data will automatically convert it


#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
