### PR TITLE
feat: support i18n in the 'delete my account' operation 

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/account/account_deletion.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/account/account_deletion.dart
@@ -14,7 +14,6 @@ import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:universal_platform/universal_platform.dart';
 
-const _confirmText = 'DELETE MY ACCOUNT';
 const _acceptableConfirmTexts = [
   'delete my account',
   'deletemyaccount',
@@ -135,7 +134,8 @@ class _AccountDeletionDialog extends StatelessWidget {
         ),
         const VSpace(12.0),
         FlowyTextField(
-          hintText: _confirmText,
+          hintText:
+              LocaleKeys.newSettings_myAccount_deleteAccount_confirmHint3.tr(),
           controller: controller,
         ),
         const VSpace(16),
@@ -176,7 +176,8 @@ class _AccountDeletionDialog extends StatelessWidget {
 bool _isConfirmTextValid(String text) {
   // don't convert the text to lower case or upper case,
   //  just check if the text is in the list
-  return _acceptableConfirmTexts.contains(text);
+  return _acceptableConfirmTexts.contains(text) ||
+      text == LocaleKeys.newSettings_myAccount_deleteAccount_confirmHint3.tr();
 }
 
 Future<void> deleteMyAccount(

--- a/frontend/resources/translations/ar-SA.json
+++ b/frontend/resources/translations/ar-SA.json
@@ -2610,12 +2610,12 @@
         "dialogTitle": "حذف الحساب",
         "dialogContent1": "هل أنت متأكد أنك تريد حذف حسابك نهائياً؟",
         "dialogContent2": "لا يمكن التراجع عن هذا الإجراء، وسوف يؤدي إلى إزالة الوصول من جميع مساحات العمل، ومسح حسابك بالكامل، بما في ذلك مساحات العمل الخاصة، وإزالتك من جميع مساحات العمل المشتركة.",
-        "confirmHint1": "من فضلك اكتب \"حذف حسابي\" للتأكيد.",
+        "confirmHint1": "من فضلك اكتب \"@:newSettings.myAccount.deleteAccount.confirmHint3\" للتأكيد.",
         "confirmHint2": "أفهم أن هذا الإجراء لا رجعة فيه وسيؤدي إلى حذف حسابي وجميع البيانات المرتبطة به بشكل دائم.",
         "confirmHint3": "حذف حسابي",
         "checkToConfirmError": "يجب عليك تحديد المربع لتأكيد الحذف",
         "failedToGetCurrentUser": "فشل في الحصول على البريد الإلكتروني الحالي للمستخدم",
-        "confirmTextValidationFailed": "نص التأكيد الخاص بك لا يتطابق مع \"حذف حسابي\"",
+        "confirmTextValidationFailed": "نص التأكيد الخاص بك لا يتطابق مع \"@:newSettings.myAccount.deleteAccount.confirmHint3\"",
         "deleteAccountSuccess": "تم حذف الحساب بنجاح"
       }
     },

--- a/frontend/resources/translations/de-DE.json
+++ b/frontend/resources/translations/de-DE.json
@@ -2517,11 +2517,11 @@
         "dialogTitle": "Benutzerkonto löschen",
         "dialogContent1": "Bist du sicher, dass du dein Benutzerkonto unwiderruflich löschen möchtest?",
         "dialogContent2": "Diese Aktion kann nicht rückgängig gemacht werden und führt dazu, dass der Zugriff auf alle Teambereiche aufgehoben wird, dein gesamtes Benutzerkonto, einschließlich privater Arbeitsbereiche, gelöscht wird und du aus allen freigegebenen Arbeitsbereichen entfernt wirst.",
-        "confirmHint1": "Geben Sie zur Bestätigung bitte „MEIN KONTO LÖSCHEN“ ein.",
+        "confirmHint1": "Geben Sie zur Bestätigung bitte „@:newSettings.myAccount.deleteAccount.confirmHint3“ ein.",
         "confirmHint3": "MEIN KONTO LÖSCHEN",
         "checkToConfirmError": "Sie müssen das Kontrollkästchen aktivieren, um das Löschen zu bestätigen",
         "failedToGetCurrentUser": "Aktuelle Benutzer-E-Mail konnte nicht abgerufen werden.",
-        "confirmTextValidationFailed": "Ihr Bestätigungstext stimmt nicht mit „MEIN KONTO LÖSCHEN“ überein.",
+        "confirmTextValidationFailed": "Ihr Bestätigungstext stimmt nicht mit „@:newSettings.myAccount.deleteAccount.confirmHint3“ überein.",
         "deleteAccountSuccess": "Konto erfolgreich gelöscht"
       }
     },

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -2594,12 +2594,12 @@
         "dialogTitle": "Delete account",
         "dialogContent1": "Are you sure you want to permanently delete your account?",
         "dialogContent2": "This action cannot be undone, and will remove access from all workspaces, erasing your entire account, including private workspaces, and removing you from all shared workspaces.",
