### PR TITLE
fix: adjust ghost button hover color

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/theme/data/builder.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/theme/data/builder.dart
@@ -206,7 +206,7 @@ class AppFlowyThemeBuilder {
           quaternary: colorScheme.neutral.neutral100,
           quaternaryHover: colorScheme.neutral.neutral200,
           transparent: colorScheme.neutral.alphaWhite0,
-          primaryAlpha5: colorScheme.neutral.alphaGrey10005,
+          primaryAlpha5: colorScheme.neutral.alphaGrey100005,
           primaryAlpha5Hover: colorScheme.neutral.alphaGrey100010,
           primaryAlpha80: colorScheme.neutral.alphaGrey100080,
           primaryAlpha80Hover: colorScheme.neutral.alphaGrey100070,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Fixed the color value for primary alpha 5 in the theme color scheme