### PR TITLE
fix: emoji menu should only be triggered when “:” has a followed letter

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/emoji_shortcut_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/emoji_shortcut_test.dart
@@ -43,12 +43,12 @@ void main() {
   });
 
   group('insert emoji by colon', () {
-    Future<void> createNewDocumentAndShowEmojiList(WidgetTester tester) async {
+    Future<void> createNewDocumentAndShowEmojiList(WidgetTester tester, {String? search}) async {
       await tester.initializeAppFlowy();
       await tester.tapAnonymousSignInButton();
       await tester.createNewPageWithNameUnderParent();
       await tester.editor.tapLineOfEditorAt(0);
-      await tester.ime.insertText(':');
+      await tester.ime.insertText(':${search ?? 'a'}');
       await tester.pumpAndSettle(Duration(seconds: 1));
     }
 
@@ -106,11 +106,10 @@ void main() {
     });
 
     testWidgets('insert with searching', (tester) async {
-      await createNewDocumentAndShowEmojiList(tester);
+      await createNewDocumentAndShowEmojiList(tester, search: 's');
 
       /// search for `smiling eyes`, IME is not working, use keyboard input
       final searchText = [
-        LogicalKeyboardKey.keyS,
         LogicalKeyboardKey.keyM,
         LogicalKeyboardKey.keyI,
         LogicalKeyboardKey.keyL,
@@ -138,16 +137,10 @@ void main() {
     });
 
     testWidgets('start searching with sapce', (tester) async {
-      await createNewDocumentAndShowEmojiList(tester);
+      await createNewDocumentAndShowEmojiList(tester, search: ' ');
 
       /// emoji list is showing
       final emojiHandler = find.byType(EmojiHandler);
-      expect(emojiHandler, findsOneWidget);
-
-      /// input space
-      await tester.simulateKeyEvent(LogicalKeyboardKey.space);
-
-      /// emoji list is dismissed
       expect(emojiHandler, findsNothing);
     });
   });

--- a/frontend/appflowy_flutter/lib/plugins/emoji/emoji_actions_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/emoji/emoji_actions_command.dart
@@ -1,21 +1,27 @@
 import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy_editor_plugins/appflowy_editor_plugins.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 import 'emoji_menu.dart';
 
-const emojiCharacter = ':';
+const _emojiCharacter = ':';
+final _letterRegExp = RegExp(r'^[a-zA-Z]$');
 
 CharacterShortcutEvent emojiCommand(BuildContext context) =>
     CharacterShortcutEvent(
       key: 'Opens Emoji Menu',
-      character: emojiCharacter,
-      handler: (editorState) {
-        emojiMenuService ??= EmojiMenu(
+      character: '',
+      regExp: _letterRegExp,
+      handler: (editorState) async {
+        return false;
+      },
+      handlerWithCharacter: (editorState, character) {
+        emojiMenuService = EmojiMenu(
           context: context,
           editorState: editorState,
         );
-        return emojiCommandHandler(editorState, context);
+        return emojiCommandHandler(editorState, context, character);
       },
     );
 
@@ -24,6 +30,7 @@ EmojiMenuService? emojiMenuService;
 Future<bool> emojiCommandHandler(
   EditorState editorState,
   BuildContext context,
+  String character,
 ) async {
   final selection = editorState.selection;
 
@@ -35,10 +42,30 @@ Future<bool> emojiCommandHandler(
     await editorState.deleteSelection(selection);
   }
 
-  await editorState.insertTextAtPosition(
-    emojiCharacter,
-    position: selection.start,
-  );
-  emojiMenuService?.show();
-  return true;
+  final node = editorState.getNodeAtPath(selection.end.path);
+  final delta = node?.delta;
+  if (node == null ||
+      delta == null ||
+      delta.isEmpty ||
+      node.type == CodeBlockKeys.type) {
+    return false;
+  }
+
+  if (selection.end.offset > 0) {
+    final plain = delta.toPlainText();
+
+    final previousCharacter = plain[selection.end.offset - 1];
+    if (previousCharacter != _emojiCharacter) return false;
+    if (!context.mounted) return false;
+
+    await editorState.insertTextAtPosition(
+      character,
+      position: selection.start,
+    );
+
+    emojiMenuService?.show(character);
+    return true;
+  }
+
+  return false;
 }

--- a/frontend/appflowy_flutter/lib/plugins/emoji/emoji_handler.dart
+++ b/frontend/appflowy_flutter/lib/plugins/emoji/emoji_handler.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:math';
 
 import 'package:appflowy/plugins/base/emoji/emoji_picker.dart';
@@ -25,6 +24,7 @@ class EmojiHandler extends StatefulWidget {
     required this.onEmojiSelect,
     this.startCharAmount = 1,
     this.cancelBySpaceHandler,
+    this.initialSearchText = '',
   });
 
   final EditorState editorState;
@@ -33,6 +33,7 @@ class EmojiHandler extends StatefulWidget {
   final VoidCallback onSelectionUpdate;
   final SelectEmojiItemHandler onEmojiSelect;
   final int startCharAmount;
+  final String initialSearchText;
   final bool Function()? cancelBySpaceHandler;
 
   @override
@@ -47,7 +48,7 @@ class _EmojiHandlerState extends State<EmojiHandler> {
   bool loaded = false;
   int invalidCounter = 0;
   late int startOffset;
-  String _search = '';
+  late String _search = widget.initialSearchText;
   double emojiHeight = 36.0;
   final configuration = EmojiPickerConfiguration(
     defaultSkinTone: lastSelectedEmojiSkinTone ?? EmojiSkinTone.none,
@@ -67,7 +68,7 @@ class _EmojiHandlerState extends State<EmojiHandler> {
       (_) => focusNode.requestFocus(),
     );
 
-    startOffset = widget.editorState.selection?.endIndex ?? 0;
+    startOffset = (widget.editorState.selection?.endIndex ?? 0) - 1;
 
     if (kCachedEmojiData != null) {
       loadEmojis(kCachedEmojiData!);
@@ -186,11 +187,14 @@ class _EmojiHandlerState extends State<EmojiHandler> {
         loaded = true;
       });
     }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _doSearch();
+    });
   }
 
-  Future<void> _doSearch() async {
-    if (!loaded) return;
-    if (_search.startsWith(' ')) {
+  void _doSearch() {
+    if (!loaded || !mounted) return;
+    if (_search.startsWith(' ') || _search.isEmpty) {
       widget.onDismiss.call();
       return;
     }
@@ -266,42 +270,13 @@ class _EmojiHandlerState extends State<EmojiHandler> {
       return KeyEventResult.handled;
     }
 
-    if ([LogicalKeyboardKey.arrowLeft, LogicalKeyboardKey.arrowRight]
-        .contains(event.logicalKey)) {
-      widget.onSelectionUpdate();
-
-      event.logicalKey == LogicalKeyboardKey.arrowLeft
-          ? widget.editorState.moveCursorForward()
-          : widget.editorState.moveCursorBackward(SelectionMoveRange.character);
-
-      /// If cursor moves before @ then dismiss menu
-      /// If cursor moves after @search.length then dismiss menu
-      final selection = widget.editorState.selection;
-      if (selection != null &&
-          (selection.endIndex < startOffset ||
-              selection.endIndex > (startOffset + _search.length))) {
-        widget.onDismiss.call();
-      }
-
-      /// Workaround: When using the move cursor methods, it seems the
-      ///  focus goes back to the editor, this makes sure this handler
-      ///  receives the next keypress.
-      ///
-      focusNode.requestFocus();
-
-      return KeyEventResult.handled;
-    }
-
     return KeyEventResult.handled;
   }
 
   void onSelect(int index) {
     widget.onEmojiSelect.call(
       context,
-      (
-        startOffset - widget.startCharAmount,
-        _search.length + widget.startCharAmount
-      ),
+      (startOffset - widget.startCharAmount, startOffset + _search.length),
       emojiData.getEmojiById(searchedEmojis[index].id),
     );
     widget.onDismiss.call();
@@ -324,8 +299,7 @@ class _EmojiHandlerState extends State<EmojiHandler> {
         .getTextInSelection(
           selection.copyWith(
             start: selection.start.copyWith(offset: startOffset),
-            end: selection.start
-                .copyWith(offset: startOffset + _search.length + 1),
+            end: selection.start.copyWith(offset: startOffset + _search.length + 1),
           ),
         )
         .join();
@@ -406,7 +380,7 @@ class _EmojiHandlerState extends State<EmojiHandler> {
 
     search = delta.toPlainText().substring(
           startOffset,
-          startOffset - 1 + _search.length,
+          startOffset + _search.length - 1,
         );
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/emoji/emoji_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/emoji/emoji_menu.dart
@@ -5,7 +5,7 @@ import 'emoji_actions_command.dart';
 import 'emoji_handler.dart';
 
 abstract class EmojiMenuService {
-  void show();
+  void show(String character);
 
   void dismiss();
 }
@@ -31,6 +31,7 @@ class EmojiMenu extends EmojiMenuService {
   Alignment _alignment = Alignment.topLeft;
   OverlayEntry? _menuEntry;
   bool selectionChangedByMenu = false;
+  String initialCharacter = '';
 
   @override
   void dismiss() {
@@ -56,7 +57,8 @@ class EmojiMenu extends EmojiMenuService {
   void _onSelectionUpdate() => selectionChangedByMenu = true;
 
   @override
-  void show() {
+  void show(String character) {
+    initialCharacter = character;
     WidgetsBinding.instance.addPostFrameCallback((_) => _show());
   }
 
@@ -97,6 +99,7 @@ class EmojiMenu extends EmojiMenuService {
                   onSelectionUpdate: _onSelectionUpdate,
                   startCharAmount: startCharAmount,
                   cancelBySpaceHandler: cancelBySpaceHandler,
+                  initialSearchText: initialCharacter,
                   onEmojiSelect: (
                     BuildContext context,
                     (int, int) replacement,
@@ -109,10 +112,14 @@ class EmojiMenu extends EmojiMenuService {
                         editorState.document.nodeAtPath(selection.end.path);
                     if (node == null) return;
                     final transaction = editorState.transaction
-                      ..replaceText(
+                      ..deleteText(
                         node,
                         replacement.$1,
-                        replacement.$2,
+                        replacement.$2 - replacement.$1,
+                      )
+                      ..insertText(
+                        node,
+                        replacement.$1,
                         emoji,
                       );
                     await editorState.apply(transaction);

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -98,8 +98,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d5c9f64
-      resolved-ref: d5c9f64ebe23642f8c0e12282816992da8b8180a
+      ref: "552f95f"
+      resolved-ref: "552f95fd15627e10a138c6db2a6d0a8089bc9a25"
       url: "https://github.com/AppFlowy-IO/appflowy-editor.git"
     source: git
     version: "5.1.0"

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -184,7 +184,7 @@ dependency_overrides:
   appflowy_editor:
     git:
       url: https://github.com/AppFlowy-IO/appflowy-editor.git
-      ref: "d5c9f64"
+      ref: "552f95f"
 
   appflowy_editor_plugins:
     git:


### PR DESCRIPTION
https://github.com/user-attachments/assets/c596a8f2-3650-4133-8045-826cec0407a4


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Improve emoji menu trigger mechanism to only activate when a colon is followed by a letter

Bug Fixes:
- Fix emoji menu activation to require a letter immediately after the colon, preventing unintended emoji menu triggers

Enhancements:
- Refactor emoji shortcut handling to add more precise activation conditions
- Modify emoji menu initialization to support initial search text