### PR TITLE
chore: hide formats when using specific ai writer commands

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/desktop_prompt_text_field.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/desktop_prompt_text_field.dart
@@ -23,6 +23,7 @@ class DesktopPromptInput extends StatefulWidget {
     required this.selectedSourcesNotifier,
     required this.onUpdateSelectedSources,
     this.hideDecoration = false,
+    this.hideFormats = false,
     this.extraBottomActionButton,
   });
 
@@ -34,6 +35,7 @@ class DesktopPromptInput extends StatefulWidget {
   final ValueNotifier<List<String>> selectedSourcesNotifier;
   final void Function(List<String>) onUpdateSelectedSources;
   final bool hideDecoration;
+  final bool hideFormats;
   final Widget? extraBottomActionButton;
 
   @override
@@ -139,11 +141,11 @@ class _DesktopPromptInputState extends State<DesktopPromptInput> {
                       children: [
                         ConstrainedBox(
                           constraints: getTextFieldConstraints(
-                            state.showPredefinedFormats,
+                            state.showPredefinedFormats && !widget.hideFormats,
                           ),
                           child: inputTextField(),
                         ),
-                        if (state.showPredefinedFormats)
+                        if (state.showPredefinedFormats && !widget.hideFormats)
                           Positioned.fill(
                             bottom: null,
                             child: TextFieldTapRegion(
@@ -168,8 +170,9 @@ class _DesktopPromptInputState extends State<DesktopPromptInput> {
                           top: null,
                           child: TextFieldTapRegion(
                             child: _PromptBottomActions(
-                              showPredefinedFormats:
+                              showPredefinedFormatBar:
                                   state.showPredefinedFormats,
+                              showPredefinedFormatButton: !widget.hideFormats,
                               onTogglePredefinedFormatSection: () =>
                                   context.read<AIPromptInputBloc>().add(
                                         AIPromptInputEvent
@@ -571,7 +574,8 @@ class PromptInputTextField extends StatelessWidget {
 class _PromptBottomActions extends StatelessWidget {
   const _PromptBottomActions({
     required this.sendButtonState,
-    required this.showPredefinedFormats,
+    required this.showPredefinedFormatBar,
+    required this.showPredefinedFormatButton,
     required this.onTogglePredefinedFormatSection,
     required this.onStartMention,
     required this.onSendPressed,
@@ -581,7 +585,8 @@ class _PromptBottomActions extends StatelessWidget {
     this.extraBottomActionButton,
   });
 
-  final bool showPredefinedFormats;
+  final bool showPredefinedFormatBar;
+  final bool showPredefinedFormatButton;
   final void Function() onTogglePredefinedFormatSection;
   final void Function() onStartMention;
   final SendButtonState sendButtonState;
@@ -600,10 +605,12 @@ class _PromptBottomActions extends StatelessWidget {
         builder: (context, state) {
           return Row(
             children: [
-              _predefinedFormatButton(),
-              const HSpace(
-                DesktopAIChatSizes.inputActionBarButtonSpacing,
-              ),
+              if (showPredefinedFormatButton) ...[
+                _predefinedFormatButton(),
+                const HSpace(
+                  DesktopAIChatSizes.inputActionBarButtonSpacing,
+                ),
+              ],
               SelectModelMenu(
                 aiModelStateNotifier:
                     context.read<AIPromptInputBloc>().aiModelStateNotifier,
@@ -641,7 +648,7 @@ class _PromptBottomActions extends StatelessWidget {
 
   Widget _predefinedFormatButton() {
     return PromptInputDesktopToggleFormatButton(
-      showFormatBar: showPredefinedFormats,
+      showFormatBar: showPredefinedFormatBar,
       onTap: onTogglePredefinedFormatSection,
     );
   }

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_model_menu.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_model_menu.dart
@@ -173,7 +173,6 @@ class _ModelItem extends StatelessWidget {
               model.i18n,
               figmaLineHeight: 20,
               overflow: TextOverflow.ellipsis,
-              color: isSelected ? Theme.of(context).colorScheme.primary : null,
             ),
             if (model.desc.isNotEmpty)
               FlowyText(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_block_component.dart
@@ -490,6 +490,12 @@ class MainContentArea extends StatelessWidget {
           return DesktopPromptInput(
             isStreaming: false,
             hideDecoration: true,
+            hideFormats: [
+              AiWriterCommand.fixSpellingAndGrammar,
+              AiWriterCommand.improveWriting,
+              AiWriterCommand.makeLonger,
+              AiWriterCommand.makeShorter,
+            ].contains(state.command),
             textController: textController,
             onSubmitted: (message, format, _) {
               cubit.runCommand(state.command, message, format);


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Hide predefined format options for specific AI writer commands in the document editor

Enhancements:
- Modify AI prompt input to conditionally hide format options based on the selected AI writer command

Chores:
- Update UI components to support hiding format-related elements dynamically