-        "confirmHint1": "Please type \"DELETE MY ACCOUNT\" to confirm.",
+        "confirmHint1": "Please type \"@:newSettings.myAccount.deleteAccount.confirmHint3\" to confirm.",
         "confirmHint2": "I understand that this action is irreversible and will permanently delete my account and all associated data.",
         "confirmHint3": "DELETE MY ACCOUNT",
         "checkToConfirmError": "You must check the box to confirm deletion",
         "failedToGetCurrentUser": "Failed to get current user email",
-        "confirmTextValidationFailed": "Your confirmation text does not match \"DELETE MY ACCOUNT\"",
+        "confirmTextValidationFailed": "Your confirmation text does not match \"@:newSettings.myAccount.deleteAccount.confirmHint3\"",
         "deleteAccountSuccess": "Account deleted successfully"
       }
     },

--- a/frontend/resources/translations/fr-FR.json
+++ b/frontend/resources/translations/fr-FR.json
@@ -2519,12 +2519,12 @@
         "dialogTitle": "Supprimer le compte",
         "dialogContent1": "Êtes-vous sûr de vouloir supprimer définitivement votre compte ?",
         "dialogContent2": "Cette action ne peut pas être annulée et supprimera l'accès à tous les espaces d'équipe, effaçant l'intégralité de votre compte, y compris les espaces de travail privés, et vous supprimant de tous les espaces de travail partagés.",
-        "confirmHint1": "Veuillez taper « SUPPRIMER MON COMPTE » pour confirmer.",
+        "confirmHint1": "Veuillez taper « @:newSettings.myAccount.deleteAccount.confirmHint3 » pour confirmer.",
         "confirmHint2": "Je comprends que cette action est irréversible et supprimera définitivement mon compte et toutes les données associées.",
         "confirmHint3": "SUPPRIMER MON COMPTE",
         "checkToConfirmError": "Vous devez cocher la case pour confirmer la suppression",
         "failedToGetCurrentUser": "Impossible d'obtenir l'e-mail de l'utilisateur actuel",
-        "confirmTextValidationFailed": "Votre texte de confirmation ne correspond pas à « SUPPRIMER MON COMPTE »",
+        "confirmTextValidationFailed": "Votre texte de confirmation ne correspond pas à « @:newSettings.myAccount.deleteAccount.confirmHint3 »",
         "deleteAccountSuccess": "Compte supprimé avec succès"
       }
     },

--- a/frontend/resources/translations/ko-KR.json
+++ b/frontend/resources/translations/ko-KR.json
@@ -2579,12 +2579,12 @@
         "dialogTitle": "계정 삭제",
         "dialogContent1": "계정을 영구적으로 삭제하시겠습니까?",
         "dialogContent2": "이 작업은 되돌릴 수 없으며, 모든 작업 공간에서 액세스를 제거하고, 개인 작업 공간을 포함한 전체 계정을 삭제하며, 모든 공유 작업 공간에서 제거됩니다.",
-        "confirmHint1": "\"내 계정 삭제\"를 입력하여 확인하세요.",
+        "confirmHint1": "\"@:newSettings.myAccount.deleteAccount.confirmHint3\"를 입력하여 확인하세요.",
         "confirmHint2": "이 작업은 되돌릴 수 없으며, 계정과 모든 관련 데이터를 영구적으로 삭제합니다.",
         "confirmHint3": "내 계정 삭제",
         "checkToConfirmError": "삭제를 확인하려면 확인란을 선택해야 합니다",
         "failedToGetCurrentUser": "현재 사용자 이메일을 가져오지 못했습니다",
-        "confirmTextValidationFailed": "확인 텍스트가 \"내 계정 삭제\"와 일치하지 않습니다",
+        "confirmTextValidationFailed": "확인 텍스트가 \"@:newSettings.myAccount.deleteAccount.confirmHint3\"와 일치하지 않습니다",
         "deleteAccountSuccess": "계정이 성공적으로 삭제되었습니다"
       }
     },

--- a/frontend/resources/translations/tr-TR.json
+++ b/frontend/resources/translations/tr-TR.json
@@ -2518,12 +2518,12 @@
         "dialogTitle": "Hesabı sil",
         "dialogContent1": "Hesabınızı kalıcı olarak silmek istediğinizden emin misiniz?",
         "dialogContent2": "Bu işlem GERİ ALINAMAZ ve tüm çalışma alanlarından erişiminizi kaldıracak, özel çalışma alanları dahil tüm hesabınızı silecek ve sizi tüm paylaşılan çalışma alanlarından çıkaracaktır.",
