### PR TITLE
fix: translations

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
@@ -203,7 +203,7 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
       );
       showToastNotification(
         context,
-        message: LocaleKeys.grid_url_copy.tr(),
+        message: LocaleKeys.message_copy_success.tr(),
       );
     }
   }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -185,7 +185,7 @@ class CopyButton extends StatelessWidget {
           if (context.mounted) {
             showToastNotification(
               context,
-              message: LocaleKeys.grid_url_copiedNotification.tr(),
+              message: LocaleKeys.message_copy_success.tr(),
             );
           }
         },

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_bubble.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_bubble.dart
@@ -377,7 +377,7 @@ class ChatAIMessagePopup extends StatelessWidget {
         if (context.mounted) {
           showToastNotification(
             context,
-            message: LocaleKeys.grid_url_copiedNotification.tr(),
+            message: LocaleKeys.message_copy_success.tr(),
           );
         }
       },

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/url.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/url.dart
@@ -203,7 +203,7 @@ class MobileURLEditor extends StatelessWidget {
               ClipboardData(text: textEditingController.text),
             );
             Fluttertoast.showToast(
-              msg: LocaleKeys.grid_url_copiedNotification.tr(),
+              msg: LocaleKeys.message_copy_success.tr(),
               gravity: ToastGravity.BOTTOM,
             );
             context.pop();

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/export_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/export_tab.dart
@@ -175,7 +175,7 @@ class ExportTab extends StatelessWidget {
         );
         showToastNotification(
           context,
-          message: LocaleKeys.grid_url_copiedNotification.tr(),
+          message: LocaleKeys.message_copy_success.tr(),
         );
       },
       (error) => showToastNotification(context, message: error.msg),

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/publish_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/publish_tab.dart
@@ -183,7 +183,7 @@ class _PublishedWidgetState extends State<_PublishedWidget> {
 
             showToastNotification(
               context,
-              message: LocaleKeys.grid_url_copy.tr(),
+              message: LocaleKeys.message_copy_success.tr(),
             );
           },
           onSubmitted: (pathName) {

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/share_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/share_tab.dart
@@ -118,7 +118,7 @@ class _ShareTabContent extends StatelessWidget {
 
     showToastNotification(
       context,
-      message: LocaleKeys.grid_url_copy.tr(),
+      message: LocaleKeys.message_copy_success.tr(),
     );
   }
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/constants.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/constants.dart
@@ -54,7 +54,7 @@ class SettingsPageSitesEvent {
     getIt<ClipboardService>().setData(ClipboardServiceData(plainText: url));
     showToastNotification(
       context,
-      message: LocaleKeys.grid_url_copy.tr(),
+      message: LocaleKeys.message_copy_success.tr(),
     );
   }
 }

