### PR TITLE
fix: retry count should be clear if the value exceeds max retries

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/custom_image_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/custom_image_block_component.dart
@@ -255,14 +255,17 @@ class CustomImageBlockComponentState extends State<CustomImageBlockComponent>
               final url = node.attributes[CustomImageBlockKeys.url];
               return Stack(
                 children: [
-                  BlockSelectionContainer(
-                    node: node,
-                    delegate: this,
-                    listenable: editorState.selectionNotifier,
-                    cursorColor: editorState.editorStyle.cursorColor,
-                    selectionColor: editorState.editorStyle.selectionColor,
-                    child: child!,
-                  ),
+                  editorState.editable
+                      ? BlockSelectionContainer(
+                          node: node,
+                          delegate: this,
+                          listenable: editorState.selectionNotifier,
+                          cursorColor: editorState.editorStyle.cursorColor,
+                          selectionColor:
+                              editorState.editorStyle.selectionColor,
+                          child: child!,
+                        )
+                      : child!,
                   if (value && url.isNotEmpty == true)
                     widget.menuBuilder!(widget.node, this, imageStateNotifier),
                 ],

--- a/frontend/appflowy_flutter/lib/shared/appflowy_network_image.dart
+++ b/frontend/appflowy_flutter/lib/shared/appflowy_network_image.dart
@@ -249,12 +249,13 @@ class FlowyNetworkRetryCounter with ChangeNotifier {
   void clear({
     required String tag,
     required String url,
-    required int maxRetries,
+    int? maxRetries,
   }) {
     _values.remove(tag);
 
     final retryCount = _values[url];
-    if (retryCount != null && retryCount >= maxRetries) {
+    if (maxRetries == null ||
+        (retryCount != null && retryCount >= maxRetries)) {
       _values.remove(url);
     }
   }

--- a/frontend/appflowy_flutter/test/unit_test/image/appflowy_network_image_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/image/appflowy_network_image_test.dart
@@ -1,0 +1,35 @@
+import 'package:appflowy/shared/appflowy_network_image.dart';
+import 'package:appflowy_backend/log.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppFlowy Network Image:', () {
+    setUpAll(() {
+      Log.shared.disableLog = true;
+    });
+
+    tearDownAll(() {
+      Log.shared.disableLog = false;
+    });
+
+    test(
+      'retry count should be clear if the value exceeds max retries',
+      () async {
+        const maxRetries = 5;
+        const fakeUrl = 'https://plus.unsplash.com/premium_photo-1731948132439';
+        final retryCounter = FlowyNetworkRetryCounter();
+        final tag = retryCounter.add(fakeUrl);
+        for (var i = 0; i < maxRetries; i++) {
+          retryCounter.increment(fakeUrl);
+          expect(retryCounter.getRetryCount(fakeUrl), i + 1);
+        }
+        retryCounter.clear(
+          tag: tag,
+          url: fakeUrl,
+          maxRetries: maxRetries,
+        );
+        expect(retryCounter.getRetryCount(fakeUrl), 0);
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

When the maximum retry count exceeds the `maxRetries`, it should be reset to avoid affecting the next round of image loading, such as when the page is reopened.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
