### PR TITLE
fix: using [[ to create subpage with error text

### DIFF
--- a/frontend/appflowy_flutter/integration_test/mobile/document/at_menu_test.dart
+++ b/frontend/appflowy_flutter/integration_test/mobile/document/at_menu_test.dart
@@ -37,5 +37,20 @@ void main() {
       await tester.tap(actionWidgets.last);
       expect(find.byType(MentionPageBlock), findsOneWidget);
     });
+
+    testWidgets('create subpage with at menu', (tester) async {
+      await tester.launchInAnonymousMode();
+      await tester.createNewDocumentOnMobile(title);
+      await tester.editor.tapLineOfEditorAt(0);
+      const subpageName = 'Subpage';
+      await tester.ime.insertText('[[$subpageName');
+      await tester.pumpAndSettle();
+      final actionWidgets = find.byType(MobileInlineActionsWidget);
+      await tester.tapButton(actionWidgets.first);
+      final firstNode =
+          tester.editor.getCurrentEditorState().getNodeAtPath([0]);
+      assert(firstNode != null);
+      expect(firstNode!.delta?.toPlainText().contains('['), false);
+    });
   });
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/page_reference_commands.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/page_reference_commands.dart
@@ -120,6 +120,7 @@ Future<bool> inlinePageReferenceCommandHandler(
             editorState: editorState,
             service: service,
             initialResults: initialResults,
+            startCharAmount: previousChar != null ? 2 : 1,
             style: style,
           )
         : InlineActionsMenu(


### PR DESCRIPTION
Before:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/588b7303-f652-44d9-80eb-7f819965c4cc" />


After: 
<img width="355" alt="image" src="https://github.com/user-attachments/assets/08d76c7c-e615-4483-a987-c5e7b61c0842" />


<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
