### PR TITLE
chore: enable integration test on windows and linux

### DIFF
--- a/.github/actions/flutter_integration_test/action.yml
+++ b/.github/actions/flutter_integration_test/action.yml
@@ -49,20 +49,43 @@ runs:
     - name: Install prerequisites
       working-directory: frontend
       run: |
-        sudo wget -qO /etc/apt/trusted.gpg.d/dart_linux_signing_key.asc https://dl-ssl.google.com/linux/linux_signing_key.pub
-        sudo wget -qO /etc/apt/sources.list.d/dart_stable.list https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list
-        sudo apt-get update
-        sudo apt-get install -y dart curl build-essential libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev keybinder-3.0 libnotify-dev network-manager
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo wget -qO /etc/apt/trusted.gpg.d/dart_linux_signing_key.asc https://dl-ssl.google.com/linux/linux_signing_key.pub
+          sudo wget -qO /etc/apt/sources.list.d/dart_stable.list https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list
+          sudo apt-get update
+          sudo apt-get install -y dart curl build-essential libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev keybinder-3.0 libnotify-dev network-manager
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          vcpkg integrate install
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          echo 'do nothing'
+        fi
       shell: bash
 
     - name: Enable Flutter Desktop
       run: |
-        flutter config --enable-linux-desktop
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          flutter config --enable-linux-desktop
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          flutter config --enable-windows-desktop
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          flutter config --enable-macos-desktop
+        fi
       shell: bash
 
     - uses: actions/download-artifact@v4
+      if: ${{ inputs.RUNNER_OS == 'Linux' }}
       with:
         name: ${{ github.run_id }}-ubuntu-latest
+
+    - uses: actions/download-artifact@v4
+      if: ${{ inputs.RUNNER_OS == 'Windows' }}
+      with:
+        name: ${{ github.run_id }}-windows-latest
+
+    - uses: actions/download-artifact@v4
+      if: ${{ inputs.RUNNER_OS == 'macOS' }}
+      with:
+        name: ${{ github.run_id }}-macos-latest
 
     - name: Uncompressed appflowy_flutter
       run: tar -xf appflowy_flutter.tar.gz
@@ -71,8 +94,14 @@ runs:
     - name: Run Flutter integration tests
       working-directory: frontend/appflowy_flutter
       run: |
-        export DISPLAY=:99
-        sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-        sudo apt-get install network-manager
-        flutter test ${{ inputs.test_path }} -d Linux --coverage
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          export DISPLAY=:99
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          sudo apt-get install network-manager
+          flutter test ${{ inputs.test_path }} -d Linux --coverage
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          flutter test ${{ inputs.test_path }} -d Windows --coverage
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          flutter test ${{ inputs.test_path }} -d macOS --coverage
+        fi
       shell: bash

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -339,7 +339,7 @@ jobs:
           flutter test integration_test/desktop/cloud/cloud_runner.dart -d Linux --coverage
         shell: bash
 
-  integration_test:
+  linux_integration_test:
     needs: [prepare-linux]
     if: github.event.pull_request.draft != true
     strategy:
@@ -350,6 +350,56 @@ jobs:
         include:
           - os: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Flutter Integration Test ${{ matrix.test_number }}
+        uses: ./.github/actions/flutter_integration_test
+        with:
+          test_path: integration_test/desktop_runner_${{ matrix.test_number }}.dart
+          flutter_version: ${{ env.FLUTTER_VERSION }}
+          rust_toolchain: ${{ env.RUST_TOOLCHAIN }}
+          cargo_make_version: ${{ env.CARGO_MAKE_VERSION }}
+          rust_target: ${{ matrix.target }}
+
+  windows_integration_test:
+    needs: [prepare-windows]
+    if: github.event.pull_request.draft != true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        test_number: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        include:
+          - os: windows-latest
+            target: "x86_64-pc-windows-msvc"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Flutter Integration Test ${{ matrix.test_number }}
+        uses: ./.github/actions/flutter_integration_test
+        with:
+          test_path: integration_test/desktop_runner_${{ matrix.test_number }}.dart
+          flutter_version: ${{ env.FLUTTER_VERSION }}
+          rust_toolchain: ${{ env.RUST_TOOLCHAIN }}
+          cargo_make_version: ${{ env.CARGO_MAKE_VERSION }}
+          rust_target: ${{ matrix.target }}
+
+  macos_integration_test:
+    needs: [prepare-macos]
+    if: github.event.pull_request.draft != true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        test_number: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        include:
+          - os: macos-latest
+            target: "x86_64-apple-darwin"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source code


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Enhance CI workflow by adding integration tests for Windows and macOS platforms, complementing the existing Linux integration tests

CI:
- Add Windows and macOS integration test jobs to the GitHub Actions workflow
- Configure integration test runners for multiple platforms with matrix strategy