### PR TITLE
fix: use normal underline for AI suggested text style

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -568,7 +568,6 @@ class EditorStyleCustomizer {
     if (style == null) {
       return null;
     }
-    final fontSize = style.fontSize ?? 14.0;
     final isLight = Theme.of(context).isLightMode;
     final textColor = isLight ? Color(0xFF007296) : Color(0xFF49CFF4);
     final underlineColor = isLight ? Color(0x33005A7A) : Color(0x3349CFF4);
@@ -578,17 +577,10 @@ class EditorStyleCustomizer {
           decoration: TextDecoration.lineThrough,
         ),
       AiWriterBlockKeys.suggestionReplacement => style.copyWith(
-          color: Colors.transparent,
+          color: textColor,
           decoration: TextDecoration.underline,
           decorationColor: underlineColor,
           decorationThickness: 1.0,
-          // hack: https://jtmuller5.medium.com/the-ultimate-guide-to-underlining-text-in-flutter-57936f5c79bb
-          shadows: [
-            Shadow(
-              color: textColor,
-              offset: Offset(0, -fontSize * 0.2),
-            ),
-          ],
         ),
       _ => style,
     };


### PR DESCRIPTION
This resolves an issue where the text isn't aligned vertically

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Modify the text style for AI suggested text to use a normal underline instead of a transparent color with shadow hack

Bug Fixes:
- Simplify the text styling for AI suggested text by removing a complex shadow-based transparency technique

Enhancements:
- Improve the visual representation of AI suggested text by using a direct underline with color