### PR TITLE
fix: optimize cover title position offset calculation

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/callout/callout_block_shortcuts.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/callout/callout_block_shortcuts.dart
@@ -32,7 +32,8 @@ CharacterShortcutEventHandler _insertNewLineHandler = (editorState) async {
   await editorState.deleteSelection(selection);
 
   if (HardwareKeyboard.instance.isShiftPressed) {
-    await editorState.insertNewLine();
+    // ignore the shift+enter event, fallback to the default behavior
+    return false;
   } else if (node.children.isEmpty) {
     // insert a new paragraph within the callout block
     final path = node.path.child(0);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
@@ -223,7 +223,7 @@ class _DocumentCoverWidgetState extends State<DocumentCoverWidget> {
     }
 
     return Positioned(
-      bottom: 0,
+      bottom: hasCover ? kToolbarHeight - kIconHeight / 2 : kToolbarHeight,
       left: 0,
       right: 0,
       child: Center(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
@@ -188,52 +188,65 @@ class _DocumentCoverWidgetState extends State<DocumentCoverWidget> {
                     onChangeCover: (type, details) =>
                         _saveIconOrCover(cover: (type, details)),
                   ),
-                _buildCoverIcon(
-                  context,
-                  constraints,
-                  offset,
-                ),
+                _buildAlignedCoverIcon(context),
               ],
             ),
-            Padding(
-              padding: EdgeInsets.fromLTRB(offset, 0, offset, 12),
-              child: Visibility(
-                visible: offset != 0,
-                child: MouseRegion(
-                  onEnter: (event) => isCoverTitleHovered.value = true,
-                  onExit: (event) => isCoverTitleHovered.value = false,
-                  child: CoverTitle(
-                    view: widget.view,
-                  ),
-                ),
-              ),
-            ),
+            _buildAlignedTitle(context),
           ],
         );
       },
     );
   }
 
-  Widget _buildCoverIcon(
-    BuildContext context,
-    BoxConstraints constraints,
-    double offset,
-  ) {
-    if (!hasIcon || offset == 0) {
+  Widget _buildAlignedTitle(BuildContext context) {
+    return Center(
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: widget.editorState.editorStyle.maxWidth ?? double.infinity,
+        ),
+        padding: widget.editorState.editorStyle.padding +
+            const EdgeInsets.symmetric(horizontal: 44),
+        child: MouseRegion(
+          onEnter: (event) => isCoverTitleHovered.value = true,
+          onExit: (event) => isCoverTitleHovered.value = false,
+          child: CoverTitle(
+            view: widget.view,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAlignedCoverIcon(BuildContext context) {
+    if (!hasIcon) {
       return const SizedBox.shrink();
     }
 
     return Positioned(
-      // if hasCover, there shouldn't be icons present so the icon can
-      // be closer to the bottom.
-      left: offset,
-      bottom: hasCover ? kToolbarHeight - kIconHeight / 2 : kToolbarHeight,
-      child: DocumentIcon(
-        editorState: widget.editorState,
-        node: widget.node,
-        icon: viewIcon,
-        documentId: view.id,
-        onChangeIcon: (icon) => _saveIconOrCover(icon: icon),
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth:
+                widget.editorState.editorStyle.maxWidth ?? double.infinity,
+          ),
+          padding: widget.editorState.editorStyle.padding +
+              const EdgeInsets.symmetric(horizontal: 44),
+          child: Row(
+            children: [
+              DocumentIcon(
+                editorState: widget.editorState,
+                node: widget.node,
+                icon: viewIcon,
+                documentId: view.id,
+                onChangeIcon: (icon) => _saveIconOrCover(icon: icon),
+              ),
+              Spacer(),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/quote/quote_block_shortcuts.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/quote/quote_block_shortcuts.dart
@@ -30,8 +30,8 @@ CharacterShortcutEventHandler _insertNewLineHandler = (editorState) async {
   await editorState.deleteSelection(selection);
 
   if (HardwareKeyboard.instance.isShiftPressed) {
-    await editorState.insertNewLine();
-    return true;
+    // ignore the shift+enter event, fallback to the default behavior
+    return false;
   } else if (node.children.isEmpty &&
       selection.endIndex == node.delta?.length) {
     // insert a new paragraph within the callout block


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- Use padding instead of positioned in cover title and cover icon
- Ingore shift+enter in callout/quote and fallback to system behavior

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.
