### PR TITLE
fix: prevent segfault due to infinite recursion in trash view

### DIFF
--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -2074,16 +2074,11 @@ pub(crate) fn get_workspace_public_view_pbs(workspace_id: &str, folder: &Folder)
 
 /// Get all the child views belong to the view id, including the child views of the child views.
 fn get_all_child_view_ids(folder: &Folder, view_id: &str) -> Vec<String> {
-  let child_view_ids = folder
-    .get_views_belong_to(view_id)
-    .into_iter()
+  folder
+    .get_view_recursively(view_id)
+    .iter()
     .map(|view| view.id.clone())
-    .collect::<Vec<String>>();
-  let mut all_child_view_ids = child_view_ids.clone();
-  for child_view_id in child_view_ids {
-    all_child_view_ids.extend(get_all_child_view_ids(folder, &child_view_id));
-  }
-  all_child_view_ids
+    .collect()
 }
 
 /// Get the current private views of the user.


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->
Currently, if the trash's parent and child hierarchy forms a cycle, the app will fail to launch due to segmentation fault, caused by infinite recursion. There is already a method in AppFlowy Collab which address this, so we just need to reuse the same method.
<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
