### PR TITLE
feat(flutter_desktop): save ai message to page improvements

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_select_sources_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_select_sources_cubit.dart
@@ -112,7 +112,7 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     selectedSourceIds = [...newSelectedSourceIds];
   }
 
-  void refreshSources(List<ViewPB> spaceViews) async {
+  void refreshSources(List<ViewPB> spaceViews, ViewPB? currentSpace) async {
     filter = "";
 
     final newSources = await Future.wait(
@@ -120,6 +120,11 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     );
     for (final source in newSources) {
       _restrictSelectionIfNecessary(source.children);
+    }
+    if (currentSpace != null) {
+      newSources
+          .firstWhereOrNull((e) => e.view.id == currentSpace.id)
+          ?.toggleIsExpanded();
     }
 
     final selected = newSources

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_select_sources_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_select_sources_cubit.dart
@@ -101,15 +101,21 @@ class ChatSource {
 }
 
 class ChatSettingsCubit extends Cubit<ChatSettingsState> {
-  ChatSettingsCubit() : super(ChatSettingsState.initial());
+  ChatSettingsCubit({
+    this.hideDisabled = false,
+  }) : super(ChatSettingsState.initial());
 
-  List<String> selectedSourceIds = [];
-  List<ChatSource> sources = [];
-  List<ChatSource> selectedSources = [];
+  final bool hideDisabled;
+
+  final List<String> selectedSourceIds = [];
+  final List<ChatSource> sources = [];
+  final List<ChatSource> selectedSources = [];
   String filter = '';
 
   void updateSelectedSources(List<String> newSelectedSourceIds) {
-    selectedSourceIds = [...newSelectedSourceIds];
+    selectedSourceIds
+      ..clear
+      ..addAll(newSelectedSourceIds);
   }
 
   void refreshSources(List<ViewPB> spaceViews, ViewPB? currentSpace) async {
@@ -163,6 +169,9 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     if (childrenViews != null) {
       for (final childView in childrenViews) {
         if (childView.layout == ViewLayoutPB.Chat) {
+          continue;
+        }
+        if (childView.layout != ViewLayoutPB.Document && hideDisabled) {
           continue;
         }
         final childChatSource = await _recursiveBuild(childView, view);

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_bottom_sheet.dart
@@ -9,7 +9,6 @@ import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
 import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
-import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
@@ -69,9 +68,8 @@ class _PromptInputMobileSelectSourcesButtonState
               value: cubit,
             ),
           ],
-          child: BlocSelector<SpaceBloc, SpaceState, List<ViewPB>>(
-            selector: (state) => state.spaces,
-            builder: (context, spaces) {
+          child: BlocBuilder<SpaceBloc, SpaceState>(
+            builder: (context, state) {
               return BlocListener<ChatBloc, ChatState>(
                 listener: (context, state) {
                   cubit
@@ -97,7 +95,9 @@ class _PromptInputMobileSelectSourcesButtonState
                     ],
                   ),
                   onTap: () async {
-                    context.read<ChatSettingsCubit>().refreshSources(spaces);
+                    context
+                        .read<ChatSettingsCubit>()
+                        .refreshSources(state.spaces, state.currentSpace);
                     await showMobileBottomSheet<void>(
                       context,
                       backgroundColor: Theme.of(context).colorScheme.surface,

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
@@ -462,9 +462,10 @@ class ChatSourceTreeItemInner extends StatelessWidget {
                   FlowyIconButton(
                     tooltipText: LocaleKeys.chat_addToPageButton.tr(),
                     width: 24,
-                    icon: const FlowySvg(
+                    icon: FlowySvg(
                       FlowySvgs.ai_add_to_page_s,
-                      size: Size.square(16),
+                      size: const Size.square(16),
+                      color: Theme.of(context).hintColor,
                     ),
                     onPressed: () => onSelected?.call(chatSource),
                   ),
@@ -474,9 +475,10 @@ class ChatSourceTreeItemInner extends StatelessWidget {
                   FlowyIconButton(
                     tooltipText: LocaleKeys.chat_addToNewPage.tr(),
                     width: 24,
-                    icon: const FlowySvg(
+                    icon: FlowySvg(
                       FlowySvgs.add_less_padding_s,
-                      size: Size.square(16),
+                      size: const Size.square(16),
+                      color: Theme.of(context).hintColor,
                     ),
                     onPressed: () => onAdd?.call(chatSource),
                   ),

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
@@ -278,7 +278,9 @@ class ChatSourceTreeItem extends StatefulWidget {
     required this.isDescendentOfSpace,
     required this.isSelectedSection,
     required this.onSelected,
+    this.onAdd,
     required this.height,
+    this.showSaveButton = false,
     this.showCheckbox = true,
   });
 
@@ -292,6 +294,10 @@ class ChatSourceTreeItem extends StatefulWidget {
   final bool isSelectedSection;
 
   final void Function(ChatSource chatSource) onSelected;
+
+  final void Function(ChatSource chatSource)? onAdd;
+
+  final bool showSaveButton;
 
   final double height;
 
@@ -312,7 +318,9 @@ class _ChatSourceTreeItemState extends State<ChatSourceTreeItem> {
         isDescendentOfSpace: widget.isDescendentOfSpace,
         isSelectedSection: widget.isSelectedSection,
         showCheckbox: widget.showCheckbox,
+        showSaveButton: widget.showSaveButton,
         onSelected: widget.onSelected,
+        onAdd: widget.onAdd,
       ),
     );
 
@@ -364,6 +372,8 @@ class _ChatSourceTreeItemState extends State<ChatSourceTreeItem> {
                 onSelected: widget.onSelected,
                 height: widget.height,
                 showCheckbox: widget.showCheckbox,
+                showSaveButton: widget.showSaveButton,
+                onAdd: widget.onAdd,
               ),
             ),
           ],
@@ -381,7 +391,9 @@ class ChatSourceTreeItemInner extends StatelessWidget {
     required this.isDescendentOfSpace,
     required this.isSelectedSection,
     required this.showCheckbox,
+    required this.showSaveButton,
     this.onSelected,
+    this.onAdd,
   });
 
   final ChatSource chatSource;
@@ -389,57 +401,90 @@ class ChatSourceTreeItemInner extends StatelessWidget {
   final bool isDescendentOfSpace;
   final bool isSelectedSection;
   final bool showCheckbox;
+  final bool showSaveButton;
   final void Function(ChatSource)? onSelected;
+  final void Function(ChatSource)? onAdd;
 
   @override
   Widget build(BuildContext context) {
-    return FlowyHover(
-      cursor: isSelectedSection ? SystemMouseCursors.basic : null,
-      style: HoverStyle(
-        hoverColor: isSelectedSection
-            ? Colors.transparent
-            : AFThemeExtension.of(context).lightGreyHover,
-      ),
-      child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTap: () {
-          if (!isSelectedSection) {
-            onSelected?.call(chatSource);
-          }
-        },
-        child: Row(
-          children: [
-            const HSpace(4.0),
-            HSpace(max(20.0 * level - (isDescendentOfSpace ? 2 : 0), 0)),
-            // builds the >, ^ or · button
-            ToggleIsExpandedButton(
-              chatSource: chatSource,
-              isSelectedSection: isSelectedSection,
-            ),
-            const HSpace(2.0),
-            // checkbox
-            if (!chatSource.view.isSpace && showCheckbox) ...[
-              SourceSelectedStatusCheckbox(
-                chatSource: chatSource,
-              ),
-              const HSpace(4.0),
-            ],
-            // icon
-            MentionViewIcon(
-              view: chatSource.view,
-            ),
-            const HSpace(6.0),
-            // title
-            Expanded(
-              child: FlowyText(
-                chatSource.view.nameOrDefault,
-                overflow: TextOverflow.ellipsis,
-                fontSize: 14.0,
-                figmaLineHeight: 18.0,
-              ),
-            ),
-          ],
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () {
+        if (!isSelectedSection) {
+          onSelected?.call(chatSource);
+        }
+      },
+      child: FlowyHover(
+        cursor: isSelectedSection ? SystemMouseCursors.basic : null,
+        style: HoverStyle(
+          hoverColor: isSelectedSection
+              ? Colors.transparent
+              : AFThemeExtension.of(context).lightGreyHover,
         ),
+        builder: (context, onHover) {
+          final isSaveButtonVisible =
+              showSaveButton && !chatSource.view.isSpace;
+          final isAddButtonVisible = onAdd != null;
+          return Row(
+            children: [
+              const HSpace(4.0),
+              HSpace(max(20.0 * level - (isDescendentOfSpace ? 2 : 0), 0)),
+              // builds the >, ^ or · button
+              ToggleIsExpandedButton(
+                chatSource: chatSource,
+                isSelectedSection: isSelectedSection,
+              ),
+              const HSpace(2.0),
+              // checkbox
+              if (!chatSource.view.isSpace && showCheckbox) ...[
+                SourceSelectedStatusCheckbox(
+                  chatSource: chatSource,
+                ),
+                const HSpace(4.0),
+              ],
+              // icon
+              MentionViewIcon(
+                view: chatSource.view,
+              ),
+              const HSpace(6.0),
+              // title
+              Expanded(
+                child: FlowyText(
+                  chatSource.view.nameOrDefault,
+                  overflow: TextOverflow.ellipsis,
+                  fontSize: 14.0,
+                  figmaLineHeight: 18.0,
+                ),
+              ),
+              if (onHover && (isSaveButtonVisible || isAddButtonVisible)) ...[
+                const HSpace(4.0),
+                if (isSaveButtonVisible)
+                  FlowyIconButton(
+                    tooltipText: LocaleKeys.chat_addToPageButton.tr(),
+                    width: 24,
+                    icon: const FlowySvg(
+                      FlowySvgs.ai_add_to_page_s,
+                      size: Size.square(16),
+                    ),
+                    onPressed: () => onSelected?.call(chatSource),
+                  ),
+                if (isSaveButtonVisible && isAddButtonVisible)
+                  const HSpace(4.0),
+                if (isAddButtonVisible)
+                  FlowyIconButton(
+                    tooltipText: LocaleKeys.chat_addToNewPage.tr(),
+                    width: 24,
+                    icon: const FlowySvg(
+                      FlowySvgs.add_less_padding_s,
+                      size: Size.square(16),
+                    ),
+                    onPressed: () => onAdd?.call(chatSource),
+                  ),
+                const HSpace(4.0),
+              ],
+            ],
+          );
+        },
       ),
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_input/select_sources_menu.dart
@@ -74,9 +74,8 @@ class _PromptInputDesktopSelectSourcesButtonState
           value: cubit,
         ),
       ],
-      child: BlocSelector<SpaceBloc, SpaceState, List<ViewPB>>(
-        selector: (state) => state.spaces,
-        builder: (context, spaces) {
+      child: BlocBuilder<SpaceBloc, SpaceState>(
+        builder: (context, state) {
           return BlocListener<ChatBloc, ChatState>(
             listener: (context, state) {
               cubit
@@ -90,11 +89,15 @@ class _PromptInputDesktopSelectSourcesButtonState
               margin: EdgeInsets.zero,
               controller: popoverController,
               onOpen: () {
-                context.read<ChatSettingsCubit>().refreshSources(spaces);
+                context
+                    .read<ChatSettingsCubit>()
+                    .refreshSources(state.spaces, state.currentSpace);
               },
               onClose: () {
                 widget.onUpdateSelectedSources(cubit.selectedSourceIds);
-                context.read<ChatSettingsCubit>().refreshSources(spaces);
+                context
+                    .read<ChatSettingsCubit>()
+                    .refreshSources(state.spaces, state.currentSpace);
               },
               popupBuilder: (_) {
                 return BlocProvider.value(

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -448,7 +448,6 @@ class _SaveToPagePopoverContent extends StatelessWidget {
                 children: _buildVisibleSources(context, state).toList(),
               ),
             ),
-            // _addToNewPageButton(context),
           ],
         );
       },

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -245,7 +245,9 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
             constraints: const BoxConstraints.tightFor(width: 300, height: 400),
             onClose: () {
               if (spaceView != null) {
-                context.read<ChatSettingsCubit>().refreshSources([spaceView]);
+                context
+                    .read<ChatSettingsCubit>()
+                    .refreshSources([spaceView], spaceView);
               }
               widget.onOverrideVisibility?.call(false);
             },
@@ -279,7 +281,9 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
           } else {
             widget.onOverrideVisibility?.call(true);
             if (spaceView != null) {
-              context.read<ChatSettingsCubit>().refreshSources([spaceView]);
+              context
+                  .read<ChatSettingsCubit>()
+                  .refreshSources([spaceView], spaceView);
             }
             popoverController.show();
           }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -230,7 +230,7 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
           )..add(const SpaceEvent.initial(openFirstPage: false)),
         ),
         BlocProvider(
-          create: (context) => ChatSettingsCubit(),
+          create: (context) => ChatSettingsCubit(hideDisabled: true),
         ),
       ],
       child: BlocSelector<SpaceBloc, SpaceState, ViewPB?>(
@@ -448,8 +448,7 @@ class _SaveToPagePopoverContent extends StatelessWidget {
                 children: _buildVisibleSources(context, state).toList(),
               ),
             ),
-            _buildDivider(),
-            _addToNewPageButton(context),
+            // _addToNewPageButton(context),
           ],
         );
       },

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -296,8 +296,8 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
     return BlocProvider.value(
       value: context.read<ChatSettingsCubit>(),
       child: _SaveToPagePopoverContent(
-        onAddToNewPage: () {
-          addMessageToNewPage(context);
+        onAddToNewPage: (parentViewId) {
+          addMessageToNewPage(context, parentViewId);
           popoverController.close();
         },
         onAddToExistingPage: (documentId) async {
@@ -328,14 +328,14 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
     return view;
   }
 
-  void addMessageToNewPage(BuildContext context) async {
+  void addMessageToNewPage(BuildContext context, String parentViewId) async {
     final chatView = await ViewBackendService.getView(
       context.read<ChatAIMessageBloc>().chatId,
     ).toNullable();
     if (chatView != null) {
       final newView = await ChatEditDocumentService.saveMessagesToNewPage(
         chatView.nameOrDefault,
-        chatView.parentViewId,
+        parentViewId,
         [widget.textMessage],
       );
 
@@ -410,7 +410,7 @@ class _SaveToPagePopoverContent extends StatelessWidget {
     required this.onAddToExistingPage,
   });
 
-  final void Function() onAddToNewPage;
+  final void Function(String) onAddToNewPage;
   final void Function(String) onAddToExistingPage;
 
   @override
@@ -480,35 +480,19 @@ class _SaveToPagePopoverContent extends StatelessWidget {
             isDescendentOfSpace: e.view.isSpace,
             isSelectedSection: false,
             showCheckbox: false,
+            showSaveButton: true,
             onSelected: (source) {
-              if (!source.view.isSpace) {
+              if (source.view.isSpace) {
+                onAddToNewPage(source.view.id);
+              } else {
                 onAddToExistingPage(source.view.id);
               }
+            },
+            onAdd: (source) {
+              onAddToNewPage(source.view.id);
             },
             height: 30.0,
           ),
         );
-  }
-
-  Widget _addToNewPageButton(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: SizedBox(
-        height: 30,
-        child: FlowyButton(
-          iconPadding: 8,
-          onTap: onAddToNewPage,
-          text: FlowyText(
-            LocaleKeys.chat_addToNewPage.tr(),
-            figmaLineHeight: 20,
-          ),
-          leftIcon: FlowySvg(
-            FlowySvgs.add_m,
-            size: const Size.square(16),
-            color: Theme.of(context).hintColor,
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -216,9 +216,9 @@
     "sourcesLimitReached": "You can only select up to 3 top-level documents and its children",
     "sourceUnsupported": "We don't support chatting with databases at this time",
     "regenerate": "Try again",
-    "addToPageButton": "Add to page",
+    "addToPageButton": "Add message to page",
     "addToPageTitle": "Add message to...",
-    "addToNewPage": "Add to a new page",
+    "addToNewPage": "Create new page",
     "addToNewPageName": "Messages extracted from \"{}\"",
     "addToNewPageSuccessToast": "Message added to",
     "openPagePreviewFailedToast": "Failed to open page"


### PR DESCRIPTION
[chore: expand current space in select sources or when saving to a page](https://github.com/AppFlowy-IO/AppFlowy/commit/3bccd592f23ea37d6802851e2b179f2eac233515)

[chore: hide non-document views while saving to page](https://github.com/AppFlowy-IO/AppFlowy/commit/4ed830c78395b09b7810b9ab3ef4f15aa3386984)

[chore: add buttons when saving to page](https://github.com/AppFlowy-IO/AppFlowy/commit/0f1e6c1ca600e2ff6047c35b741a2ea623d8f0af)

![Screenshot 2025-01-03 at 1 22 50 PM](https://github.com/user-attachments/assets/41d25795-f97d-4da5-b9f2-a1cb9f2efd84)


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
