### PR TITLE
fix: some toolbar text display error

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_format_toolbar_items.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_format_toolbar_items.dart
@@ -3,7 +3,6 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_page.dart';
 import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
-
 // ignore: implementation_imports
 import 'package:appflowy_editor/src/editor/toolbar/desktop/items/utils/tooltip_util.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -11,29 +10,30 @@ import 'package:flowy_infra_ui/style_widget/icon_button.dart';
 import 'package:flutter/material.dart';
 
 import 'custom_placeholder_toolbar_item.dart';
+import 'toolbar_id_enum.dart';
 
 final List<ToolbarItem> customMarkdownFormatItems = [
   _FormatToolbarItem(
-    id: 'toolbar.bold',
+    id: ToolbarId.bold,
     name: 'bold',
     svg: FlowySvgs.toolbar_bold_m,
   ),
   group1PaddingItem,
   _FormatToolbarItem(
-    id: 'toolbar.underline',
+    id: ToolbarId.underline,
     name: 'underline',
     svg: FlowySvgs.toolbar_underline_m,
   ),
   group1PaddingItem,
   _FormatToolbarItem(
-    id: 'toolbar.italic',
+    id: ToolbarId.italic,
     name: 'italic',
     svg: FlowySvgs.toolbar_inline_italic_m,
   ),
 ];
 
 final ToolbarItem customInlineCodeItem = _FormatToolbarItem(
-  id: 'toolbar.code',
+  id: ToolbarId.code,
   name: 'code',
   svg: FlowySvgs.toolbar_inline_code_m,
   group: 2,
@@ -41,90 +41,86 @@ final ToolbarItem customInlineCodeItem = _FormatToolbarItem(
 
 class _FormatToolbarItem extends ToolbarItem {
   _FormatToolbarItem({
-    required String id,
+    required ToolbarId id,
     required String name,
     required FlowySvgData svg,
     super.group = 1,
   }) : super(
-    id: 'editor.$id',
-    isActive: showInAnyTextType,
-    builder: (context,
-        editorState,
-        highlightColor,
-        iconColor,
-        tooltipBuilder,) {
-      final selection = editorState.selection!;
-      final nodes = editorState.getNodesInSelection(selection);
-      final isHighlight = nodes.allSatisfyInSelection(
-        selection,
-            (delta) =>
-        delta.isNotEmpty &&
-            delta.everyAttributes((attr) => attr[name] == true),
-      );
+          id: id.id,
+          isActive: showInAnyTextType,
+          builder: (
+            context,
+            editorState,
+            highlightColor,
+            iconColor,
+            tooltipBuilder,
+          ) {
+            final selection = editorState.selection!;
+            final nodes = editorState.getNodesInSelection(selection);
+            final isHighlight = nodes.allSatisfyInSelection(
+              selection,
+              (delta) =>
+                  delta.isNotEmpty &&
+                  delta.everyAttributes((attr) => attr[name] == true),
+            );
 
-      final hoverColor = isHighlight
-          ? highlightColor
-          : EditorStyleCustomizer.toolbarHoverColor(context);
-      final isDark = Theme
-          .of(context)
-          .brightness == Brightness.dark;
+            final hoverColor = isHighlight
+                ? highlightColor
+                : EditorStyleCustomizer.toolbarHoverColor(context);
+            final isDark = Theme.of(context).brightness == Brightness.dark;
 
-      final child = FlowyIconButton(
-        width: 36,
-        height: 32,
-        hoverColor: hoverColor,
-        isSelected: isHighlight,
-        icon: FlowySvg(
-          svg,
-          size: Size.square(20.0),
-          color: (isDark && isHighlight)
-              ? Color(0xFF282E3A)
-              : Theme
-              .of(context)
-              .iconTheme
-              .color,
-        ),
-        onPressed: () =>
-            editorState.toggleAttribute(
-              name,
-              selection: selection,
-            ),
-      );
+            final child = FlowyIconButton(
+              width: 36,
+              height: 32,
+              hoverColor: hoverColor,
+              isSelected: isHighlight,
+              icon: FlowySvg(
+                svg,
+                size: Size.square(20.0),
+                color: (isDark && isHighlight)
+                    ? Color(0xFF282E3A)
+                    : Theme.of(context).iconTheme.color,
+              ),
+              onPressed: () => editorState.toggleAttribute(
+                name,
+                selection: selection,
+              ),
+            );
 
-      if (tooltipBuilder != null) {
-        return tooltipBuilder(
-          context,
-          id,
-          _getTooltipText(id),
-          child,
+            if (tooltipBuilder != null) {
+              return tooltipBuilder(
+                context,
+                id.id,
+                _getTooltipText(id),
+                child,
+              );
+            }
+            return child;
+          },
         );
-      }
-      return child;
-    },
-  );
 }
 
-String _getTooltipText(String id) {
+String _getTooltipText(ToolbarId id) {
   switch (id) {
-    case 'toolbar.underline':
+    case ToolbarId.underline:
       return '${LocaleKeys.toolbar_underline.tr()}${shortcutTooltips(
         '⌘ + U',
         'CTRL + U',
         'CTRL + U',
       )}';
-    case 'toolbar.bold':
+    case ToolbarId.bold:
       return '${LocaleKeys.toolbar_bold.tr()}${shortcutTooltips(
         '⌘ + B',
         'CTRL + B',
         'CTRL + B',
       )}';
-    case 'toolbar.italic':
+    case ToolbarId.italic:
       return '${LocaleKeys.toolbar_italic.tr()}${shortcutTooltips(
         '⌘ + I',
         'CTRL + I',
         'CTRL + I',
       )}';