-        "confirmHint1": "Onaylamak için lütfen \"HESABIMI SİL\" yazın.",
+        "confirmHint1": "Onaylamak için lütfen \"@:newSettings.myAccount.deleteAccount.confirmHint3\" yazın.",
         "confirmHint2": "Bu işlemin GERİ ALINAMAZ olduğunu ve hesabımı ve ilişkili tüm verileri kalıcı olarak sileceğini anlıyorum.",
         "confirmHint3": "HESABIMI SİL",
         "checkToConfirmError": "Silme işlemini onaylamak için kutuyu işaretlemelisiniz",
         "failedToGetCurrentUser": "Mevcut kullanıcı e-postası alınamadı",
-        "confirmTextValidationFailed": "Onay metniniz \"HESABIMI SİL\" ile eşleşmiyor",
+        "confirmTextValidationFailed": "Onay metniniz \"@:newSettings.myAccount.deleteAccount.confirmHint3\" ile eşleşmiyor",
         "deleteAccountSuccess": "Hesap başarıyla silindi"
       }
     },

--- a/frontend/resources/translations/vi-VN.json
+++ b/frontend/resources/translations/vi-VN.json
@@ -2270,12 +2270,12 @@
         "dialogTitle": "Xóa tài khoản",
         "dialogContent1": "Bạn có chắc chắn muốn xóa vĩnh viễn tài khoản của mình không?",
         "dialogContent2": "Không thể hoàn tác hành động này và sẽ xóa quyền truy cập khỏi mọi không gian làm việc nhóm, xóa toàn bộ tài khoản của bạn, bao gồm cả không gian làm việc riêng tư và xóa bạn khỏi mọi không gian làm việc được chia sẻ.",
-        "confirmHint1": "Vui lòng nhập \"XÓA TÀI KHOẢN CỦA TÔI\" để xác nhận.",
+        "confirmHint1": "Vui lòng nhập \"@:newSettings.myAccount.deleteAccount.confirmHint3\" để xác nhận.",
         "confirmHint2": "Tôi hiểu rằng hành động này là không thể đảo ngược và sẽ xóa vĩnh viễn tài khoản của tôi cùng mọi dữ liệu liên quan.",
         "confirmHint3": "XÓA TÀI KHOẢN CỦA TÔI",
         "checkToConfirmError": "Bạn phải đánh dấu vào ô để xác nhận việc xóa",
         "failedToGetCurrentUser": "Không lấy được email người dùng hiện tại",
-        "confirmTextValidationFailed": "Văn bản xác nhận của bạn không khớp với \"XÓA TÀI KHOẢN CỦA TÔI\"",
+        "confirmTextValidationFailed": "Văn bản xác nhận của bạn không khớp với \"@:newSettings.myAccount.deleteAccount.confirmHint3\"",
         "deleteAccountSuccess": "Tài khoản đã được xóa thành công"
       }
     },

--- a/frontend/resources/translations/zh-CN.json
+++ b/frontend/resources/translations/zh-CN.json
@@ -1920,7 +1920,14 @@
         "deleteMyAccount": "删除我的账户",
         "dialogTitle": "删除帐户",
         "dialogContent1": "你确定要永久删除您的帐户吗？",
-        "dialogContent2": "此操作无法撤消，并且将删除所有团队空间的访问权限，删除你的整个帐户（包括私人工作区），并将你从所有共享工作区中删除。"
+        "dialogContent2": "此操作无法撤消，并且将删除所有团队空间的访问权限，删除你的整个帐户（包括私人工作区），并将你从所有共享工作区中删除。",
+        "confirmHint1": "请输入 \"@:newSettings.myAccount.deleteAccount.confirmHint3\" 以确认。",
+        "confirmHint2": "我理解此操作是不可逆的，并且将永久删除我的帐户和所有关联数据。",
+        "confirmHint3": "删除我的账户",
+        "checkToConfirmError": "你必须勾选以确认删除。",
+        "failedToGetCurrentUser": "获取当前用户邮箱失败",
+        "confirmTextValidationFailed": "你的确认文本不匹配 \"@:newSettings.myAccount.deleteAccount.confirmHint3\"",
+        "deleteAccountSuccess": "账户删除成功"
       }
     },
     "workplace": {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- support i18n in the 'delete my account' operation

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Add internationalization (i18n) support for the account deletion confirmation text

New Features:
- Implement localized confirmation text for account deletion dialog

Enhancements:
- Update account deletion confirmation text validation to support localized text

Documentation:
- Update translation files for multiple languages to support account deletion localization