### PR TITLE
fix: unable to paste iframe in editor

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_plain_text.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_plain_text.dart
@@ -32,8 +32,11 @@ extension PasteFromPlainText on EditorState {
 
     await deleteSelectionIfNeeded();
 
+    /// try to parse the plain text as markdown
     final nodes = customMarkdownToDocument(plainText).root.children;
     if (nodes.isEmpty) {
+      /// if the markdown parser failed, fallback to the plain text parser
+      await pastePlainText(plainText);
       return;
     }
     if (nodes.length == 1) {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/7514

If the HTML can't be parsed during pasting, fall back to the plain text option.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