-    case 'toolbar.code':
+    case ToolbarId.code:
       return '${LocaleKeys.document_toolbar_inlineCode.tr()}${shortcutTooltips(
         '⌘ + E',
         'CTRL + E',

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_format_toolbar_items.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_format_toolbar_items.dart
@@ -3,6 +3,7 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/document/presentation/editor_page.dart';
 import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
+
 // ignore: implementation_imports
 import 'package:appflowy_editor/src/editor/toolbar/desktop/items/utils/tooltip_util.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -13,26 +14,26 @@ import 'custom_placeholder_toolbar_item.dart';
 
 final List<ToolbarItem> customMarkdownFormatItems = [
   _FormatToolbarItem(
-    id: 'bold',
+    id: 'toolbar.bold',
     name: 'bold',
     svg: FlowySvgs.toolbar_bold_m,
   ),
   group1PaddingItem,
   _FormatToolbarItem(
-    id: 'underline',
+    id: 'toolbar.underline',
     name: 'underline',
     svg: FlowySvgs.toolbar_underline_m,
   ),
   group1PaddingItem,
   _FormatToolbarItem(
-    id: 'italic',
+    id: 'toolbar.italic',
     name: 'italic',
     svg: FlowySvgs.toolbar_inline_italic_m,
   ),
 ];
 
 final ToolbarItem customInlineCodeItem = _FormatToolbarItem(
-  id: 'code',
+  id: 'toolbar.code',
   name: 'code',
   svg: FlowySvgs.toolbar_inline_code_m,
   group: 2,
@@ -45,98 +46,90 @@ class _FormatToolbarItem extends ToolbarItem {
     required FlowySvgData svg,
     super.group = 1,
   }) : super(
-          id: 'editor.$id',
-          isActive: showInAnyTextType,
-          builder: (
-            context,
-            editorState,
-            highlightColor,
-            iconColor,
-            tooltipBuilder,
-          ) {
-            final selection = editorState.selection!;
-            final nodes = editorState.getNodesInSelection(selection);
-            final isHighlight = nodes.allSatisfyInSelection(
-              selection,
-              (delta) =>
-                  delta.isNotEmpty &&
-                  delta.everyAttributes((attr) => attr[name] == true),
-            );
+    id: 'editor.$id',
+    isActive: showInAnyTextType,
+    builder: (context,
+        editorState,
+        highlightColor,
+        iconColor,
+        tooltipBuilder,) {
+      final selection = editorState.selection!;
+      final nodes = editorState.getNodesInSelection(selection);
+      final isHighlight = nodes.allSatisfyInSelection(
+        selection,
+            (delta) =>
+        delta.isNotEmpty &&
+            delta.everyAttributes((attr) => attr[name] == true),
+      );
 
-            final hoverColor = isHighlight
-                ? highlightColor
-                : EditorStyleCustomizer.toolbarHoverColor(context);
-            final isDark = Theme.of(context).brightness == Brightness.dark;
+      final hoverColor = isHighlight
+          ? highlightColor
+          : EditorStyleCustomizer.toolbarHoverColor(context);
+      final isDark = Theme
+          .of(context)
+          .brightness == Brightness.dark;
 
-            final child = FlowyIconButton(
-              width: 36,
-              height: 32,
-              hoverColor: hoverColor,
-              isSelected: isHighlight,
-              icon: FlowySvg(
-                svg,
-                size: Size.square(20.0),
-                color: (isDark && isHighlight)
-                    ? Color(0xFF282E3A)
-                    : Theme.of(context).iconTheme.color,
-              ),
-              onPressed: () => editorState.toggleAttribute(
-                name,
-                selection: selection,
-              ),
-            );
+      final child = FlowyIconButton(
+        width: 36,
+        height: 32,
+        hoverColor: hoverColor,
+        isSelected: isHighlight,
+        icon: FlowySvg(
+          svg,
+          size: Size.square(20.0),
+          color: (isDark && isHighlight)
+              ? Color(0xFF282E3A)
+              : Theme
+              .of(context)
+              .iconTheme
+              .color,
+        ),
+        onPressed: () =>
+            editorState.toggleAttribute(
+              name,
+              selection: selection,
+            ),
+      );
 
-            if (tooltipBuilder != null) {
-              return tooltipBuilder(
-                context,
-                id,
-                getTooltipText(id),
-                child,
-              );
-            }
-            return child;
-          },
+      if (tooltipBuilder != null) {
+        return tooltipBuilder(
+          context,
+          id,
+          _getTooltipText(id),
+          child,
         );
+      }
+      return child;
+    },
+  );
 }
 
