### PR TITLE
chore: remove iconContent from IconsData

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/cloud/sidebar/sidebar_icon_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/cloud/sidebar/sidebar_icon_test.dart
@@ -45,7 +45,7 @@ void main() {
     );
 
     final icons = find.byWidgetPredicate(
-      (w) => w is FlowySvg && w.svgString == firstIcon.iconContent,
+      (w) => w is FlowySvg && w.svgString == firstIcon.svgString,
     );
     expect(icons, findsOneWidget);
     await tester.tapIcon(EmojiIconData.icon(firstIcon));
@@ -54,7 +54,7 @@ void main() {
     final spaceIcon = find.descendant(
       of: spaceHeader,
       matching: find.byWidgetPredicate(
-        (w) => w is FlowySvg && w.svgString == firstIcon.iconContent,
+        (w) => w is FlowySvg && w.svgString == firstIcon.svgString,
       ),
     );
     expect(spaceIcon, findsOneWidget);

--- a/frontend/appflowy_flutter/integration_test/desktop/command_palette/folder_search_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/command_palette/folder_search_test.dart
@@ -103,8 +103,8 @@ void main() {
       final iconData = IconsData.fromJson(jsonDecode(emojiIconData.emoji));
 
       /// icon displayed correctly
-      expect(firstSvg.svgString, iconData.iconContent);
-      expect(lastSvg.svgString, iconData.iconContent);
+      expect(firstSvg.svgString, iconData.svgString);
+      expect(lastSvg.svgString, iconData.svgString);
 
       testWidgets('select the content in document and search', (tester) async {
         const firstDocument = ''; // empty document

--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_callout_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_callout_test.dart
@@ -59,8 +59,8 @@ void main() {
         .evaluate()
         .first
         .widget as IconWidget;
-    final iconWidgetData = iconWidget.data;
-    expect(iconWidgetData.iconContent, iconData.iconContent);
+    final iconWidgetData = iconWidget.iconsData;
+    expect(iconWidgetData.svgString, iconData.svgString);
     expect(iconWidgetData.iconName, iconData.iconName);
     expect(iconWidgetData.groupName, iconData.groupName);
   });

--- a/frontend/appflowy_flutter/integration_test/shared/common_operations.dart
+++ b/frontend/appflowy_flutter/integration_test/shared/common_operations.dart
@@ -928,7 +928,6 @@ extension CommonOperations on WidgetTester {
     return EmojiIconData.icon(
       IconsData(
         firstGroup.name,
-        firstIcon.content,
         firstIcon.name,
         builtInSpaceColors.first,
       ),

--- a/frontend/appflowy_flutter/integration_test/shared/emoji.dart
+++ b/frontend/appflowy_flutter/integration_test/shared/emoji.dart
@@ -35,7 +35,7 @@ extension EmojiTestExtension on WidgetTester {
     final selectedSvg = find.descendant(
       of: find.byType(FlowyIconPicker),
       matching: find.byWidgetPredicate(
-        (w) => w is FlowySvg && w.svgString == iconsData.iconContent,
+        (w) => w is FlowySvg && w.svgString == iconsData.svgString,
       ),
     );
 

--- a/frontend/appflowy_flutter/integration_test/shared/expectation.dart
+++ b/frontend/appflowy_flutter/integration_test/shared/expectation.dart
@@ -245,7 +245,7 @@ extension Expectation on WidgetTester {
       final icon = find.descendant(
         of: pageName,
         matching: find.byWidgetPredicate(
-          (w) => w is FlowySvg && w.svgString == iconsData.iconContent,
+          (w) => w is FlowySvg && w.svgString == iconsData.svgString,
         ),
       );
       expect(icon, findsOneWidget);
@@ -269,7 +269,7 @@ extension Expectation on WidgetTester {
       final icon = find.descendant(
         of: find.byType(ViewTitleBar),
         matching: find.byWidgetPredicate(
-          (w) => w is FlowySvg && w.svgString == iconsData.iconContent,
+          (w) => w is FlowySvg && w.svgString == iconsData.svgString,
         ),
       );
       expect(icon, findsOneWidget);

--- a/frontend/appflowy_flutter/lib/plugins/base/icon/icon_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/base/icon/icon_widget.dart
@@ -1,27 +1,32 @@
+import 'package:appflowy/plugins/base/emoji/emoji_text.dart';
 import 'package:appflowy/shared/icon_emoji_picker/icon_picker.dart';
 import 'package:flutter/material.dart';
 
 import '../../../generated/flowy_svgs.g.dart';
 
 class IconWidget extends StatelessWidget {
-  const IconWidget({
-    super.key,
-    required this.size,
-    required this.data,
-  });
+  const IconWidget({super.key, required this.size, required this.iconsData});
 
-  final IconsData data;
+  final IconsData iconsData;
   final double size;
 
   @override
   Widget build(BuildContext context) {
-    final colorValue = int.tryParse(data.color ?? '');
+    final colorValue = int.tryParse(iconsData.color ?? '');
     Color? color;
     if (colorValue != null) {
       color = Color(colorValue);
     }
+    final svgString = iconsData.svgString;
+    if (svgString == null) {
+      return EmojiText(
+        emoji: '❓',
+        fontSize: size,
+        textAlign: TextAlign.center,
+      );
+    }
     return FlowySvg.string(
-      data.iconContent,
+      svgString,
       size: Size.square(size),
       color: color,
     );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart
@@ -92,7 +92,7 @@ class RawEmojiIconWidget extends StatelessWidget {
           /// size of the icons
           final iconSize = Platform.isMacOS ? emojiSize * 0.9 : emojiSize;
           return IconWidget(
-            data: iconData,
+            iconsData: iconData,
             size: iconSize,
           );
         default:

--- a/frontend/appflowy_flutter/lib/shared/icon_emoji_picker/icon_picker.dart
+++ b/frontend/appflowy_flutter/lib/shared/icon_emoji_picker/icon_picker.dart
@@ -173,7 +173,6 @@ class _FlowyIconPickerState extends State<FlowyIconPicker> {
               widget.onSelectedIcon(
                 IconsData(
                   value.$1.name,
-                  value.$2.content,
                   value.$2.name,
                   color,
                 ).toResult(isRandom: true),
@@ -232,16 +231,14 @@ class _FlowyIconPickerState extends State<FlowyIconPicker> {
 }
 
 class IconsData {
-  IconsData(this.groupName, this.iconContent, this.iconName, this.color);
+  IconsData(this.groupName, this.iconName, this.color);
 
   final String groupName;
-  final String iconContent;
   final String iconName;
   final String? color;
 
   String get iconString => jsonEncode({
         'groupName': groupName,
-        'iconContent': iconContent,
         'iconName': iconName,
         if (color != null) 'color': color,
       });
@@ -251,11 +248,16 @@ class IconsData {
   static IconsData fromJson(dynamic json) {
     return IconsData(
       json['groupName'],
-      json['iconContent'],
       json['iconName'],
       json['color'],
     );
   }
+
+  String? get svgString => kIconGroups
+      ?.firstWhereOrNull((group) => group.name == groupName)
+      ?.icons
+      .firstWhereOrNull((icon) => icon.name == iconName)
+      ?.content;
 }
 
 class IconPicker extends StatefulWidget {
@@ -317,7 +319,6 @@ class _IconPickerState extends State<IconPicker> {
                           widget.onSelectedIcon(
                             IconsData(
                               groupName,
-                              icon.content,
                               icon.name,
                               color,
                             ),
@@ -336,7 +337,6 @@ class _IconPickerState extends State<IconPicker> {
                           widget.onSelectedIcon(
                             IconsData(
                               groupName,
-                              icon.content,
                               icon.name,
                               null,
                             ),


### PR DESCRIPTION

Remove `iconContent` from `IconsData` to avoid unnecessary data cost

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
