### PR TITLE
chore: toast message when theme folder doesn't have permission

### DIFF
--- a/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
+++ b/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
@@ -133,7 +133,6 @@ Future<bool> _afLaunchLocalUri(
   };
   if (context != null && context.mounted) {
     showToastNotification(
-      context,
       message: message,
       type: result.type == ResultType.done
           ? ToastificationType.success

--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/mobile_view_page.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/mobile_view_page.dart
@@ -336,7 +336,6 @@ class _MobileViewPageState extends State<MobileViewPage> {
       listener: (context, state) {
         if (state.isLocked) {
           showToastNotification(
-            context,
             message: LocaleKeys.lockPage_pageLockedToast.tr(),
           );
 
@@ -366,7 +365,6 @@ class _MobileViewPageState extends State<MobileViewPage> {
       listener: (context, state) {
         if (state.isLocked) {
           showToastNotification(
-            context,
             message: LocaleKeys.lockPage_pageLockedToast.tr(),
           );
         }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/base/view_page/more_bottom_sheet.dart
@@ -161,7 +161,6 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
     context.pop();
 
     showToastNotification(
-      context,
       message: LocaleKeys.button_duplicateSuccessfully.tr(),
     );
   }
@@ -170,7 +169,6 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
     _toggleFavorite(context);
 
     showToastNotification(
-      context,
       message: LocaleKeys.button_favoriteSuccessfully.tr(),
     );
   }
@@ -179,7 +177,6 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
     _toggleFavorite(context);
 
     showToastNotification(
-      context,
       message: LocaleKeys.button_unfavoriteSuccessfully.tr(),
     );
   }
@@ -202,7 +199,6 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
         ),
       );
       showToastNotification(
-        context,
         message: LocaleKeys.message_copy_success.tr(),
       );
     }
@@ -234,12 +230,10 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
         ),
       );
       showToastNotification(
-        context,
         message: LocaleKeys.shareAction_copyLinkSuccess.tr(),
       );
     } else {
       showToastNotification(
-        context,
         message: LocaleKeys.shareAction_copyLinkToBlockFailed.tr(),
         type: ToastificationType.error,
       );
@@ -323,11 +317,9 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
     if (state.publishResult != null) {
       state.publishResult!.fold(
         (value) => showToastNotification(
-          context,
           message: LocaleKeys.publish_publishSuccessfully.tr(),
         ),
         (error) => showToastNotification(
-          context,
           message: '${LocaleKeys.publish_publishFailed.tr()}: ${error.code}',
           type: ToastificationType.error,
         ),
@@ -335,11 +327,9 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
     } else if (state.unpublishResult != null) {
       state.unpublishResult!.fold(
         (value) => showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishSuccessfully.tr(),
         ),
         (error) => showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishFailed.tr(),
           description: error.msg,
           type: ToastificationType.error,
@@ -349,7 +339,6 @@ class MobileViewPageMoreBottomSheet extends StatelessWidget {
       state.updatePathNameResult!.onSuccess(
         (value) {
           showToastNotification(
-            context,
             message:
                 LocaleKeys.settings_sites_success_updatePathNameSuccess.tr(),
           );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/bottom_sheet_view_item.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/bottom_sheet_view_item.dart
@@ -65,7 +65,6 @@ class _MobileViewItemBottomSheetState extends State<MobileViewItemBottomSheet> {
                 Navigator.pop(context);
                 context.read<ViewBloc>().add(const ViewEvent.duplicate());
                 showToastNotification(
-                  context,
                   message: LocaleKeys.button_duplicateSuccessfully.tr(),
                 );
                 break;
@@ -84,7 +83,6 @@ class _MobileViewItemBottomSheetState extends State<MobileViewItemBottomSheet> {
                     .read<FavoriteBloc>()
                     .add(FavoriteEvent.toggle(widget.view));
                 showToastNotification(
-                  context,
                   message: !widget.view.isFavorite
                       ? LocaleKeys.button_favoriteSuccessfully.tr()
                       : LocaleKeys.button_unfavoriteSuccessfully.tr(),
@@ -146,7 +144,6 @@ class _MobileViewItemBottomSheetState extends State<MobileViewItemBottomSheet> {
         Navigator.pop(context);
 
         showToastNotification(
-          context,
           message: LocaleKeys.sideBar_removeSuccess.tr(),
         );
       },

--- a/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/default_mobile_action_pane.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/bottom_sheet/default_mobile_action_pane.dart
@@ -45,7 +45,6 @@ enum MobilePaneActionType {
           size: 24.0,
           onPressed: (context) {
             showToastNotification(
-              context,
               message: LocaleKeys.button_unfavoriteSuccessfully.tr(),
             );
 
@@ -61,7 +60,6 @@ enum MobilePaneActionType {
           size: 24.0,
           onPressed: (context) {
             showToastNotification(
-              context,
               message: LocaleKeys.button_favoriteSuccessfully.tr(),
             );
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/widgets/row_page_button.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/widgets/row_page_button.dart
@@ -103,7 +103,7 @@ class _OpenRowPageButtonState extends State<OpenRowPageButton> {
     Log.info('Open row page(${widget.documentId})');
 
     if (view == null) {
-      showToastNotification(context, message: 'Failed to open row page');
+      showToastNotification(message: 'Failed to open row page');
       // reload the view again
       unawaited(_preloadView(context));
       Log.error('Failed to open row page(${widget.documentId})');

--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/mobile_home_page.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/mobile_home_page.dart
@@ -329,7 +329,7 @@ class _HomePageState extends State<_HomePage> {
     }
 
     if (message != null) {
-      showToastNotification(context, message: message, type: toastType);
+      showToastNotification(message: message, type: toastType);
     }
   }
 }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/home/space/mobile_space_menu.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/home/space/mobile_space_menu.dart
@@ -339,7 +339,6 @@ class _SpaceMenuItemTrailingState extends State<SpaceMenuItemTrailing> {
     context.read<SpaceBloc>().add(const SpaceEvent.duplicate());
 
     showToastNotification(
-      context,
       message: LocaleKeys.space_success_duplicateSpace.tr(),
     );
 
@@ -374,7 +373,6 @@ class _SpaceMenuItemTrailingState extends State<SpaceMenuItemTrailing> {
                 .add(SpaceEvent.rename(space: widget.space, name: name));
 
             showToastNotification(
-              context,
               message: LocaleKeys.space_success_renameSpace.tr(),
             );
           },
@@ -424,7 +422,6 @@ class _SpaceMenuItemTrailingState extends State<SpaceMenuItemTrailing> {
             );
 
         showToastNotification(
-          context,
           message: LocaleKeys.space_success_updateSpace.tr(),
         );
 
@@ -457,7 +454,6 @@ class _SpaceMenuItemTrailingState extends State<SpaceMenuItemTrailing> {
         context.read<SpaceBloc>().add(SpaceEvent.delete(widget.space));
 
         showToastNotification(
-          context,
           message: LocaleKeys.space_success_deleteSpace.tr(),
         );
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/mobile_bottom_navigation_bar.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/mobile_bottom_navigation_bar.dart
@@ -332,7 +332,6 @@ class _NotificationNavigationBar extends StatelessWidget {
     }
 
     showToastNotification(
-      context,
       message: LocaleKeys
           .settings_notifications_markAsReadNotifications_allSuccess
           .tr(),
@@ -350,7 +349,6 @@ class _NotificationNavigationBar extends StatelessWidget {
     }
 
     showToastNotification(
-      context,
       message: LocaleKeys.settings_notifications_archiveNotifications_allSuccess
           .tr(),
     );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/settings_popup_menu.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/settings_popup_menu.dart
@@ -108,7 +108,6 @@ class NotificationSettingsPopupMenu extends StatelessWidget {
 
   void _onMarkAllAsRead(BuildContext context) {
     showToastNotification(
-      context,
       message: LocaleKeys
           .settings_notifications_markAsReadNotifications_allSuccess
           .tr(),
@@ -119,7 +118,6 @@ class NotificationSettingsPopupMenu extends StatelessWidget {
 
   void _onArchiveAll(BuildContext context) {
     showToastNotification(
-      context,
       message: LocaleKeys.settings_notifications_archiveNotifications_allSuccess
           .tr(),
     );
@@ -133,7 +131,6 @@ class NotificationSettingsPopupMenu extends StatelessWidget {
     }
 
     showToastNotification(
-      context,
       message: 'Unarchive all success (Debug Mode)',
     );
 

--- a/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/slide_actions.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/slide_actions.dart
@@ -31,7 +31,6 @@ enum NotificationPaneActionType {
           size: 24.0,
           onPressed: (context) {
             showToastNotification(
-              context,
               message: LocaleKeys
                   .settings_notifications_markAsReadNotifications_success
                   .tr(),
@@ -55,7 +54,6 @@ enum NotificationPaneActionType {
           size: 24.0,
           onPressed: (context) {
             showToastNotification(
-              context,
               message: 'Unarchive notification success',
             );
 
@@ -168,7 +166,6 @@ class _NotificationMoreActions extends StatelessWidget {
     Navigator.of(context).pop();
 
     showToastNotification(
-      context,
       message: LocaleKeys.settings_notifications_markAsReadNotifications_success
           .tr(),
     );
@@ -191,7 +188,6 @@ class _NotificationMoreActions extends StatelessWidget {
 
   void _onArchive(BuildContext context) {
     showToastNotification(
-      context,
       message: LocaleKeys.settings_notifications_archiveNotifications_success
           .tr()
           .tr(),

--- a/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/tab.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/tab.dart
@@ -74,7 +74,6 @@ class _NotificationTabState extends State<NotificationTab>
 
     if (context.mounted) {
       showToastNotification(
-        context,
         message: LocaleKeys.settings_notifications_refreshSuccess.tr(),
       );
     }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/support_setting_group.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/support_setting_group.dart
@@ -81,7 +81,6 @@ class SupportSettingGroup extends StatelessWidget {
                   );
                   if (context.mounted) {
                     showToastNotification(
-                      context,
                       message: LocaleKeys.settings_files_clearCacheSuccess.tr(),
                     );
                   }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/workspace/invite_members_screen.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/workspace/invite_members_screen.dart
@@ -201,7 +201,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
       result.fold(
         (s) {
           showToastNotification(
-            context,
             message:
                 LocaleKeys.settings_appearance_members_addMemberSuccess.tr(),
             bottomPadding: keyboardHeight,
@@ -218,7 +217,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
             exceededLimit = f.code == ErrorCode.WorkspaceMemberLimitExceeded;
           });
           showToastNotification(
-            context,
             type: ToastificationType.error,
             bottomPadding: keyboardHeight,
             message: message,
@@ -229,7 +227,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
       result.fold(
         (s) {
           showToastNotification(
-            context,
             message:
                 LocaleKeys.settings_appearance_members_inviteMemberSuccess.tr(),
             bottomPadding: keyboardHeight,
@@ -247,7 +244,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
             exceededLimit = f.code == ErrorCode.WorkspaceMemberLimitExceeded;
           });
           showToastNotification(
-            context,
             type: ToastificationType.error,
             message: message,
             bottomPadding: keyboardHeight,
@@ -258,7 +254,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
       result.fold(
         (s) {
           showToastNotification(
-            context,
             message: LocaleKeys
                 .settings_appearance_members_removeFromWorkspaceSuccess
                 .tr(),
@@ -267,7 +262,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
         },
         (f) {
           showToastNotification(
-            context,
             type: ToastificationType.error,
             message: LocaleKeys
                 .settings_appearance_members_removeFromWorkspaceFailed
@@ -283,7 +277,6 @@ class _InviteMemberPageState extends State<_InviteMemberPage> {
     final email = emailController.text;
     if (!isEmail(email)) {
       return showToastNotification(
-        context,
         type: ToastificationType.error,
         message: LocaleKeys.settings_appearance_members_emailInvalidError.tr(),
       );

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -184,7 +184,6 @@ class CopyButton extends StatelessWidget {
           );
           if (context.mounted) {
             showToastNotification(
-              context,
               message: LocaleKeys.message_copy_success.tr(),
             );
           }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_bubble.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_bubble.dart
@@ -376,7 +376,6 @@ class ChatAIMessagePopup extends StatelessWidget {
         }
         if (context.mounted) {
           showToastNotification(
-            context,
             message: LocaleKeys.message_copy_success.tr(),
           );
         }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/message_util.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/message_util.dart
@@ -14,7 +14,6 @@ import 'package:universal_platform/universal_platform.dart';
 void openPageFromMessage(BuildContext context, ViewPB? view) {
   if (view == null) {
     showToastNotification(
-      context,
       message: LocaleKeys.chat_openPagePreviewFailedToast.tr(),
       type: ToastificationType.error,
     );
@@ -36,7 +35,6 @@ void showSaveMessageSuccessToast(BuildContext context, ViewPB? view) {
     return;
   }
   showToastNotification(
-    context,
     richMessage: TextSpan(
       children: [
         TextSpan(

--- a/frontend/appflowy_flutter/lib/plugins/document/application/document_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/application/document_bloc.dart
@@ -442,7 +442,6 @@ class DocumentBloc extends Bloc<DocumentEvent, DocumentState> {
       final context = AppGlobals.rootNavKey.currentContext;
       if (context != null && context.mounted) {
         showToastNotification(
-          context,
           message: 'document integrity check failed',
           type: ToastificationType.error,
         );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/ai_writer_toolbar_item.dart
@@ -150,7 +150,6 @@ class _AiWriterToolbarActionListState extends State<AiWriterToolbarActionList> {
           });
         } else {
           showToastNotification(
-            context,
             message: LocaleKeys.document_plugins_appflowyAIEditDisabled.tr(),
           );
         }
@@ -196,7 +195,6 @@ class ImproveWritingButton extends StatelessWidget {
           _insertAiNode(editorState, AiWriterCommand.improveWriting);
         } else {
           showToastNotification(
-            context,
             message: LocaleKeys.document_plugins_appflowyAIEditDisabled.tr(),
           );
         }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_copy_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/code_block/code_block_copy_button.dart
@@ -47,7 +47,6 @@ class _CopyButton extends StatelessWidget {
 
             if (context.mounted) {
               showToastNotification(
-                context,
                 message: LocaleKeys.document_codeBlock_codeCopiedSnackbar.tr(),
               );
             }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_image.dart
@@ -73,7 +73,6 @@ extension PasteFromImage on EditorState {
       Log.info('unsupported format: $format');
       if (UniversalPlatform.isMobile) {
         showToastNotification(
-          context,
           message: LocaleKeys.document_imageBlock_error_invalidImageFormat.tr(),
         );
       }
@@ -112,7 +111,6 @@ extension PasteFromImage on EditorState {
 
         if (errorMessage != null && context.mounted) {
           showToastNotification(
-            context,
             message: errorMessage,
           );
           return false;
@@ -131,7 +129,6 @@ extension PasteFromImage on EditorState {
       Log.error('cannot copy image file', e);
       if (context.mounted) {
         showToastNotification(
-          context,
           message: LocaleKeys.document_imageBlock_error_invalidImage.tr(),
         );
       }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
@@ -241,7 +241,6 @@ class _LinkHoverTriggerState extends State<LinkHoverTrigger> {
         .setData(ClipboardServiceData(plainText: href));
     if (context.mounted) {
       showToastNotification(
-        context,
         message: LocaleKeys.shareAction_copyLinkSuccess.tr(),
       );
     }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/error/error_block_component_builder.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/error/error_block_component_builder.dart
@@ -154,7 +154,6 @@ class _ErrorBlockComponentWidgetState extends State<ErrorBlockComponentWidget>
 
   void _copyBlockContent() {
     showToastNotification(
-      context,
       message: LocaleKeys.document_errorBlock_blockContentHasBeenCopied.tr(),
     );
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/file/file_util.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/file/file_util.dart
@@ -105,7 +105,6 @@ Future<void> downloadMediaFile(
   } else {
     if (userProfile == null) {
       return showToastNotification(
-        context,
         message: LocaleKeys.grid_media_downloadFailedToken.tr(),
       );
     }
@@ -128,14 +127,12 @@ Future<void> downloadMediaFile(
 
         if (result != null && context.mounted) {
           showToastNotification(
-            context,
             type: ToastificationType.error,
             message: LocaleKeys.grid_media_downloadSuccess.tr(),
           );
         }
       } else if (context.mounted) {
         showToastNotification(
-          context,
           type: ToastificationType.error,
           message: LocaleKeys.document_plugins_image_imageDownloadFailed.tr(),
         );
@@ -159,13 +156,11 @@ Future<void> downloadMediaFile(
 
         if (context.mounted) {
           showToastNotification(
-            context,
             message: LocaleKeys.grid_media_downloadSuccess.tr(),
           );
         }
       } else if (context.mounted) {
         showToastNotification(
-          context,
           type: ToastificationType.error,
           message: LocaleKeys.document_plugins_image_imageDownloadFailed.tr(),
         );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/custom_image_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/custom_image_block_component.dart
@@ -378,7 +378,6 @@ class CustomImageBlockComponentState extends State<CustomImageBlockComponent>
         onTap: () async {
           context.pop();
           showToastNotification(
-            context,
             message: LocaleKeys.document_plugins_image_copiedToPasteBoard.tr(),
           );
           await getIt<ClipboardService>().setPlainText(url);
@@ -431,7 +430,6 @@ class CustomImageBlockComponentState extends State<CustomImageBlockComponent>
       );
       if (mounted) {
         showToastNotification(
-          context,
           message: result.isSuccess
               ? LocaleKeys.document_imageBlock_successToAddImageToGallery.tr()
               : LocaleKeys.document_imageBlock_failedToAddImageToGallery.tr(),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/image_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/image_menu.dart
@@ -117,14 +117,12 @@ class _ImageMenuState extends State<ImageMenu> {
 
         if (mounted) {
           showToastNotification(
-            context,
             message: LocaleKeys.message_copy_success.tr(),
           );
         }
       } catch (e) {
         if (mounted) {
           showToastNotification(
-            context,
             message: LocaleKeys.message_copy_fail.tr(),
             type: ToastificationType.error,
           );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/multi_image_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/multi_image_menu.dart
@@ -218,7 +218,6 @@ class _MultiImageMenuState extends State<MultiImageMenu> {
       ClipboardData(text: images[widget.indexNotifier.value].url),
     );
     showToastNotification(
-      context,
       message: LocaleKeys.document_plugins_image_copiedToPasteBoard.tr(),
     );
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
@@ -78,7 +78,6 @@ class _LinkPreviewMenuState extends State<LinkPreviewMenu> {
     if (url != null) {
       Clipboard.setData(ClipboardData(text: url));
       showToastNotification(
-        context,
         message: LocaleKeys.document_plugins_urlPreview_copiedToPasteBoard.tr(),
       );
     }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/child_page_transaction_handler.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/child_page_transaction_handler.dart
@@ -100,7 +100,6 @@ class ChildPageTransactionHandler extends MentionTransactionHandler {
         Log.error(error);
         if (context.mounted) {
           showToastNotification(
-            context,
             message: LocaleKeys.document_plugins_subPage_errors_failedDeletePage
                 .tr(),
           );

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/export_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/export_tab.dart
@@ -174,11 +174,10 @@ class ExportTab extends StatelessWidget {
           ClipboardServiceData(plainText: markdown),
         );
         showToastNotification(
-          context,
           message: LocaleKeys.message_copy_success.tr(),
         );
       },
-      (error) => showToastNotification(context, message: error.msg),
+      (error) => showToastNotification(message: error.msg),
     );
   }
 }

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/publish_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/publish_tab.dart
@@ -85,11 +85,9 @@ class PublishTab extends StatelessWidget {
     if (state.publishResult != null) {
       state.publishResult!.fold(
         (value) => showToastNotification(
-          context,
           message: LocaleKeys.publish_publishSuccessfully.tr(),
         ),
         (error) => showToastNotification(
-          context,
           message: '${LocaleKeys.publish_publishFailed.tr()}: ${error.code}',
           type: ToastificationType.error,
         ),
@@ -97,11 +95,9 @@ class PublishTab extends StatelessWidget {
     } else if (state.unpublishResult != null) {
       state.unpublishResult!.fold(
         (value) => showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishSuccessfully.tr(),
         ),
         (error) => showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishFailed.tr(),
           description: error.msg,
           type: ToastificationType.error,
@@ -110,14 +106,12 @@ class PublishTab extends StatelessWidget {
     } else if (state.updatePathNameResult != null) {
       state.updatePathNameResult!.fold(
         (value) => showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_success_updatePathNameSuccess.tr(),
         ),
         (error) {
           Log.error('update path name failed: $error');
 
           showToastNotification(
-            context,
             message: LocaleKeys.settings_sites_error_updatePathNameFailed.tr(),
             type: ToastificationType.error,
             description: error.code.publishErrorMessage,
@@ -182,7 +176,6 @@ class _PublishedWidgetState extends State<_PublishedWidget> {
             );
 
             showToastNotification(
-              context,
               message: LocaleKeys.message_copy_success.tr(),
             );
           },
@@ -292,7 +285,6 @@ class _PublishWidgetState extends State<_PublishWidget> {
               // check if any database is selected
               if (_selectedViews.isEmpty) {
                 showToastNotification(
-                  context,
                   message: LocaleKeys.publish_noDatabaseSelected.tr(),
                 );
                 return;
@@ -611,7 +603,6 @@ class _PublishDatabaseSelectorState extends State<_PublishDatabaseSelector> {
             // unable to deselect the primary database
             if (isPrimaryDatabase) {
               showToastNotification(
-                context,
                 message:
                     LocaleKeys.publish_unableToDeselectPrimaryDatabase.tr(),
               );

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/share_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/share_button.dart
@@ -70,7 +70,6 @@ class ShareButton extends StatelessWidget {
       case ShareType.html:
       case ShareType.csv:
         showToastNotification(
-          context,
           message: LocaleKeys.settings_files_exportFileSuccess.tr(),
         );
         break;
@@ -81,7 +80,6 @@ class ShareButton extends StatelessWidget {
 
   void _handleExportError(BuildContext context, FlowyError error) {
     showToastNotification(
-      context,
       message:
           '${LocaleKeys.settings_files_exportFileFail.tr()}: ${error.code}',
     );

--- a/frontend/appflowy_flutter/lib/plugins/shared/share/share_tab.dart
+++ b/frontend/appflowy_flutter/lib/plugins/shared/share/share_tab.dart
@@ -117,7 +117,6 @@ class _ShareTabContent extends StatelessWidget {
     );
 
     showToastNotification(
-      context,
       message: LocaleKeys.message_copy_success.tr(),
     );
   }

--- a/frontend/appflowy_flutter/lib/shared/flowy_error_page.dart
+++ b/frontend/appflowy_flutter/lib/shared/flowy_error_page.dart
@@ -45,7 +45,6 @@ class _MobileSyncErrorPage extends StatelessWidget {
       onTapUp: () {
         getIt<ClipboardService>().setPlainText(error.toString());
         showToastNotification(
-          context,
           message: LocaleKeys.message_copy_success.tr(),
           bottomPadding: 0,
         );
@@ -101,7 +100,7 @@ class _DesktopSyncErrorPage extends StatelessWidget {
       onTapUp: () {
         getIt<ClipboardService>().setPlainText(error.toString());
         showToastNotification(
-          context,
+          
           message: LocaleKeys.message_copy_success.tr(),
           bottomPadding: 0,
         );

--- a/frontend/appflowy_flutter/lib/startup/tasks/appflowy_cloud_task.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/appflowy_cloud_task.dart
@@ -129,7 +129,7 @@ class AppFlowyCloudDeepLink {
               final context = AppGlobals.rootNavKey.currentState?.context;
               if (context != null) {
                 showToastNotification(
-                  context,
+                  
                   message: err.msg,
                 );
               }

--- a/frontend/appflowy_flutter/lib/user/presentation/helpers/handle_open_workspace_error.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/helpers/handle_open_workspace_error.dart
@@ -17,14 +17,14 @@ void handleOpenWorkspaceError(BuildContext context, FlowyError error) {
     case ErrorCode.InvalidEncryptSecret:
     case ErrorCode.NetworkError:
       showToastNotification(
-        context,
+        
         message: error.msg,
         type: ToastificationType.error,
       );
       break;
     default:
       showToastNotification(
-        context,
+        
         message: error.msg,
         type: ToastificationType.error,
         callbacks: ToastificationCallbacks(

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/magic_link_sign_in_buttons.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/magic_link_sign_in_buttons.dart
@@ -65,7 +65,7 @@ class _SignInWithMagicLinkButtonsState
   void _sendMagicLink(BuildContext context, String email) {
     if (!isEmail(email)) {
       return showToastNotification(
-        context,
+        
         message: LocaleKeys.signIn_invalidEmail.tr(),
         type: ToastificationType.error,
       );

--- a/frontend/appflowy_flutter/lib/util/share_log_files.dart
+++ b/frontend/appflowy_flutter/lib/util/share_log_files.dart
@@ -25,7 +25,7 @@ Future<void> shareLogFiles(BuildContext? context) async {
   if (archiveLogFiles.isEmpty) {
     if (context != null && context.mounted) {
       showToastNotification(
-        context,
+        
         message: LocaleKeys.noLogFiles.tr(),
         type: ToastificationType.error,
       );
@@ -42,7 +42,7 @@ Future<void> shareLogFiles(BuildContext? context) async {
   if (zip == null) {
     if (context != null && context.mounted) {
       showToastNotification(
-        context,
+        
         message: LocaleKeys.noLogFiles.tr(),
         type: ToastificationType.error,
       );
@@ -72,7 +72,7 @@ Future<void> shareLogFiles(BuildContext? context) async {
   } catch (e) {
     if (context != null && context.mounted) {
       showToastNotification(
-        context,
+        
         message: e.toString(),
         type: ToastificationType.error,
       );

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 
 import 'package:appflowy/core/config/kv.dart';
 import 'package:appflowy/core/config/kv_keys.dart';
+import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/user/application/user_settings_service.dart';
 import 'package:appflowy/util/color_to_hex_string.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/base_appearance.dart';
+import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/date_time.pbenum.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_setting.pb.dart';
@@ -17,6 +19,7 @@ import 'package:flowy_infra/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:universal_platform/universal_platform.dart';
 
 part 'appearance_cubit.freezed.dart';
 
@@ -97,7 +100,19 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
   Future<void> setTheme(String themeName) async {
     _appearanceSettings.theme = themeName;
     unawaited(_saveAppearanceSettings());
-    emit(state.copyWith(appTheme: await AppTheme.fromName(themeName)));
+    try {
+      final theme = await AppTheme.fromName(themeName);
+      emit(state.copyWith(appTheme: theme));
+    } catch (e) {
+      Log.error("Error setting theme: $e");
+      if (UniversalPlatform.isMacOS) {
+        showToastNotification(
+          message:
+              LocaleKeys.settings_workspacePage_theme_failedToLoadThemes.tr(),
+          type: ToastificationType.error,
+        );
+      }
+    }
   }
 
   /// Reset the current user selected theme back to the default

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/sidebar_workspace.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/sidebar_workspace.dart
@@ -169,7 +169,7 @@ class _SidebarWorkspaceState extends State<SidebarWorkspace> {
 
     if (message != null) {
       showToastNotification(
-        context,
+        
         message: message,
         type: result.fold(
           (_) => ToastificationType.success,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/account/account_deletion.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/account/account_deletion.dart
@@ -193,7 +193,7 @@ Future<void> deleteMyAccount(
 
   if (!isChecked) {
     showToastNotification(
-      context,
+      
       type: ToastificationType.warning,
       bottomPadding: bottomPadding,
       message: LocaleKeys
@@ -208,7 +208,7 @@ Future<void> deleteMyAccount(
 
   if (confirmText.isEmpty || !_isConfirmTextValid(confirmText)) {
     showToastNotification(
-      context,
+      
       type: ToastificationType.warning,
       bottomPadding: bottomPadding,
       message: LocaleKeys
@@ -226,7 +226,7 @@ Future<void> deleteMyAccount(
 
       loading.stop();
       showToastNotification(
-        context,
+        
         message: LocaleKeys
             .newSettings_myAccount_deleteAccount_deleteAccountSuccess
             .tr(),
@@ -245,7 +245,7 @@ Future<void> deleteMyAccount(
 
       loading.stop();
       showToastNotification(
-        context,
+        
         type: ToastificationType.error,
         bottomPadding: bottomPadding,
         message: f.msg,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_manage_data_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_manage_data_view.dart
@@ -157,7 +157,7 @@ class SettingsManageDataView extends StatelessWidget {
 
                           if (context.mounted) {
                             showToastNotification(
-                              context,
+                              
                               message: LocaleKeys
                                   .settings_manageDataPage_cache_dialog_successHint
                                   .tr(),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/constants.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/constants.dart
@@ -53,7 +53,6 @@ class SettingsPageSitesEvent {
     );
     getIt<ClipboardService>().setData(ClipboardServiceData(plainText: url));
     showToastNotification(
-      context,
       message: LocaleKeys.message_copy_success.tr(),
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/domain/domain_item.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/domain/domain_item.dart
@@ -253,7 +253,6 @@ class _FreePlanUpgradeButton extends StatelessWidget {
           onTap: () {
             if (isOwner) {
               showToastNotification(
-                context,
                 message:
                     LocaleKeys.settings_sites_namespace_redirectToPayment.tr(),
                 type: ToastificationType.info,
@@ -264,7 +263,6 @@ class _FreePlanUpgradeButton extends StatelessWidget {
                   );
             } else {
               showToastNotification(
-                context,
                 message: LocaleKeys
                     .settings_sites_namespace_pleaseAskOwnerToSetHomePage
                     .tr(),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/domain/domain_settings_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/domain/domain_settings_dialog.dart
@@ -216,7 +216,6 @@ class _DomainSettingsDialogState extends State<DomainSettingsDialog> {
     result.fold(
       (s) {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_success_namespaceUpdated.tr(),
         );
 
@@ -234,7 +233,6 @@ class _DomainSettingsDialogState extends State<DomainSettingsDialog> {
         Log.error('Failed to update namespace: $f');
 
         showToastNotification(
-          context,
           message: basicErrorMessage,
           type: ToastificationType.error,
           description: errorMessage,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/published_page/published_view_settings_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/published_page/published_view_settings_dialog.dart
@@ -203,7 +203,6 @@ class _PublishedViewSettingsDialogState
     result.fold(
       (s) {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_success_updatePathNameSuccess.tr(),
         );
         Navigator.of(context).pop();
@@ -212,7 +211,6 @@ class _PublishedViewSettingsDialogState
         Log.error('update path name failed: $f');
 
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_error_updatePathNameFailed.tr(),
           type: ToastificationType.error,
           description: f.code.publishErrorMessage,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/settings_sites_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/sites/settings_sites_view.dart
@@ -178,7 +178,6 @@ class _SettingsSitesPageView extends StatelessWidget {
         Log.error('Failed to generate payment link for Pro Plan: ${f.msg}');
 
         showToastNotification(
-          context,
           message:
               LocaleKeys.settings_sites_error_failedToGeneratePaymentLink.tr(),
           type: ToastificationType.error,
@@ -188,14 +187,12 @@ class _SettingsSitesPageView extends StatelessWidget {
         result != null) {
       result.fold((_) {
         showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishSuccessfully.tr(),
         );
       }, (f) {
         Log.error('Failed to unpublish view: ${f.msg}');
 
         showToastNotification(
-          context,
           message: LocaleKeys.publish_unpublishFailed.tr(),
           type: ToastificationType.error,
           description: f.msg,
@@ -204,14 +201,12 @@ class _SettingsSitesPageView extends StatelessWidget {
     } else if (type == SettingsSitesActionType.setHomePage && result != null) {
       result.fold((s) {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_success_setHomepageSuccess.tr(),
         );
       }, (f) {
         Log.error('Failed to set homepage: ${f.msg}');
 
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_error_setHomepageFailed.tr(),
           type: ToastificationType.error,
         );
@@ -220,14 +215,12 @@ class _SettingsSitesPageView extends StatelessWidget {
         result != null) {
       result.fold((s) {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_success_removeHomePageSuccess.tr(),
         );
       }, (f) {
         Log.error('Failed to remove homepage: ${f.msg}');
 
         showToastNotification(
-          context,
           message: LocaleKeys.settings_sites_error_removeHomePageFailed.tr(),
           type: ToastificationType.error,
         );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/settings_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/settings_dialog.dart
@@ -363,7 +363,6 @@ class _SelfHostSettingsState extends State<_SelfHostSettings> {
   }) async {
     if (cloudUrl.isEmpty || webUrl.isEmpty) {
       showToastNotification(
-        context,
         message: LocaleKeys.settings_menu_pleaseInputValidURL.tr(),
         type: ToastificationType.error,
       );
@@ -375,7 +374,6 @@ class _SelfHostSettingsState extends State<_SelfHostSettings> {
     if (mounted) {
       if (isValid) {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_menu_changeUrl.tr(args: [cloudUrl]),
         );
 
@@ -387,7 +385,6 @@ class _SelfHostSettingsState extends State<_SelfHostSettings> {
         await runAppFlowy();
       } else {
         showToastNotification(
-          context,
           message: LocaleKeys.settings_menu_pleaseInputValidURL.tr(),
           type: ToastificationType.error,
         );
@@ -522,7 +519,6 @@ class _SupportSettings extends StatelessWidget {
                   await getIt<FlowyCacheManager>().clearAllCache();
                   if (context.mounted) {
                     showToastNotification(
-                      context,
                       message: LocaleKeys
                           .settings_manageDataPage_cache_dialog_successHint
                           .tr(),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/dialogs.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/dialogs.dart
@@ -157,7 +157,6 @@ class _NavigatorTextFieldDialogState extends State<NavigatorTextFieldDialog> {
             onOkPressed: () {
               if (newValue.isEmpty) {
                 showToastNotification(
-                  context,
                   message: LocaleKeys.space_spaceNameCannotBeEmpty.tr(),
                 );
                 return;
@@ -363,8 +362,7 @@ class OkCancelButton extends StatelessWidget {
   }
 }
 
-void showToastNotification(
-  BuildContext context, {
+void showToastNotification({
   String? message,
   TextSpan? richMessage,
   String? description,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/version_section.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/float_bubble/version_section.dart
@@ -51,7 +51,6 @@ class FlowyVersionSection extends CustomActionCell {
                     }
                     enableDocumentInternalLog = !enableDocumentInternalLog;
                     showToastNotification(
-                      context,
                       message: enableDocumentInternalLog
                           ? 'Enabled Internal Log'
                           : 'Disabled Internal Log',

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/view_title_bar.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/view_title_bar.dart
@@ -74,7 +74,6 @@ class ViewTitleBar extends StatelessWidget {
       listener: (context, state) {
         if (state.isLocked) {
           showToastNotification(
-            context,
             message: LocaleKeys.lockPage_pageLockedToast.tr(),
           );
         }

--- a/frontend/resources/translations/en.json
+++ b/frontend/resources/translations/en.json
@@ -628,7 +628,8 @@
       "theme": {
         "title": "Theme",
         "description": "Select a preset theme, or upload your own custom theme.",
-        "uploadCustomThemeTooltip": "Upload a custom theme"
+        "uploadCustomThemeTooltip": "Upload a custom theme",
+        "failedToLoadThemes": "Failed to load themes, please check your permission settings in System Settings > Privacy and Security > Files and Folders > @:appName"
       },
       "workspaceFont": {
         "title": "Workspace font",


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Modify toast notification function to remove context parameter and update related function calls across the application

Enhancements:
- Update multiple files to use the new toast notification signature
- Remove context parameter from showToastNotification function calls

Chores:
- Refactor toast notification implementation to remove context dependency