### PR TITLE
fix: ai writer gestures

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_block_component.dart
@@ -18,6 +18,7 @@ import 'operations/ai_writer_cubit.dart';
 import 'operations/ai_writer_entities.dart';
 import 'operations/ai_writer_node_extension.dart';
 import 'suggestion_action_bar.dart';
+import 'widgets/ai_writer_gesture_detector.dart';
 
 class AiWriterBlockKeys {
   const AiWriterBlockKeys._();
@@ -168,10 +169,11 @@ class _AIWriterBlockComponentState extends State<AiWriterBlockComponent> {
                   children: [
                     BlocBuilder<AiWriterCubit, AiWriterState>(
                       builder: (context, state) {
-                        return GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: () => onTapOutside(),
-                          onTapDown: (_) => onTapOutside(),
+                        return AiWriterGestureDetector(
+                          behavior: state is GeneratingAiWriterState
+                              ? HitTestBehavior.opaque
+                              : HitTestBehavior.translucent,
+                          onPointerEvent: () => onTapOutside(),
                         );
                       },
                     ),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_gesture_detector.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_gesture_detector.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+class AiWriterGestureDetector extends StatelessWidget {
+  const AiWriterGestureDetector({
+    super.key,
+    required this.behavior,
+    required this.onPointerEvent,
+    this.child,
+  });
+
+  final HitTestBehavior behavior;
+  final void Function() onPointerEvent;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      behavior: behavior,
+      gestures: <Type, GestureRecognizerFactory>{
+        TapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+          () => TapGestureRecognizer(),
+          (instance) {
+            instance
+              ..onTap = onPointerEvent
+              ..onTapDown = (_) => onPointerEvent();
+          },
+        ),
+        ImmediateMultiDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+                    ImmediateMultiDragGestureRecognizer>(
+                () => ImmediateMultiDragGestureRecognizer(), (instance) {
+          instance.onStart = (offset) => null;
+        }),
+      },
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
1. When generating, disable scrolling along with any mouse interaction. Such interactions will pop a confirmation dialog to cancel and remove
2. When not generating, enable scrolling, but don't allow any other sort of mouse interaction, including but not limited to:
    - tapping
    - tap and hold
    - tap and drag
    - three finger drag

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
