### PR TITLE
fix: gallery not rendering in row page

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/layouts/image_browser_layout.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/layouts/image_browser_layout.dart
@@ -27,7 +27,7 @@ import 'package:provider/provider.dart';
 
 import '../image_render.dart';
 
-const _thumbnailItemSize = 100.0;
+const _thumbnailItemSize = 100.0, _imageHeight = 400.0;
 
 class ImageBrowserLayout extends ImageBlockMultiLayout {
   const ImageBrowserLayout({
@@ -59,13 +59,13 @@ class _ImageBrowserLayoutState extends State<ImageBrowserLayout> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
+    final gallery = Stack(
       children: [
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SizedBox(
-              height: 400,
+              height: _imageHeight,
               width: MediaQuery.of(context).size.width,
               child: GestureDetector(
                 onDoubleTap: () => _openInteractiveViewer(context),
@@ -257,6 +257,10 @@ class _ImageBrowserLayoutState extends State<ImageBrowserLayout> {
           ),
         ),
       ],
+    );
+    return SizedBox(
+      height: _imageHeight + _thumbnailItemSize + 20,
+      child: gallery,
     );
   }
 


### PR DESCRIPTION
The issue is caused by non-limited height of `ImageBrowserLayout`

After adding specific height:

![image](https://github.com/user-attachments/assets/2c0b705e-f23a-4e03-8dc7-c82d52755a82)

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
