### PR TITLE
fix: unable to delete the callout block when it's in the first line

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
@@ -704,7 +704,14 @@ TableBlockComponentBuilder _buildTableBlockComponentBuilder(
   BlockComponentConfiguration configuration,
 ) {
   return TableBlockComponentBuilder(
-    menuBuilder: (node, editorState, position, dir, onBuild, onClose) =>
+    menuBuilder: (
+      node,
+      editorState,
+      position,
+      dir,
+      onBuild,
+      onClose,
+    ) =>
         TableMenu(
       node: node,
       editorState: editorState,
@@ -731,7 +738,14 @@ TableCellBlockComponentBuilder _buildTableCellBlockComponentBuilder(
       }
       return buildEditorCustomizedColor(context, node, colorString);
     },
-    menuBuilder: (node, editorState, position, dir, onBuild, onClose) =>
+    menuBuilder: (
+      node,
+      editorState,
+      position,
+      dir,
+      onBuild,
+      onClose,
+    ) =>
         TableMenu(
       node: node,
       editorState: editorState,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
@@ -153,7 +153,10 @@ class _AppFlowyEditorPageState extends State<AppFlowyEditorPage>
     ]);
 
     indentableBlockTypes.add(ToggleListBlockKeys.type);
-    convertibleBlockTypes.add(ToggleListBlockKeys.type);
+    convertibleBlockTypes.addAll([
+      ToggleListBlockKeys.type,
+      CalloutBlockKeys.type,
+    ]);
 
     effectiveScrollController = widget.scrollController ?? ScrollController();
     // disable the color parse in the HTML decoder.

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/callout/callout_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/callout/callout_block_component.dart
@@ -210,6 +210,9 @@ class _CalloutBlockComponentWidgetState
             key: ValueKey(widget.node.id + emoji.emoji),
             enable: editorState.editable,
             title: '',
+            margin: UniversalPlatform.isMobile
+                ? const EdgeInsets.symmetric(vertical: 2.0, horizontal: 10.0)
+                : EdgeInsets.zero,
             emoji: emoji,
             emojiSize: emojiSize,
             showBorder: false,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/7433

- Added the callout block type to convertibleBlockTypes to support converting it to paragraph when using backspace.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
