### PR TITLE
fix: replace the selected text with ai response in the same line

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_cubit.dart
@@ -211,13 +211,20 @@ class AiWriterCubit extends Cubit<AiWriterState> {
       return;
     }
 
+    // Accept
+    //
+    // If the user clicks accept, we need to replace the selection with the AI's response
     if (action case SuggestionAction.accept) {
       await _textRobot.persist();
+
+      // Clear the format of the selected text.
+      // From grey color to the original color.
       await formatSelection(
         editorState,
         selection,
         ApplySuggestionFormatType.clear,
       );
+
       final nodes = editorState.getNodesInSelection(selection);
       final transaction = editorState.transaction..deleteNodes(nodes);
       await editorState.apply(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_node_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_node_extension.dart
@@ -57,11 +57,27 @@ extension AiWriterNodeExtension on EditorState {
       slicedNodes.add(copiedNode);
     }
 
+    for (final (i, node) in slicedNodes.indexed) {
+      final childNodesShouldBeDeleted = <Node>[];
+      for (final child in node.children) {
+        if (!child.path.inSelection(selection)) {
+          childNodesShouldBeDeleted.add(child);
+        }
+      }
+      for (final child in childNodesShouldBeDeleted) {
+        slicedNodes[i] = node.copyWith(
+          children: node.children.where((e) => e.id != child.id).toList(),
+          type: selection.startIndex != 0 ? ParagraphBlockKeys.type : node.type,
+        );
+      }
+    }
+
     final markdown = await customDocumentToMarkdown(
       Document.blank()..insert([0], slicedNodes),
     );
 
-    return markdown;
+    // trim the last \n if it exists
+    return markdown.trimRight();
   }
 
   List<String> getPlainTextInSelection(Selection? selection) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_node_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_node_extension.dart
@@ -72,8 +72,11 @@ extension AiWriterNodeExtension on EditorState {
       }
     }
 
