### PR TITLE
chore: cancel button not visible in [Reset to Default] for shortcuts(#7171)

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_shortcuts_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_shortcuts_view.dart
@@ -8,6 +8,7 @@ import 'package:appflowy/plugins/document/presentation/editor_plugins/copy_and_p
 import 'package:appflowy/plugins/document/presentation/editor_plugins/toggle/toggle_block_shortcuts.dart';
 import 'package:appflowy/workspace/application/settings/shortcuts/settings_shortcuts_cubit.dart';
 import 'package:appflowy/workspace/application/settings/shortcuts/settings_shortcuts_service.dart';
+import 'package:appflowy/workspace/presentation/home/menu/sidebar/space/shared_widget.dart';
 import 'package:appflowy/workspace/presentation/settings/shared/settings_alert_dialog.dart';
 import 'package:appflowy/workspace/presentation/settings/shared/settings_body.dart';
 import 'package:appflowy/workspace/presentation/settings/widgets/emoji_picker/emoji_shortcut_event.dart';
@@ -55,21 +56,24 @@ class _SettingsShortcutsViewState extends State<SettingsShortcutsView> {
                 ),
                 const HSpace(10),
                 _ResetButton(
-                  onReset: () => SettingsAlertDialog(
-                    isDangerous: true,
-                    title: LocaleKeys.settings_shortcutsPage_resetDialog_title
-                        .tr(),
-                    subtitle: LocaleKeys
-                        .settings_shortcutsPage_resetDialog_description
-                        .tr(),
-                    confirmLabel: LocaleKeys
-                        .settings_shortcutsPage_resetDialog_buttonLabel
-                        .tr(),
-                    confirm: () {
-                      Navigator.of(context).pop();
-                      context.read<ShortcutsCubit>().resetToDefault();
-                    },
-                  ).show(context),
+                  onReset: () {
+                    showConfirmDialog(
+                      context: context,
+                      title: LocaleKeys.settings_shortcutsPage_resetDialog_title
+                          .tr(),
+                      description: LocaleKeys
+                          .settings_shortcutsPage_resetDialog_description
+                          .tr(),
+                      confirmLabel: LocaleKeys
+                          .settings_shortcutsPage_resetDialog_buttonLabel
+                          .tr(),
+                      onConfirm: () {
+                        context.read<ShortcutsCubit>().resetToDefault();
+                        Navigator.of(context).pop();
+                      },
+                      style: ConfirmPopupStyle.cancelAndOk,
+                    );
+                  },
                 ),
               ],
             ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_alert_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_alert_dialog.dart
@@ -1,12 +1,10 @@
-import 'package:flutter/material.dart';
-
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/size.dart';
-import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/widget/dialog/styled_dialogs.dart';
+import 'package:flutter/material.dart';
 
 class SettingsAlertDialog extends StatefulWidget {
   const SettingsAlertDialog({
@@ -201,18 +199,16 @@ class _Actions extends StatelessWidget {
       children: [
         if (!hideCancelButton) ...[
           SizedBox(
-            height: 24,
-            child: FlowyTextButton(
-              LocaleKeys.button_cancel.tr(),
-              padding: const EdgeInsets.symmetric(
+            height: 48,
+            child: PrimaryRoundedButton(
+              text: LocaleKeys.button_cancel.tr(),
+              margin: const EdgeInsets.symmetric(
                 horizontal: 24,
                 vertical: 12,
               ),
-              fontColor: AFThemeExtension.of(context).textColor,
-              fillColor: Colors.transparent,
-              hoverColor: Colors.transparent,
-              radius: Corners.s12Border,
-              onPressed: () {
+              fontWeight: FontWeight.w600,
+              radius: 12.0,
+              onTap: () {
                 cancel?.call();
                 Navigator.of(context).pop();
               },


### PR DESCRIPTION
Fix the issue: #7171

Before the fix: 

![image](https://github.com/user-attachments/assets/b0d6395c-c4dc-4b4c-904c-280229eab9ce)

After the fix:

dark | light
---|---
![image](https://github.com/user-attachments/assets/56ab39b8-8cc8-459a-8a81-d86c75997c61) | ![image](https://github.com/user-attachments/assets/6cfd856a-3bd5-4595-aaa0-c98a9e2a85b8)


### Feature Preview

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
