### PR TITLE
fix(flutter_desktop): selection going missing while scrolling

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/chat_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/chat_page.dart
@@ -121,21 +121,24 @@ class _ChatContentPage extends StatelessWidget {
                   child: Align(
                     alignment: Alignment.topCenter,
                     child: _wrapConstraints(
-                      ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context)
-                            .copyWith(scrollbars: false),
-                        child: Chat(
-                          chatController:
-                              context.read<ChatBloc>().chatController,
-                          user: User(id: userProfile.id.toString()),
-                          darkTheme: ChatTheme.fromThemeData(Theme.of(context)),
-                          theme: ChatTheme.fromThemeData(Theme.of(context)),
-                          builders: Builders(
-                            inputBuilder: (_) => const SizedBox.shrink(),
-                            textMessageBuilder: _buildTextMessage,
-                            chatMessageBuilder: _buildChatMessage,
-                            scrollToBottomBuilder: _buildScrollToBottom,
-                            chatAnimatedListBuilder: _buildChatAnimatedList,
+                      SelectionArea(
+                        child: ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context)
+                              .copyWith(scrollbars: false),
+                          child: Chat(
+                            chatController:
+                                context.read<ChatBloc>().chatController,
+                            user: User(id: userProfile.id.toString()),
+                            darkTheme:
+                                ChatTheme.fromThemeData(Theme.of(context)),
+                            theme: ChatTheme.fromThemeData(Theme.of(context)),
+                            builders: Builders(
+                              inputBuilder: (_) => const SizedBox.shrink(),
+                              textMessageBuilder: _buildTextMessage,
+                              chatMessageBuilder: _buildChatMessage,
+                              scrollToBottomBuilder: _buildScrollToBottom,
+                              chatAnimatedListBuilder: _buildChatAnimatedList,
+                            ),
                           ),
                         ),
                       ),

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/user_text_message.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/user_text_message.dart
@@ -83,7 +83,6 @@ class TextMessageText extends StatelessWidget {
       text,
       lineHeight: 1.4,
       maxLines: null,
-      selectable: true,
       color: AFThemeExtension.of(context).textColor,
     );
   }

--- a/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra_ui/lib/style_widget/text.dart
@@ -15,7 +15,6 @@ class FlowyText extends StatelessWidget {
   final TextDecoration? decoration;
   final Color? decorationColor;
   final double? decorationThickness;
-  final bool selectable;
   final String? fontFamily;
   final List<String>? fallbackFontFamily;
   final bool withTooltip;
@@ -41,7 +40,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.fontFamily,
     this.fallbackFontFamily,
     // // https://api.flutter.dev/flutter/painting/TextStyle/height.html
@@ -63,7 +61,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.fontFamily,
     this.fallbackFontFamily,
     this.lineHeight,
@@ -86,7 +83,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.fontFamily,
     this.fallbackFontFamily,
     this.lineHeight,
@@ -108,7 +104,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.fontFamily,
     this.fallbackFontFamily,
     this.lineHeight,
@@ -130,7 +125,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.fontFamily,
     this.fallbackFontFamily,
     this.lineHeight,
@@ -153,7 +147,6 @@ class FlowyText extends StatelessWidget {
     this.maxLines = 1,
     this.decoration,
     this.decorationColor,
-    this.selectable = false,
     this.lineHeight,
     this.withTooltip = false,
     this.strutStyle = const StrutStyle(forceStrutHeight: true),
@@ -211,32 +204,21 @@ class FlowyText extends StatelessWidget {
               : null,
         );
 
-    if (selectable) {
-      child = IntrinsicHeight(
-        child: SelectableText(
-          text,
-          maxLines: maxLines,
-          textAlign: textAlign,
-          style: textStyle,
-        ),
-      );
-    } else {
-      child = Text(
-        text,
-        maxLines: maxLines,
-        textAlign: textAlign,
-        overflow: overflow ?? TextOverflow.clip,
-        style: textStyle,
-        strutStyle: !isEmoji || (isEmoji && optimizeEmojiAlign)
-            ? StrutStyle.fromTextStyle(
-                textStyle,
-                forceStrutHeight: true,
-                leadingDistribution: TextLeadingDistribution.even,
-                height: lineHeight,
-              )
-            : null,
-      );
-    }
+    child = Text(
+      text,
+      maxLines: maxLines,
+      textAlign: textAlign,
+      overflow: overflow ?? TextOverflow.clip,
+      style: textStyle,
+      strutStyle: !isEmoji || (isEmoji && optimizeEmojiAlign)
+          ? StrutStyle.fromTextStyle(
+              textStyle,
+              forceStrutHeight: true,
+              leadingDistribution: TextLeadingDistribution.even,
+              height: lineHeight,
+            )
+          : null,
+    );
 
     if (withTooltip) {
       child = FlowyTooltip(


### PR DESCRIPTION
NB: the selectable field of `FlowyText` has been removed. The recommendation from Flutter is that we use Text + SelectableArea instead of SelectableText.

~~Also, this PR would work better with a newer version of flutter as this method doesn't work with double tap to select a word and triple tap to select paragraph in the current flutter version~~ (EDIT: Updated to 3.27.4)

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