-String getTooltipText(String id) {
+String _getTooltipText(String id) {
   switch (id) {
-    case 'underline':
+    case 'toolbar.underline':
       return '${LocaleKeys.toolbar_underline.tr()}${shortcutTooltips(
         '⌘ + U',
         'CTRL + U',
         'CTRL + U',
       )}';
-    case 'bold':
+    case 'toolbar.bold':
       return '${LocaleKeys.toolbar_bold.tr()}${shortcutTooltips(
         '⌘ + B',
         'CTRL + B',
         'CTRL + B',
       )}';
-    case 'italic':
+    case 'toolbar.italic':
       return '${LocaleKeys.toolbar_italic.tr()}${shortcutTooltips(
         '⌘ + I',
         'CTRL + I',
         'CTRL + I',
       )}';
-    case 'strikethrough':
-      return '${LocaleKeys.toolbar_strike.tr()}${shortcutTooltips(
-        '⌘ + SHIFT + S',
-        'CTRL + SHIFT + S',
-        'CTRL + SHIFT + S',
-      )}';
-    case 'code':
+    case 'toolbar.code':
       return '${LocaleKeys.document_toolbar_inlineCode.tr()}${shortcutTooltips(
         '⌘ + E',
         'CTRL + E',
         'CTRL + E',
       )}';