+    // use \n\n as line break to improve the ai response
+    // using \n will cause the ai response treat the text as a single line
     final markdown = await customDocumentToMarkdown(
       Document.blank()..insert([0], slicedNodes),
+      lineBreak: '\n\n',
     );
 
     // trim the last \n if it exists

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
@@ -424,6 +424,7 @@ class MarkdownTextRobot {
         firstMarkdownDelta != null) {
       final startIndex = selection.startIndex;
       final length = delta.length - startIndex;
+
       transaction
         ..deleteText(firstNode, startIndex, length)
         ..insertTextDelta(firstNode, startIndex, firstMarkdownDelta);
@@ -439,7 +440,9 @@ class MarkdownTextRobot {
         lastMarkdownNode != null &&
         lastMarkdownDelta != null) {
       final endIndex = selection.endIndex;
+
       transaction.deleteText(lastNode, 0, endIndex);
+
       // if the last node is same as the first node, it means we have replaced the
       // selected text in the first node.
       if (lastMarkdownNode.id != firstMarkdownNode?.id) {
@@ -457,8 +460,9 @@ class MarkdownTextRobot {
     }
 
     // step 4
-    if (nodes.length > 2) {
-      final middleNodes = nodes.skip(1).take(nodes.length - 2).toList();
+    final length = nodes.length - 2;
+    if (length > 0) {
+      final middleNodes = nodes.skip(1).take(length).toList();
       transaction.deleteNodes(middleNodes);
     }
 

--- a/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
+++ b/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
@@ -27,6 +27,7 @@ Future<String> customDocumentToMarkdown(
   Document document, {
   String path = '',
   AsyncValueSetter<Archive>? onArchive,
+  String lineBreak = '',
 }) async {
   final List<Future<ArchiveFile>> fileFutures = [];
 
@@ -41,7 +42,7 @@ Future<String> customDocumentToMarkdown(
   try {
     markdown = documentToMarkdown(
       document,
-      lineBreak: '\n\n',
+      lineBreak: lineBreak,
       customParsers: [
         const MathEquationNodeParser(),
         const CalloutNodeParser(),

--- a/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
+++ b/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
@@ -41,6 +41,7 @@ Future<String> customDocumentToMarkdown(
   try {
     markdown = documentToMarkdown(
       document,
+      lineBreak: '\n\n',
       customParsers: [
         const MathEquationNodeParser(),
         const CalloutNodeParser(),

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -98,8 +98,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "552f95f"
-      resolved-ref: "552f95fd15627e10a138c6db2a6d0a8089bc9a25"
+      ref: "361b99c38370abeeb19656f89e8c31cb3666623b"
+      resolved-ref: "361b99c38370abeeb19656f89e8c31cb3666623b"
       url: "https://github.com/AppFlowy-IO/appflowy-editor.git"
     source: git
     version: "5.1.0"

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -184,7 +184,7 @@ dependency_overrides:
   appflowy_editor:
     git:
       url: https://github.com/AppFlowy-IO/appflowy-editor.git
-      ref: "552f95f"
+      ref: "361b99c38370abeeb19656f89e8c31cb3666623b"
 
   appflowy_editor_plugins:
     git:

--- a/frontend/appflowy_flutter/test/bloc_test/ai_writer_test/ai_writer_bloc_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/ai_writer_test/ai_writer_bloc_test.dart
@@ -375,7 +375,7 @@ void main() {
       await blocResponseFuture();
       bloc.runResponseAction(SuggestionAction.accept);
       await blocResponseFuture();
-      expect(editorState.document.root.children.length, 1);
+      expect(editorState.document.root.children.length, 2);
       expect(
         editorState.getNodeAtPath([0])!.delta!.toPlainText(),
         'Hello World',

--- a/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
@@ -732,6 +732,75 @@ Email became **widely prevalent**, and instant messaging services like *ICQ* and
         expect(d7.attributes, null);
       }
     });
+
+    test(
+        'the length of the returned response less than the length of the selected text',
+        () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+          offset: 'The introduction of the World Wide Web'.length,
+        ),
+        end: Position(
+          path: [2],
+          offset:
+              'Email became widespread, and instant messaging services like ICQ and AOL Instant Messenger gained popularity'
+                  .length,
+        ),
+      );
+
+      final markdownText =
+          ''' in the **early 1990s** marked a *significant turning point* in technological history.''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterNodes = editorState.document.root.children;
+      expect(afterNodes.length, 2);
+
+      {
+        // first paragraph
+        final delta1 = afterNodes[0].delta!.toList();
+        expect(delta1.length, 5);
+
+        final d1 = delta1[0] as TextInsert;
+        expect(d1.text, "The introduction of the World Wide Web in the ");
+        expect(d1.attributes, null);
+
+        final d2 = delta1[1] as TextInsert;
+        expect(d2.text, "early 1990s");
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta1[2] as TextInsert;
+        expect(d3.text, " marked a ");
+        expect(d3.attributes, null);
+
+        final d4 = delta1[3] as TextInsert;
+        expect(d4.text, "significant turning point");
+        expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d5 = delta1[4] as TextInsert;
+        expect(d5.text, " in technological history.");
+        expect(d5.attributes, null);
+      }
+
+      {
+        // second paragraph
+        final delta2 = afterNodes[1].delta!.toList();
+        expect(delta2.length, 1);
+
+        final d1 = delta2[0] as TextInsert;
+        expect(d1.text, ", allowing for real-time text communication.");
+        expect(d1.attributes, null);
+      }
+    });
   });
 }
 

--- a/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
@@ -294,6 +294,200 @@ void main() {
       );
     });
   });
+
+  group('markdown text robot - replace in same line:', () {
+    final text1 =
+        '''The introduction of the World Wide Web in the early 1990s marked a turning point. ''';
+    final text2 =
+        '''Tim Berners-Lee's invention made the internet accessible to non-technical users, opening the floodgates for mass adoption. ''';
+    final text3 =
+        '''Email became widespread, and instant messaging services like ICQ and AOL Instant Messenger gained popularity, allowing for real-time text communication.''';
+
+    Document buildTestDocument() {
+      return Document(
+        root: pageNode(
+          children: [
+            paragraphNode(delta: Delta()..insert(text1 + text2 + text3)),
+          ],
+        ),
+      );
+    }
+
+    // 1. create a document with a paragraph node
+    // 2. use the text robot to replace the selected content in the same line
+    // 3. check the document
+    test('the selection is in the middle of the text', () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+          offset: text1.length,
+        ),
+        end: Position(
+          path: [0],
+          offset: text1.length + text2.length,
+        ),
+      );
+
+      final markdownText =
+          '''Tim Berners-Lee's invention of the **World Wide Web** transformed the internet, making it accessible to _non-technical users_ and opening the floodgates for global mass adoption.''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterDelta = editorState.document.root.children[0].delta!.toList();
+      expect(afterDelta.length, 5);
+
+      final d1 = afterDelta[0] as TextInsert;
+      expect(d1.text, '${text1}Tim Berners-Lee\'s invention of the ');
+      expect(d1.attributes, null);
+
+      final d2 = afterDelta[1] as TextInsert;
+      expect(d2.text, 'World Wide Web');
+      expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+      final d3 = afterDelta[2] as TextInsert;
+      expect(d3.text, ' transformed the internet, making it accessible to ');
+      expect(d3.attributes, null);
+
+      final d4 = afterDelta[3] as TextInsert;
+      expect(d4.text, 'non-technical users');
+      expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+      final d5 = afterDelta[4] as TextInsert;
+      expect(
+        d5.text,
+        ' and opening the floodgates for global mass adoption.$text3',
+      );
+      expect(d5.attributes, null);
+    });
+
+    test('replace markdown text with selection from start to middle', () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+        ),
+        end: Position(
+          path: [0],
+          offset: text1.length,
+        ),
+      );
+
+      final markdownText =
+          '''The **invention** of the _World Wide Web_ by Tim Berners-Lee transformed how we access information.''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterDelta = editorState.document.root.children[0].delta!.toList();
+      expect(afterDelta.length, 5);
+
+      final d1 = afterDelta[0] as TextInsert;
+      expect(d1.text, 'The ');
+      expect(d1.attributes, null);
+
+      final d2 = afterDelta[1] as TextInsert;
+      expect(d2.text, 'invention');
+      expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+      final d3 = afterDelta[2] as TextInsert;
+      expect(d3.text, ' of the ');
+      expect(d3.attributes, null);
+
+      final d4 = afterDelta[3] as TextInsert;
+      expect(d4.text, 'World Wide Web');
+      expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+      final d5 = afterDelta[4] as TextInsert;
+      expect(
+        d5.text,
+        ' by Tim Berners-Lee transformed how we access information.$text2$text3',
+      );
+      expect(d5.attributes, null);
+    });
+
+    test('replace markdown text with selection from middle to end', () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+          offset: text1.length + text2.length,
+        ),
+        end: Position(
+          path: [0],
+          offset: text1.length + text2.length + text3.length,
+        ),
+      );
+
+      final markdownText =
+          '''**Email** became widespread, and instant messaging services like *ICQ* and **AOL Instant Messenger** gained tremendous popularity, allowing for seamless real-time text communication across the globe.''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterDelta = editorState.document.root.children[0].delta!.toList();
+      expect(afterDelta.length, 7);
+
+      final d1 = afterDelta[0] as TextInsert;
+      expect(
+        d1.text,
+        text1 + text2,
+      );
+      expect(d1.attributes, null);
+
+      final d2 = afterDelta[1] as TextInsert;
+      expect(d2.text, 'Email');
+      expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+      final d3 = afterDelta[2] as TextInsert;
+      expect(
+        d3.text,
+        ' became widespread, and instant messaging services like ',
+      );
+      expect(d3.attributes, null);
+
+      final d4 = afterDelta[3] as TextInsert;
+      expect(d4.text, 'ICQ');
+      expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+      final d5 = afterDelta[4] as TextInsert;
+      expect(d5.text, ' and ');
+      expect(d5.attributes, null);
+
+      final d6 = afterDelta[5] as TextInsert;
+      expect(
+        d6.text,
+        'AOL Instant Messenger',
+      );
+      expect(d6.attributes, {AppFlowyRichTextKeys.bold: true});
+
+      final d7 = afterDelta[6] as TextInsert;
+      expect(
+        d7.text,
+        ' gained tremendous popularity, allowing for seamless real-time text communication across the globe.',
+      );
+      expect(d7.attributes, null);
+    });
+  });
 }
 
 const _sample1 = '''# The Curious Cat

--- a/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
@@ -488,6 +488,251 @@ void main() {
       expect(d7.attributes, null);
     });
   });
+
+  group('markdown text robot - replace in multiple lines:', () {
+    final text1 =
+        '''The introduction of the World Wide Web in the early 1990s marked a turning point. ''';
+    final text2 =
+        '''Tim Berners-Lee's invention made the internet accessible to non-technical users, opening the floodgates for mass adoption. ''';
+    final text3 =
+        '''Email became widespread, and instant messaging services like ICQ and AOL Instant Messenger gained popularity, allowing for real-time text communication.''';
+
+    Document buildTestDocument() {
+      return Document(
+        root: pageNode(
+          children: [
+            paragraphNode(delta: Delta()..insert(text1)),
+            paragraphNode(delta: Delta()..insert(text2)),
+            paragraphNode(delta: Delta()..insert(text3)),
+          ],
+        ),
+      );
+    }
+
+    // 1. create a document with 3 paragraph nodes
+    // 2. use the text robot to replace the selected content in the multiple lines
+    // 3. check the document
+    test(
+        'the selection starts with the first paragraph and ends with the middle of second paragraph',
+        () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+        ),
+        end: Position(
+          path: [1],
+          offset: text2.length -
+              ', opening the floodgates for mass adoption. '.length,
+        ),
+      );
+
+      final markdownText =
+          '''The **introduction** of the World Wide Web in the *early 1990s* marked a significant turning point.
+
+Tim Berners-Lee's **revolutionary invention** made the internet accessible to non-technical users''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterNodes = editorState.document.root.children;
+      expect(afterNodes.length, 3);
+
+      {
+        // first paragraph
+        final delta1 = afterNodes[0].delta!.toList();
+        expect(delta1.length, 5);
+
+        final d1 = delta1[0] as TextInsert;
+        expect(d1.text, 'The ');
+        expect(d1.attributes, null);
+
+        final d2 = delta1[1] as TextInsert;
+        expect(d2.text, 'introduction');
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta1[2] as TextInsert;
+        expect(d3.text, ' of the World Wide Web in the ');
+        expect(d3.attributes, null);
+
+        final d4 = delta1[3] as TextInsert;
+        expect(d4.text, 'early 1990s');
+        expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d5 = delta1[4] as TextInsert;
+        expect(d5.text, ' marked a significant turning point.');
+        expect(d5.attributes, null);
+      }
+
+      {
+        // second paragraph
+        final delta2 = afterNodes[1].delta!.toList();
+        expect(delta2.length, 3);
+
+        final d1 = delta2[0] as TextInsert;
+        expect(d1.text, "Tim Berners-Lee's ");
+        expect(d1.attributes, null);
+
+        final d2 = delta2[1] as TextInsert;
+        expect(d2.text, "revolutionary invention");
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta2[2] as TextInsert;
+        expect(
+          d3.text,
+          " made the internet accessible to non-technical users, opening the floodgates for mass adoption. ",
+        );
+        expect(d3.attributes, null);
+      }
+
+      {
+        // third paragraph
+        final delta3 = afterNodes[2].delta!.toList();
+        expect(delta3.length, 1);
+
+        final d1 = delta3[0] as TextInsert;
+        expect(d1.text, text3);
+        expect(d1.attributes, null);
+      }
+    });
+
+    test(
+        'the selection starts with the middle of the first paragraph and ends with the middle of last paragraph',
+        () async {
+      final document = buildTestDocument();
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(
+          path: [0],
+          offset: 'The introduction of the World Wide Web'.length,
+        ),
+        end: Position(
+          path: [2],
+          offset:
+              'Email became widespread, and instant messaging services like ICQ and AOL Instant Messenger gained popularity'
+                  .length,
+        ),
+      );
+
+      final markdownText =
+          ''' in the **early 1990s** marked a *significant turning point* in technological history.
+
+Tim Berners-Lee's **revolutionary invention** made the internet accessible to non-technical users, opening the floodgates for *unprecedented mass adoption*.
+
+Email became **widely prevalent**, and instant messaging services like *ICQ* and *AOL Instant Messenger* gained tremendous popularity
+          ''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final afterNodes = editorState.document.root.children;
+      expect(afterNodes.length, 3);
+
+      {
+        // first paragraph
+        final delta1 = afterNodes[0].delta!.toList();
+        expect(delta1.length, 5);
+
+        final d1 = delta1[0] as TextInsert;
+        expect(d1.text, 'The introduction of the World Wide Web in the ');
+        expect(d1.attributes, null);
+
+        final d2 = delta1[1] as TextInsert;
+        expect(d2.text, 'early 1990s');
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta1[2] as TextInsert;
+        expect(d3.text, ' marked a ');
+        expect(d3.attributes, null);
+
+        final d4 = delta1[3] as TextInsert;
+        expect(d4.text, 'significant turning point');
+        expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d5 = delta1[4] as TextInsert;
+        expect(d5.text, ' in technological history.');
+        expect(d5.attributes, null);
+      }
+
+      {
+        // second paragraph
+        final delta2 = afterNodes[1].delta!.toList();
+        expect(delta2.length, 5);
+
+        final d1 = delta2[0] as TextInsert;
+        expect(d1.text, "Tim Berners-Lee's ");
+        expect(d1.attributes, null);
+
+        final d2 = delta2[1] as TextInsert;
+        expect(d2.text, "revolutionary invention");
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta2[2] as TextInsert;
+        expect(
+          d3.text,
+          " made the internet accessible to non-technical users, opening the floodgates for ",
+        );
+        expect(d3.attributes, null);
+
+        final d4 = delta2[3] as TextInsert;
+        expect(d4.text, "unprecedented mass adoption");
+        expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d5 = delta2[4] as TextInsert;
+        expect(d5.text, ".");
+        expect(d5.attributes, null);
+      }
+
+      {
+        // third paragraph
+        // third paragraph
+        final delta3 = afterNodes[2].delta!.toList();
+        expect(delta3.length, 7);
+
+        final d1 = delta3[0] as TextInsert;
+        expect(d1.text, "Email became ");
+        expect(d1.attributes, null);
+
+        final d2 = delta3[1] as TextInsert;
+        expect(d2.text, "widely prevalent");
+        expect(d2.attributes, {AppFlowyRichTextKeys.bold: true});
+
+        final d3 = delta3[2] as TextInsert;
+        expect(d3.text, ", and instant messaging services like ");
+        expect(d3.attributes, null);
+
+        final d4 = delta3[3] as TextInsert;
+        expect(d4.text, "ICQ");
+        expect(d4.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d5 = delta3[4] as TextInsert;
+        expect(d5.text, " and ");
+        expect(d5.attributes, null);
+
+        final d6 = delta3[5] as TextInsert;
+        expect(d6.text, "AOL Instant Messenger");
+        expect(d6.attributes, {AppFlowyRichTextKeys.italic: true});
+
+        final d7 = delta3[6] as TextInsert;
+        expect(
+          d7.text,
+          " gained tremendous popularity, allowing for real-time text communication.",
+        );
+        expect(d7.attributes, null);
+      }
+    });
+  });
 }
 
 const _sample1 = '''# The Curious Cat


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- [x] replace the selected text with ai response in the same line
- [x] replace the selected text with ai response in the multiple lines
- [x] only pass the selected content to ai writer

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Implement functionality to replace selected text with AI-generated markdown response within the same line or across multiple lines in the document editor

New Features:
- Add a new method to replace selected text with AI-generated markdown response, supporting both single-line and multi-line text replacements

Enhancements:
- Extend the MarkdownTextRobot class to support text replacement with markdown formatting
- Improve AI writer functionality to handle text selection replacement

Tests:
- Add comprehensive unit tests for replacing text in different selection scenarios (start, middle, and end of a paragraph)