### PR TITLE
fix: title position working incorrectly with document width setting

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/cover_title.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/cover_title.dart
@@ -1,7 +1,6 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/application/document_appearance_cubit.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/shared_context/shared_context.dart';
-import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy/shared/text_field/text_filed_with_metric_lines.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/view/view_bloc.dart';
@@ -93,7 +92,6 @@ class _InnerCoverTitleState extends State<_InnerCoverTitle> {
       builder: (context, state) {
         final appearance = context.read<DocumentAppearanceCubit>().state;
         return Container(
-          padding: EditorStyleCustomizer.documentPaddingWithOptionMenu,
           constraints: BoxConstraints(maxWidth: width),
           child: Theme(
             data: Theme.of(context).copyWith(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
@@ -196,7 +196,7 @@ class _DocumentCoverWidgetState extends State<DocumentCoverWidget> {
               ],
             ),
             Padding(
-              padding: const EdgeInsets.only(bottom: 12.0),
+              padding: EdgeInsets.fromLTRB(offset, 0, offset, 12),
               child: MouseRegion(
                 onEnter: (event) => isCoverTitleHovered.value = true,
                 onExit: (event) => isCoverTitleHovered.value = false,


### PR DESCRIPTION
Before: 

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/4102968a-acb5-461e-a441-8ea09d02ec62" />

After:

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/e230bc8c-3ce7-4dba-91b8-e545a1160c03" />

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
