### PR TITLE
fix: docker ci

### DIFF
--- a/frontend/scripts/docker-buildfiles/Dockerfile
+++ b/frontend/scripts/docker-buildfiles/Dockerfile
@@ -39,7 +39,8 @@ RUN dart pub global activate protoc_plugin 21.1.2
 # Install build dependencies for AppFlowy using pacman
 RUN sudo pacman -S --needed --noconfirm jemalloc git libkeybinder3 sqlite clang rsync libnotify rocksdb zstd mpv
 RUN sudo ln -s /usr/bin/sha1sum /usr/bin/shasum
-RUN source ~/.cargo/env && cargo install cargo-make cargo-binstall --locked
+RUN source ~/.cargo/env && cargo install cargo-make --version 0.37.18 --locked
+RUN source ~/.cargo/env && cargo install cargo-binstall --version 1.10.17 --locked
 RUN source ~/.cargo/env && cargo binstall duckscript_cli --locked -y
 
 # Build AppFlowy


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

Specify the `cargo-binstall` version as 1.10.17.

```log
#30 94.55 error: failed to compile `cargo-binstall v1.10.18`, intermediate artifacts can be found at `/tmp/cargo-installOmw6K4`.
#30 94.55 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
#30 94.55 
#30 94.55 Caused by:
#30 94.55   rustc 1.80.1 is not supported by the following package:
#30 94.55     home@0.5.11 requires rustc 1.81
#30 94.55      Summary Successfully installed cargo-make! Failed to install cargo-binstall (see error(s) above).
#30 94.55 error: some crates failed to install
#30 ERROR: process "/bin/sh -c source ~/.cargo/env && cargo install cargo-make cargo-binstall --locked" did not complete successfully: exit code: 101
------
 > [builder 18/23] RUN source ~/.cargo/env && cargo install cargo-make cargo-binstall --locked:
94.48   Downloaded anstyle v1.0.10
94.48   Downloaded anstream v0.6.18
94.55 error: failed to compile `cargo-binstall v1.10.18`, intermediate artifacts can be found at `/tmp/cargo-installOmw6K4`.
94.55 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
94.55 
94.55 Caused by:
94.55   rustc 1.80.1 is not supported by the following package:
94.55     home@0.5.11 requires rustc 1.81
94.55      Summary Successfully installed cargo-make! Failed to install cargo-binstall (see error(s) above).
94.55 error: some crates failed to install
```

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
