### PR TITLE
fix: using date picker with @ menu get some errors

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_date_block.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_date_block.dart
@@ -60,8 +60,6 @@ class MentionDateBlock extends StatefulWidget {
 }
 
 class _MentionDateBlockState extends State<MentionDateBlock> {
-  final PopoverMutex mutex = PopoverMutex();
-
   late bool _includeTime = widget.includeTime;
   late DateTime? parsedDate = DateTime.tryParse(widget.date);
 
@@ -69,12 +67,6 @@ class _MentionDateBlockState extends State<MentionDateBlock> {
   void didUpdateWidget(covariant oldWidget) {
     parsedDate = DateTime.tryParse(widget.date);
     super.didUpdateWidget(oldWidget);
-  }
-
-  @override
-  void dispose() {
-    mutex.dispose();
-    super.dispose();
   }
 
   @override
@@ -105,7 +97,6 @@ class _MentionDateBlockState extends State<MentionDateBlock> {
 
           final options = DatePickerOptions(
             focusedDay: parsedDate,
-            popoverMutex: mutex,
             selectedDay: parsedDate,
             includeTime: _includeTime,
             dateFormat: appearance.dateFormat,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/appflowy_date_picker_base.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/appflowy_date_picker_base.dart
@@ -23,6 +23,7 @@ abstract class AppFlowyDatePicker extends StatefulWidget {
     this.onIncludeTimeChanged,
     this.onIsRangeChanged,
     this.onReminderSelected,
+    this.enableDidUpdate = true,
   });
 
   final DateTime? dateTime;
@@ -55,6 +56,7 @@ abstract class AppFlowyDatePicker extends StatefulWidget {
 
   final ReminderOption reminderOption;
   final OnReminderSelected? onReminderSelected;
+  final bool enableDidUpdate;
 }
 
 abstract class AppFlowyDatePickerState<T extends AppFlowyDatePicker>
@@ -75,32 +77,29 @@ abstract class AppFlowyDatePickerState<T extends AppFlowyDatePicker>
   @override
   void initState() {
     super.initState();
-
-    dateTime = widget.dateTime;
-    startDateTime = widget.isRange ? widget.dateTime : null;
-    endDateTime = widget.isRange ? widget.endDateTime : null;
-    includeTime = widget.includeTime;
-    isRange = widget.isRange;
-    reminderOption = widget.reminderOption;
+    initData();
 
     focusedDateTime = widget.dateTime ?? DateTime.now();
   }
 
   @override
   void didUpdateWidget(covariant oldWidget) {
-    dateTime = widget.dateTime;
-    if (widget.isRange) {
-      startDateTime = widget.dateTime;
-      endDateTime = widget.endDateTime;
-    } else {
-      startDateTime = endDateTime = null;
+    if (widget.enableDidUpdate) {
+      initData();
     }
-    includeTime = widget.includeTime;
-    isRange = widget.isRange;
     if (oldWidget.reminderOption != widget.reminderOption) {
       reminderOption = widget.reminderOption;
     }
     super.didUpdateWidget(oldWidget);
+  }
+
+  void initData() {
+    dateTime = widget.dateTime;
+    startDateTime = widget.isRange ? widget.dateTime : null;
+    endDateTime = widget.isRange ? widget.endDateTime : null;
+    includeTime = widget.includeTime;
+    isRange = widget.isRange;
+    reminderOption = widget.reminderOption;
   }
 
   void onDateSelectedFromDatePicker(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/desktop_date_picker.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/desktop_date_picker.dart
@@ -32,6 +32,7 @@ class DesktopAppFlowyDatePicker extends AppFlowyDatePicker {
     super.onIncludeTimeChanged,
     super.onIsRangeChanged,
     super.onReminderSelected,
+    super.enableDidUpdate,
     this.popoverMutex,
     this.options = const [],
   });

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_picker_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/date_picker/widgets/date_picker_dialog.dart
@@ -16,7 +16,6 @@ import 'package:flutter/services.dart';
 class DatePickerOptions {
   DatePickerOptions({
     DateTime? focusedDay,
-    this.popoverMutex,
     this.selectedDay,
     this.includeTime = false,
     this.isRange = false,
@@ -31,7 +30,6 @@ class DatePickerOptions {
   }) : focusedDay = focusedDay ?? DateTime.now();
 
   final DateTime focusedDay;
-  final PopoverMutex? popoverMutex;
   final DateTime? selectedDay;
   final bool includeTime;
   final bool isRange;
@@ -48,6 +46,7 @@ class DatePickerOptions {
 
 abstract class DatePickerService {
   void show(Offset offset, {required DatePickerOptions options});
+
   void dismiss();
 }
 
@@ -60,6 +59,7 @@ class DatePickerMenu extends DatePickerService {
 
   final BuildContext context;
   final EditorState editorState;
+  PopoverMutex? popoverMutex;
 
   OverlayEntry? _menuEntry;
 
@@ -67,6 +67,9 @@ class DatePickerMenu extends DatePickerService {
   void dismiss() {
     _menuEntry?.remove();
     _menuEntry = null;
+    popoverMutex?.close();
+    popoverMutex?.dispose();
+    popoverMutex = null;
   }
 
   @override
@@ -97,6 +100,7 @@ class DatePickerMenu extends DatePickerService {
       }
     }
 
+    popoverMutex = PopoverMutex();
     _menuEntry = OverlayEntry(
       builder: (_) => Material(
         type: MaterialType.transparency,
@@ -119,6 +123,7 @@ class DatePickerMenu extends DatePickerService {
                     offset: Offset(offsetX, offsetY),
                     showBelow: showBelow,
                     options: options,
+                    popoverMutex: popoverMutex,
                   ),
                 ],
               ),
@@ -137,11 +142,13 @@ class _AnimatedDatePicker extends StatelessWidget {
     required this.offset,
     required this.showBelow,
     required this.options,
+    this.popoverMutex,
   });
 
   final Offset offset;
   final bool showBelow;
   final DatePickerOptions options;
+  final PopoverMutex? popoverMutex;
 
   @override
   Widget build(BuildContext context) {
@@ -165,11 +172,12 @@ class _AnimatedDatePicker extends StatelessWidget {
           dateFormat: options.dateFormat.simplified,
           timeFormat: options.timeFormat.simplified,
           dateTime: options.selectedDay,
-          popoverMutex: options.popoverMutex,
+          popoverMutex: popoverMutex,
           reminderOption: options.selectedReminderOption ?? ReminderOption.none,
           onDaySelected: options.onDaySelected,
           onRangeSelected: options.onRangeSelected,
           onReminderSelected: options.onReminderSelected,
+          enableDidUpdate: false,
         ),
       ),
     );


### PR DESCRIPTION

<img width="546" alt="image" src="https://github.com/user-attachments/assets/9270d39f-891b-4be2-bba6-bfe0b6fad5d5" />

- Firstly,  change the `include time`
- Then click the reminder, I got an errror

```
======== Exception caught by gesture library =======================================================
The following assertion was thrown while dispatching a pointer event:
A _PopoverStateNotifier was used after being disposed.

Once you have called dispose() on a _PopoverStateNotifier, it can no longer be used.
When the exception was thrown, this was the stack: 
#0      ChangeNotifier.debugAssertNotDisposed.<anonymous closure> (package:flutter/src/foundation/change_notifier.dart:183:9)
#1      ChangeNotifier.debugAssertNotDisposed (package:flutter/src/foundation/change_notifier.dart:190:6)
#2      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:416:27)
#3      _PopoverStateNotifier.state= (package:appflowy_popover/src/mutex.dart:45:5)
#4      PopoverMutex.state= (package:appflowy_popover/src/mutex.dart:24:55)
#5      PopoverState.showOverlay (package:appflowy_popover/src/popover.dart:221:21)
#6      PopoverState._buildChild.<anonymous closure> (package:appflowy_popover/src/popover.dart:294:9)
#7      PopoverState._callHandler (package:appflowy_popover/src/popover.dart:348:14)
#8      PopoverState._buildClickHandler.<anonymous closure> (package:appflowy_popover/src/popover.dart:322:22)
#9      RenderPointerListener.handleEvent (package:flutter/src/rendering/proxy_box.dart:3084:53)
#10     GestureBinding.dispatchEvent (package:flutter/src/gestures/binding.dart:482:22)
#11     RendererBinding.dispatchEvent (package:flutter/src/rendering/binding.dart:457:11)
#12     GestureBinding._handlePointerEventImmediately (package:flutter/src/gestures/binding.dart:427:7)
#13     GestureBinding.handlePointerEvent (package:flutter/src/gestures/binding.dart:390:5)
#14     ScaledWidgetsFlutterBinding._flushPointerEventQueue (package:scaled_app/scaled_app.dart:158:7)
#15     ScaledWidgetsFlutterBinding._handlePointerDataPacket (package:scaled_app/scaled_app.dart:129:9)
#16     _invoke1 (dart:ui/hooks.dart:328:13)
#17     PlatformDispatcher._dispatchPointerDataPacket (dart:ui/platform_dispatcher.dart:450:7)
#18     _dispatchPointerDataPacket (dart:ui/hooks.dart:262:31)
Event: PointerDownEvent#84077(position: Offset(727.2, 727.9))
```



### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
