### PR TITLE
fix: uri paste from Safari becoming blank pastes

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/clipboard_service.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/clipboard_service.dart
@@ -129,9 +129,14 @@ class ClipboardService {
     }
 
     final plainText = await reader.readValue(Formats.plainText);
-    final html = await reader.readValue(Formats.htmlText);
+    var html = await reader.readValue(Formats.htmlText);
     final inAppJson = await reader.readValue(inAppJsonFormat);
     final tableJson = await reader.readValue(tableJsonFormat);
+    final uri = await reader.readValue(Formats.uri);
+    if (uri != null && html == null) {
+      html = '<span><a href="${uri.uri.toString()}">${uri.name ?? uri.uri.toString()}</a></span>';
+      Log.info('link converted to html: $html');
+    }
     (String, Uint8List?)? image;
     if (reader.canProvide(Formats.png)) {
       image = ('png', await reader.readFile(Formats.png));


### PR DESCRIPTION
Safari's (or GitHub) Share button -> Copy copies a rich text link that results in noop in the Appflowy when pasting. Workaround: tap in the address bar to copy and paste

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
