### PR TITLE
fix: overwriting a selected text removes more than expected

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/emoji/emoji_actions_command.dart
+++ b/frontend/appflowy_flutter/lib/plugins/emoji/emoji_actions_command.dart
@@ -38,10 +38,6 @@ Future<bool> emojiCommandHandler(
     return false;
   }
 
-  if (!selection.isCollapsed) {
-    await editorState.deleteSelection(selection);
-  }
-
   final node = editorState.getNodeAtPath(selection.end.path);
   final delta = node?.delta;
   if (node == null ||
@@ -57,6 +53,10 @@ Future<bool> emojiCommandHandler(
     final previousCharacter = plain[selection.end.offset - 1];
     if (previousCharacter != _emojiCharacter) return false;
     if (!context.mounted) return false;
+
+    if (!selection.isCollapsed) {
+      await editorState.deleteSelection(selection);
+    }
 
     await editorState.insertTextAtPosition(
       character,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

If the emoji panel is not open, do not trigger the emoji handler to avoid unintentionally deleting characters.

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Corrects the text deletion behavior when inserting an emoji over a selected text, ensuring only the selected text is removed before emoji insertion