### PR TITLE
fix: potential issues with displaying CircleAvatar

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/user_avatar.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/user_avatar.dart
@@ -90,15 +90,14 @@ class UserAvatar extends StatelessWidget {
                   : null,
             ),
         child: ClipRRect(
-          borderRadius: Corners.s5Border,
-          child: CircleAvatar(
-            backgroundColor: Colors.transparent,
-            child: Image.network(
-              iconUrl,
-              fit: BoxFit.cover,
-              errorBuilder: (context, error, stackTrace) =>
-                  _buildEmptyAvatar(context),
-            ),
+          borderRadius: BorderRadius.circular(size / 2),
+          child: Image.network(
+            iconUrl,
+            width: size,
+            height: size,
+            fit: BoxFit.cover,
+            errorBuilder: (context, error, stackTrace) =>
+                _buildEmptyAvatar(context),
           ),
         ),
       ),


### PR DESCRIPTION
Fix the issue of the `UserAvatar` component not displaying network images as circular.


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