--- a/frontend/resources/translations/ar-SA.json
+++ b/frontend/resources/translations/ar-SA.json
@@ -1672,8 +1672,7 @@
     "url": {
       "launch": "فتح في المتصفح",
       "copy": "إنسخ الرابط",
-      "textFieldHint": "أدخل عنوان URL",
-      "copiedNotification": "تمت نسخها إلى الحافظة!"
+      "textFieldHint": "أدخل عنوان URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "قاعدة البيانات ذات الصلة",

--- a/frontend/resources/translations/de-DE.json
+++ b/frontend/resources/translations/de-DE.json
@@ -1625,8 +1625,7 @@
     "url": {
       "launch": "Im Browser öffnen",
       "copy": "Webadresse kopieren",
-      "textFieldHint": "Gebe eine URL ein",
-      "copiedNotification": "In die Zwischenablage kopiert!"
+      "textFieldHint": "Gebe eine URL ein"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Verwandte Datenbank",

--- a/frontend/resources/translations/el-GR.json
+++ b/frontend/resources/translations/el-GR.json
@@ -723,9 +723,8 @@
     },
     "url": {
       "launch": "Άνοιγμα συνδέσμου στο πρόγραμμα περιήγησης",
-      "copy": "Copied link to clipboard",
-      "textFieldHint": "Enter a URL",
-      "copiedNotification": "Copied to clipboard!"
+      "copy": "Copy link to clipboard",
+      "textFieldHint": "Enter a URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Related Database",

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -1647,9 +1647,8 @@
     },
     "url": {
       "launch": "Open link in browser",
-      "copy": "Copied link to clipboard",
-      "textFieldHint": "Enter a URL",
-      "copiedNotification": "Copied to clipboard!"
+      "copy": "Copy link to clipboard",
+      "textFieldHint": "Enter a URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Related Database",
@@ -2273,7 +2272,7 @@
   },
   "message": {
     "copy": {
-      "success": "Copied!",
+      "success": "Copied to clipboard",
       "fail": "Unable to copy"
     }
   },

--- a/frontend/resources/translations/es-VE.json
+++ b/frontend/resources/translations/es-VE.json
@@ -866,8 +866,7 @@
     "url": {
       "launch": "Abrir en el navegador",
       "copy": "Copiar URL",
-      "textFieldHint": "Introduce una URL",
-      "copiedNotification": "¡Copiado al portapapeles!"
+      "textFieldHint": "Introduce una URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Base de datos relacionada",

--- a/frontend/resources/translations/fr-FR.json
+++ b/frontend/resources/translations/fr-FR.json
@@ -1612,8 +1612,7 @@
     "url": {
       "launch": "Ouvrir dans le navigateur",
       "copy": "Copier l'URL",
-      "textFieldHint": "Entrez une URL",
-      "copiedNotification": "Copié dans le presse-papier!"
+      "textFieldHint": "Entrez une URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Base de données associée",

--- a/frontend/resources/translations/he.json
+++ b/frontend/resources/translations/he.json
@@ -1243,8 +1243,7 @@
     "url": {
       "launch": "פתיחת קישור בדפדפן",
       "copy": "העתקת קישור ללוח הגזירים",
-      "textFieldHint": "נא למלא כתובת",
-      "copiedNotification": "הועתק ללוח הגזירים!"
+      "textFieldHint": "נא למלא כתובת"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "מסד נתונים קשור",

--- a/frontend/resources/translations/ja-JP.json
+++ b/frontend/resources/translations/ja-JP.json
@@ -1577,8 +1577,7 @@
     "url": {
       "launch": "リンクをブラウザで開く",
       "copy": "リンクをクリップボードにコピー",
-      "textFieldHint": "URLを入力",
-      "copiedNotification": "クリップボードにコピーされました！"
+      "textFieldHint": "URLを入力"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "関連データベース",

--- a/frontend/resources/translations/ko-KR.json
+++ b/frontend/resources/translations/ko-KR.json
@@ -1634,8 +1634,7 @@
     "url": {
       "launch": "브라우저에서 링크 열기",
       "copy": "링크를 클립보드에 복사",
-      "textFieldHint": "URL 입력",
-      "copiedNotification": "클립보드에 복사되었습니다!"
+      "textFieldHint": "URL 입력"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "관련 데이터베이스",

--- a/frontend/resources/translations/ru-RU.json
+++ b/frontend/resources/translations/ru-RU.json
@@ -1420,8 +1420,7 @@
     "url": {
       "launch": "Открыть в браузере",
       "copy": "Скопировать URL",
-      "textFieldHint": "Введите URL-адрес",
-      "copiedNotification": "Скопировано в буфер обмена!"
+      "textFieldHint": "Введите URL-адрес"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Связанная база данных",

--- a/frontend/resources/translations/th-TH.json
+++ b/frontend/resources/translations/th-TH.json
@@ -1570,8 +1570,7 @@
     "url": {
       "launch": "เปิดในเบราว์เซอร์",
       "copy": "คัดลอก URL",
-      "textFieldHint": "ป้อน URL",
-      "copiedNotification": "คัดลอกไปยังคลิปบอร์ดแล้ว!"
+      "textFieldHint": "ป้อน URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "ฐานข้อมูลที่เกี่ยวข้อง",

--- a/frontend/resources/translations/tr-TR.json
+++ b/frontend/resources/translations/tr-TR.json
@@ -1608,8 +1608,7 @@
     "url": {
       "launch": "Bağlantıyı tarayıcıda aç",
       "copy": "Bağlantıyı panoya kopyala",
-      "textFieldHint": "Bir URL girin",
-      "copiedNotification": "Panoya kopyalandı!"
+      "textFieldHint": "Bir URL girin"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "İlişkili Veritabanı",

--- a/frontend/resources/translations/uk-UA.json
+++ b/frontend/resources/translations/uk-UA.json
@@ -1445,8 +1445,7 @@
     "url": {
       "launch": "Відкрити посилання в браузері",
       "copy": "Копіювати посилання в буфер обміну",
-      "textFieldHint": "Введіть URL",
-      "copiedNotification": "Скопійовано в буфер обміну!"
+      "textFieldHint": "Введіть URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Пов'язана база даних",

--- a/frontend/resources/translations/vi-VN.json
+++ b/frontend/resources/translations/vi-VN.json
@@ -1439,8 +1439,7 @@
     "url": {
       "launch": "Mở liên kết trong trình duyệt",
       "copy": "Sao chép URL",
-      "textFieldHint": "Nhập một URL",
-      "copiedNotification": "Đã sao chép vào bảng tạm!"
+      "textFieldHint": "Nhập một URL"
     },
     "relation": {
       "relatedDatabasePlaceLabel": "Cơ sở dữ liệu liên quan",

--- a/frontend/resources/translations/zh-CN.json
+++ b/frontend/resources/translations/zh-CN.json
@@ -1270,8 +1270,7 @@
     "url": {
       "launch": "在浏览器中打开链接",
       "copy": "将链接复制到剪贴板",
-      "textFieldHint": "输入 URL",
-      "copiedNotification": "已复制到剪贴板！"
+      "textFieldHint": "输入 URL"
     },
     "relation": {
       "rowSearchTextFieldPlaceholder": "搜索"

--- a/frontend/resources/translations/zh-TW.json
+++ b/frontend/resources/translations/zh-TW.json
@@ -838,8 +838,7 @@
     "url": {
       "launch": "在瀏覽器中開啟",
       "copy": "複製網址",
-      "textFieldHint": "輸入網址",
-      "copiedNotification": "已複製到剪貼簿"
+      "textFieldHint": "輸入網址"
     },
     "menuName": "網格",
     "referencedGridPrefix": "檢視",


### PR DESCRIPTION
1. Stop using grid_url_copy for toast notifications and use message_copy_success instead
2. Remove grid_url_copiedNotification tokens

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Update translation tokens for copy success notifications across multiple files

Bug Fixes:
- Replace deprecated grid-related copy notification tokens with a more generic message_copy_success token

Enhancements:
- Standardize copy success notifications across different parts of the application