### PR TITLE
fix: auto updater should not block the launch process

### DIFF
--- a/frontend/appflowy_flutter/lib/shared/version_checker/version_checker.dart
+++ b/frontend/appflowy_flutter/lib/shared/version_checker/version_checker.dart
@@ -54,7 +54,7 @@ class VersionChecker {
           .nonNulls
           .firstWhereOrNull((e) => e.os == ApplicationInfo.os);
     } catch (e) {
-      Log.error('Failed to check for updates: $e');
+      Log.info('Failed to check for updates: $e');
     }
 
     return null;

--- a/frontend/appflowy_flutter/lib/startup/tasks/auto_update_task.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/auto_update_task.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/shared/version_checker/version_checker.dart';
 import 'package:appflowy/startup/tasks/app_widget.dart';
@@ -26,7 +28,8 @@ class AutoUpdateTask extends LaunchTask {
       return;
     }
 
-    await _setupAutoUpdater();
+    // don't use await here, because the auto updater is not a blocking operation
+    unawaited(_setupAutoUpdater());
 
     ApplicationInfo.isCriticalUpdateNotifier.addListener(
       _showCriticalUpdateDialog,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/7424

The auto updater should not block the launch process. It can be run without await.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
