### PR TITLE
fix: show cursor at end of selection when generating

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_scroll_wrapper.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_scroll_wrapper.dart
@@ -208,11 +208,26 @@ class _AiWriterScrollWrapperState extends State<AiWriterScrollWrapper> {
     throttler.call(() {
       if (aiWriterCubit.aiWriterNode != null) {
         final path = aiWriterCubit.aiWriterNode!.path;
-        if (path.isNotEmpty) {
-          widget.editorState.updateSelectionWithReason(
-            Selection.collapsed(Position(path: path)),
-          );
+
+        if (path.isEmpty) {
+          return;
         }
+
+        if (path.previous.isNotEmpty) {
+          final node = widget.editorState.getNodeAtPath(path.previous);
+          if (node != null && node.delta != null && node.delta!.isNotEmpty) {
+            widget.editorState.updateSelectionWithReason(
+              Selection.collapsed(
+                Position(path: path, offset: node.delta!.length),
+              ),
+            );
+            return;
+          }
+        }
+
+        widget.editorState.updateSelectionWithReason(
+          Selection.collapsed(Position(path: path)),
+        );
       }
     });
   }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Modify cursor placement logic to ensure the cursor is positioned at the end of the previous node's content when generating AI-written text