### PR TITLE
fix: quote block flashes on the AI chat page while generating an answer.

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_markdown_text.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_markdown_text.dart
@@ -64,8 +64,12 @@ class _AppFlowyEditorMarkdownState extends State<_AppFlowyEditorMarkdown> {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.markdown != widget.markdown) {
-      editorState.dispose();
-      editorState = _parseMarkdown(widget.markdown.trim());
+      final editorState = _parseMarkdown(
+        widget.markdown.trim(),
+        previousDocument: this.editorState.document,
+      );
+      this.editorState.dispose();
+      this.editorState = editorState;
       scrollController.dispose();
       scrollController = EditorScrollController(
         editorState: editorState,
@@ -129,8 +133,30 @@ class _AppFlowyEditorMarkdownState extends State<_AppFlowyEditorMarkdown> {
     );
   }
 
-  EditorState _parseMarkdown(String markdown) {
+  EditorState _parseMarkdown(
+    String markdown, {
+    Document? previousDocument,
+  }) {
+    // merge the nodes from the previous document with the new document to keep the same node ids
     final document = customMarkdownToDocument(markdown);
+    final documentIterator = NodeIterator(
+      document: document,
+      startNode: document.root,
+    );
+    if (previousDocument != null) {
+      final previousDocumentIterator = NodeIterator(
+        document: previousDocument,
+        startNode: previousDocument.root,
+      );
+      while (
+          documentIterator.moveNext() && previousDocumentIterator.moveNext()) {
+        final currentNode = documentIterator.current;
+        final previousNode = previousDocumentIterator.current;
+        if (currentNode.path.equals(previousNode.path)) {
+          currentNode.id = previousNode.id;
+        }
+      }
+    }
     final editorState = EditorState(document: document);
     return editorState;
   }

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -90,8 +90,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ec7350d
-      resolved-ref: ec7350da7c298639c85e88229033da0c8aae8578
+      ref: "5070212"
+      resolved-ref: "5070212ee0f02182a8acdd760b4d7b42264baec4"
       url: "https://github.com/AppFlowy-IO/appflowy-editor.git"
     source: git
     version: "5.1.0"

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -180,7 +180,7 @@ dependency_overrides:
   appflowy_editor:
     git:
       url: https://github.com/AppFlowy-IO/appflowy-editor.git
-      ref: "ec7350d"
+      ref: "5070212"
 
   appflowy_editor_plugins:
     git:


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

https://github.com/user-attachments/assets/87402a67-9059-4e2b-9dd7-5c8257fb572e

- Keep the same node id on the AI chat page when generating an answer.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