-    case 'align_left':
-      return LocaleKeys.document_toolbar_alignLeft.tr();
-    case 'align_center':
-      return LocaleKeys.document_toolbar_alignCenter.tr();
-    case 'align_right':
-      return LocaleKeys.document_toolbar_alignRight.tr();
     default:
       return '';
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_hightlight_color_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_hightlight_color_toolbar_item.dart
@@ -6,11 +6,12 @@ import 'package:appflowy_editor/appflowy_editor.dart' hide ColorPicker;
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 
-const _kHighlightColorItemId = 'editor.highlightColor';
+import 'toolbar_id_enum.dart';
+
 String? _customHighlightColorHex;
 
 final customHighlightColorItem = ToolbarItem(
-  id: _kHighlightColorItemId,
+  id: ToolbarId.highlightColor.id,
   group: 1,
   isActive: showInAnyTextType,
   builder: (context, editorState, highlightColor, iconColor, tooltipBuilder) =>
@@ -107,7 +108,7 @@ class _HighlightColorPickerWidgetState
 
     return widget.tooltipBuilder?.call(
           context,
-          _kHighlightColorItemId,
+          ToolbarId.highlightColor.id,
           AppFlowyEditorL10n.current.highlightColor,
           child,
         ) ??

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_link_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_link_toolbar_item.dart
@@ -4,10 +4,10 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flowy_infra_ui/style_widget/icon_button.dart';
 import 'package:flutter/material.dart';
 
-const _kLinkItemId = 'editor.link';
+import 'toolbar_id_enum.dart';
 
 final customLinkItem = ToolbarItem(
-  id: _kLinkItemId,
+  id: ToolbarId.link.id,
   group: 4,
   isActive: onlyShowInSingleSelectionAndTextType,
   builder: (context, editorState, highlightColor, iconColor, tooltipBuilder) {
@@ -39,7 +39,7 @@ final customLinkItem = ToolbarItem(
     if (tooltipBuilder != null) {
       return tooltipBuilder(
         context,
-        _kLinkItemId,
+        ToolbarId.highlightColor.id,
         AppFlowyEditorL10n.current.link,
         child,
       );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_placeholder_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_placeholder_toolbar_item.dart
@@ -4,11 +4,10 @@ import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 
-const placeholderItemId = 'editor.placeholder';
-const paddingPlaceholderItemId = 'editor.padding_placeholder';
+import 'toolbar_id_enum.dart';
 
 final ToolbarItem customPlaceholderItem = ToolbarItem(
-  id: placeholderItemId,
+  id: ToolbarId.placeholder.id,
   group: -1,
   isActive: (editorState) => true,
   builder: (context, __, ___, ____, _____) {
@@ -28,7 +27,7 @@ ToolbarItem buildPaddingPlaceholderItem(
   bool Function(EditorState editorState)? isActive,
 }) =>
     ToolbarItem(
-      id: paddingPlaceholderItemId,
+      id: ToolbarId.paddingPlaceHolder.id,
       group: group,
       isActive: isActive,
       builder: (context, __, ___, ____, _____) => HSpace(4),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_align_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_align_toolbar_item.dart
@@ -6,10 +6,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 
-const _kTextAlignItemId = 'editor.text_align';
+import 'toolbar_id_enum.dart';
 
 final ToolbarItem customTextAlignItem = ToolbarItem(
-  id: _kTextAlignItemId,
+  id: ToolbarId.textAlign.id,
   group: 4,
   isActive: onlyShowInSingleSelectionAndTextType,
   builder: (
@@ -114,7 +114,7 @@ class _TextAlignActionListState extends State<TextAlignActionList> {
 
     return widget.tooltipBuilder?.call(
           context,
-          _kTextAlignItemId,
+          ToolbarId.textAlign.id,
           LocaleKeys.document_toolbar_textAlign.tr(),
           child,
         ) ??

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_color_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_color_toolbar_item.dart
@@ -7,12 +7,12 @@ import 'package:appflowy_editor/appflowy_editor.dart' hide ColorPicker;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
+import 'toolbar_id_enum.dart';
 
-const _kTextColorItemId = 'editor.textColor';
 String? _customColorHex;
 
 final customTextColorItem = ToolbarItem(
-  id: _kTextColorItemId,
+  id: ToolbarId.textColor.id,
   group: 1,
   isActive: showInAnyTextType,
   builder: (context, editorState, highlightColor, iconColor, tooltipBuilder) =>
@@ -106,7 +106,7 @@ class _TextColorPickerWidgetState extends State<TextColorPickerWidget> {
 
     return widget.tooltipBuilder?.call(
           context,
-          _kTextColorItemId,
+          ToolbarId.textColor.id,
           LocaleKeys.document_toolbar_textColor.tr(),
           child,
         ) ??

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_color_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/custom_text_color_toolbar_item.dart
@@ -107,7 +107,7 @@ class _TextColorPickerWidgetState extends State<TextColorPickerWidget> {
     return widget.tooltipBuilder?.call(
           context,
           _kTextColorItemId,
-          AppFlowyEditorL10n.current.textColor,
+          LocaleKeys.document_toolbar_textColor.tr(),
           child,
         ) ??
         child;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/more_option_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/more_option_toolbar_item.dart
@@ -165,8 +165,8 @@ class _MoreOptionActionListState extends State<MoreOptionActionList> {
             rightIcon: FlowyText(
               shortcutTooltips(
                 '⌘⇧S',
-                'CTRL+SHIFT+S',
-                'CTRL+SHIFT+S',
+                'Ctrl⇧S',
+                'Ctrl⇧S',
               ).trim(),
               color: fontColor,
               fontSize: 12,
@@ -180,8 +180,8 @@ class _MoreOptionActionListState extends State<MoreOptionActionList> {
               rightIcon: FlowyText(
                 shortcutTooltips(
                   '⌘⇧E',
-                  'CTRL+SHIFT+E',
-                  'CTRL+SHIFT+E',
+                  'Ctrl⇧E',
+                  'Ctrl⇧E',
                 ).trim(),
                 color: fontColor,
                 fontSize: 12,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_heading_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_heading_toolbar_item.dart
@@ -8,10 +8,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 
-const _kTextHeadingItemId = 'editor.text_heading';
+import 'toolbar_id_enum.dart';
 
 final ToolbarItem customTextHeadingItem = ToolbarItem(
-  id: _kTextHeadingItemId,
+  id: ToolbarId.textHeading.id,
   group: 1,
   isActive: onlyShowInSingleTextTypeSelectionAndExcludeTable,
   builder: (
@@ -109,7 +109,7 @@ class _TextHeadingActionListState extends State<TextHeadingActionList> {
 
     return widget.tooltipBuilder?.call(
           context,
-          _kTextHeadingItemId,
+          ToolbarId.textHeading.id,
           LocaleKeys.document_toolbar_textSize.tr(),
           child,
         ) ??

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_suggestions_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_suggestions_toolbar_item.dart
@@ -14,8 +14,7 @@ import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flutter/material.dart';
 
 import 'text_heading_toolbar_item.dart';
-
-const _kSuggestionsItemId = 'editor.suggestions';
+import 'toolbar_id_enum.dart';
 
 @visibleForTesting
 const kSuggestionsItemKey = ValueKey('SuggestionsItem');
@@ -24,7 +23,7 @@ const kSuggestionsItemKey = ValueKey('SuggestionsItem');
 const kSuggestionsItemListKey = ValueKey('SuggestionsItemList');
 
 final ToolbarItem suggestionsItem = ToolbarItem(
-  id: _kSuggestionsItemId,
+  id: ToolbarId.suggestions.id,
   group: 3,
   isActive: enableSuggestions,
   builder: (
@@ -159,7 +158,7 @@ class _SuggestionsActionListState extends State<SuggestionsActionList> {
 
     return widget.tooltipBuilder?.call(
           context,
-          _kSuggestionsItemId,
+          ToolbarId.suggestions.id,
           currentSuggestionItem.title,
           child,
         ) ??

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/toolbar_id_enum.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/toolbar_id_enum.dart
@@ -1,0 +1,19 @@
+enum ToolbarId {
+  bold,
+  underline,
+  italic,
+  code,
+  highlightColor,
+  textColor,
+  link,
+  placeholder,
+  paddingPlaceHolder,
+  textAlign,
+  moreOption,
+  textHeading,
+  suggestions,
+}
+
+extension ToolbarIdExtension on ToolbarId {
+  String get id => 'editor.$name';
+}

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -550,7 +550,7 @@ class EditorStyleCustomizer {
           style: context.tooltipTextStyle(),
         ),
         TextSpan(
-          text: (Platform.isMacOS ? '⌘+' : 'Ctrl+\\') + tooltip.$2,
+          text: (Platform.isMacOS ? '⌘+' : 'Ctrl+') + tooltip.$2,
           style: context.tooltipTextStyle()?.copyWith(
                 color: Theme.of(context).hintColor,
               ),

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -2118,7 +2118,6 @@
       "moreOptions": "More options",
       "font": "Font",
       "inlineCode": "Inline code",
-
       "suggestions": "Suggestions",
       "turnInto": "Turn into",
       "equation": "Equation"


### PR DESCRIPTION
- The tooltip text should only upper case the first letter of the first word
- The tooltip text on windows should not have `\`
- Add shortcut hint for some of the `more option` menu buttons

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
