### PR TITLE
fix: default page name should be empty when creating

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/mobile_view_page.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/mobile_view_page.dart
@@ -293,6 +293,9 @@ class _MobileViewPageState extends State<MobileViewPage> {
           );
         }
 
+        final name =
+            widget.fixedTitle ?? view?.nameOrDefault ?? widget.title ?? '';
+
         return Opacity(
           opacity: value,
           child: Row(
@@ -305,7 +308,7 @@ class _MobileViewPageState extends State<MobileViewPage> {
                 const HSpace(4),
               ],
               FlowyText.medium(
-                widget.fixedTitle ?? view?.name ?? widget.title ?? '',
+                name,
                 fontSize: 15.0,
                 overflow: TextOverflow.ellipsis,
                 figmaLineHeight: 18.0,

--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/space/mobile_space.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/space/mobile_space.dart
@@ -98,7 +98,7 @@ class MobileSpace extends StatelessWidget {
             Navigator.of(sheetContext).pop();
             context.read<SpaceBloc>().add(
                   SpaceEvent.createPage(
-                    name: layout.defaultName,
+                    name: '',
                     layout: layout,
                     index: 0,
                     openAfterCreate: true,

--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/tab/mobile_space_tab.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/tab/mobile_space_tab.dart
@@ -11,7 +11,6 @@ import 'package:appflowy/workspace/application/menu/sidebar_sections_bloc.dart';
 import 'package:appflowy/workspace/application/sidebar/folder/folder_bloc.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
 import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
-import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
@@ -193,7 +192,7 @@ class _MobileSpaceTabState extends State<MobileSpaceTab>
     if (context.read<SpaceBloc>().state.spaces.isNotEmpty) {
       context.read<SpaceBloc>().add(
             SpaceEvent.createPage(
-              name: layout.defaultName,
+              name: '',
               layout: layout,
               openAfterCreate: true,
             ),
@@ -202,7 +201,7 @@ class _MobileSpaceTabState extends State<MobileSpaceTab>
       // only support create document in section
       context.read<SidebarSectionsBloc>().add(
             SidebarSectionsEvent.createRootViewInSection(
-              name: layout.defaultName,
+              name: '',
               index: 0,
               viewSection: FolderSpaceType.public.toViewSectionPB,
             ),


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- [x] default page name should be empty when creating
- [x] the AI chat page should be renamed after sending the first message.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
