### PR TITLE
chore: adjust replace, insert below, discard selection behavior

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/operations/ai_writer_cubit.dart
@@ -57,8 +57,13 @@ class AiWriterCubit extends Cubit<AiWriterState> {
     bool withDiscard = true,
     bool withUnformat = true,
   }) async {
+    if (aiWriterNode == null) {
+      return;
+    }
     if (withDiscard) {
-      await _textRobot.discard();
+      await _textRobot.discard(
+        afterSelection: aiWriterNode!.aiWriterSelection,
+      );
     }
     _textRobot.clear();
     _textRobot.reset();
@@ -230,6 +235,12 @@ class AiWriterCubit extends Cubit<AiWriterState> {
 
       _aiWriterCubitLog(
         'trigger accept action, markdown text: $trimmedMarkdownText',
+      );
+
+      await formatSelection(
+        editorState,
+        selection,
+        ApplySuggestionFormatType.clear,
       );
 
       await _textRobot.deleteAINodes();

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_scroll_wrapper.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/ai/widgets/ai_writer_scroll_wrapper.dart
@@ -40,6 +40,7 @@ class _AiWriterScrollWrapperState extends State<AiWriterScrollWrapper> {
     onRemoveNode: () {
       aiWriterRegistered = false;
       widget.editorState.service.keyboardService?.enableShortcuts();
+      widget.editorState.service.keyboardService?.enable();
     },
     onAppendToDocument: onAppendToDocument,
   );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
@@ -118,7 +118,7 @@ class MarkdownTextRobot {
     }
 
     await _lock.synchronized(() async {
-      await _refresh(inMemoryUpdate: false);
+      await _refresh(inMemoryUpdate: false, updateSelection: true);
     });
 
     if (_enableDebug) {
@@ -156,7 +156,9 @@ class MarkdownTextRobot {
   }
 
   /// Discard the inserted content
-  Future<void> discard() async {
+  Future<void> discard({
+    Selection? afterSelection,
+  }) async {
     final start = _insertPosition;
     if (start == null) {
       return;
@@ -164,6 +166,8 @@ class MarkdownTextRobot {
     if (_insertedNodes.isEmpty) {
       return;
     }
+
+    afterSelection ??= Selection.collapsed(start);
 
     // fallback to the calculated position if the selection is null.
     final end = Position(
@@ -174,7 +178,7 @@ class MarkdownTextRobot {
     );
     final transaction = editorState.transaction
       ..deleteNodes(deletedNodes)
-      ..afterSelection = Selection.collapsed(start);
+      ..afterSelection = afterSelection;
 
     await editorState.apply(
       transaction,


### PR DESCRIPTION
1. clear the grey + strike-through for selected text before accepting (aka replacing), so that undoing the action using Ctrl + Z won't show the grey + strike-through
2. update after selection to more acceptable positions
3. After exiting, immediately request focus using the keyboard service

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Adjust the behavior of text replacement, insertion, and selection discarding in the AI writer functionality

Bug Fixes:
- Prevent potential null pointer exceptions by adding null checks in AI writer operations
- Ensure keyboard service is fully re-enabled after removing AI writer node

Enhancements:
- Improve handling of AI writer node selection and text replacement operations
- Enhance text robot discard method to support custom after-selection positioning

Chores:
- Refactor AI writer and markdown text robot methods to be more robust and flexible