### PR TITLE
fix: search results were filtered accidentally

### DIFF
--- a/frontend/rust-lib/flowy-search/src/document/handler.rs
+++ b/frontend/rust-lib/flowy-search/src/document/handler.rs
@@ -57,11 +57,11 @@ impl SearchHandler for DocumentSearchHandler {
 
     // Grab all views from folder cache
     // Notice that `get_all_view_pb` returns Views that don't include trashed and private views
-    let mut views = self.folder_manager.get_all_views_pb().await?.into_iter();
+    let views = self.folder_manager.get_all_views_pb().await?;
     let mut search_results: Vec<SearchResultPB> = vec![];
 
     for result in results {
-      if let Some(view) = views.find(|v| v.id == result.object_id) {
+      if let Some(view) = views.iter().find(|v| v.id == result.object_id) {
         // If there is no View for the result, we don't add it to the results
         // If possible we will extract the icon to display for the result
         let icon: Option<ResultIconPB> = match view.icon.clone() {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

the iterator was consumed by `find()`, it can't be reused in next loop.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
