### PR TITLE
fix: don't include icon while exporting callout to md

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
+import 'package:appflowy/shared/icon_emoji_picker/flowy_icon_emoji_picker.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 
 class CalloutNodeParser extends NodeParser {
@@ -17,8 +18,15 @@ class CalloutNodeParser extends NodeParser {
         .split('\n')
         .map((e) => '> $e')
         .join('\n');
+    final type = node.attributes[CalloutBlockKeys.iconType];
+    final icon = type == FlowyIconType.emoji.name
+        ? node.attributes[CalloutBlockKeys.icon]
+        : null;
+
+    final content = icon == null ? markdown : "> $icon\n$markdown";
+
     return '''
-$markdown
+$content
 
 ''';
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
@@ -10,7 +10,6 @@ class CalloutNodeParser extends NodeParser {
   @override
   String transform(Node node, DocumentMarkdownEncoder? encoder) {
     assert(node.children.isEmpty);
-    final icon = node.attributes[CalloutBlockKeys.icon];
     final delta = node.delta ?? Delta()
       ..insert('');
     final String markdown = DeltaMarkdownEncoder()
@@ -19,7 +18,6 @@ class CalloutNodeParser extends NodeParser {
         .map((e) => '> $e')
         .join('\n');
     return '''
-> $icon
 $markdown
 
 ''';

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/callout_node_parser.dart
@@ -19,7 +19,7 @@ class CalloutNodeParser extends NodeParser {
         .map((e) => '> $e')
         .join('\n');
     final type = node.attributes[CalloutBlockKeys.iconType];
-    final icon = type == FlowyIconType.emoji.name
+    final icon = type == FlowyIconType.emoji.name || type == null || type == ""
         ? node.attributes[CalloutBlockKeys.icon]
         : null;
 


### PR DESCRIPTION
There isn't a call out block in markdown, so we convert to quote instead. We also include the icon (emoji) in the first line to preserve the information. Icons, however, can't be converted.

![Screenshot 2025-03-10 at 11 10 09 AM](https://github.com/user-attachments/assets/f02cbee4-0be3-4051-a259-d759145b8d2f)


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
