### PR TITLE
fix: unable to accept the response from 'mark longer'

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/markdown_text_robot.dart
@@ -320,6 +320,12 @@ class MarkdownTextRobot {
     required Selection selection,
     required String markdownText,
   }) async {
+    if (markdownText.isEmpty) {
+      assert(false, 'Expected non-empty markdown text');
+      Log.error('Expected non-empty markdown text');
+      return;
+    }
+
     selection = selection.normalized;
 
     // If the selection is not a single node, do nothing.
@@ -372,15 +378,42 @@ class MarkdownTextRobot {
     //   }
     // ]
     final document = customMarkdownToDocument(markdownText);
+    final nodes = document.root.children;
     final decoder = DeltaMarkdownDecoder();
     final markdownDelta =
-        document.nodeAtPath([0])?.delta ?? decoder.convert(markdownText);
+        nodes.firstOrNull?.delta ?? decoder.convert(markdownText);
+
+    if (markdownDelta.isEmpty) {
+      assert(false, 'Expected non-empty markdown delta');
+      Log.error('Expected non-empty markdown delta');
+      return;
+    }
 
     // Replace the delta of the selected node.
     final transaction = editorState.transaction;
-    transaction
-      ..deleteText(node, startIndex, length)
-      ..insertTextDelta(node, startIndex, markdownDelta);
+
+    // it means the user selected the entire sentence, we just replace the node
+    if (startIndex == 0 && length == node.delta?.length) {
+      transaction
+        ..insertNodes(node.path.next, nodes)
+        ..deleteNode(node);
+    } else {
+      // it means the user selected a part of the sentence, we need to delete the
+      // selected part and insert the new delta.
+      transaction
+        ..deleteText(node, startIndex, length)
+        ..insertTextDelta(node, startIndex, markdownDelta);
+
+      // Add the remaining nodes to the document.
+      final remainingNodes = nodes.skip(1);
+      if (remainingNodes.isNotEmpty) {
+        transaction.insertNodes(
+          node.path.next,
+          remainingNodes,
+        );
+      }
+    }
+
     await editorState.apply(transaction);
   }
 

--- a/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
@@ -489,6 +489,13 @@ void main() {
     });
 
     test('replace markdown text with selection from start to end', () async {
+      final text1 =
+          '''The introduction of the World Wide Web in the early 1990s marked a turning point.''';
+      final text2 =
+          '''Tim Berners-Lee's invention made the internet accessible to non-technical users, opening the floodgates for mass adoption.''';
+      final text3 =
+          '''Email became widespread, and instant messaging services like ICQ and AOL Instant Messenger gained popularity, allowing for real-time text communication.''';
+
       final document = Document(
         root: pageNode(
           children: [
@@ -526,21 +533,21 @@ void main() {
       expect(d1.attributes, null);
       expect(nodes[0].type, NumberedListBlockKeys.type);
 
-      final d2 = nodes[1].delta!.toList()[1] as TextInsert;
+      final d2 = nodes[1].delta!.toList()[0] as TextInsert;
       expect(d2.text, text1);
       expect(d2.attributes, null);
       expect(nodes[1].type, NumberedListBlockKeys.type);
 
-      final d3 = nodes[2].delta!.toList()[2] as TextInsert;
+      final d3 = nodes[2].delta!.toList()[0] as TextInsert;
       expect(d3.text, text1);
       expect(d3.attributes, null);
       expect(nodes[2].type, NumberedListBlockKeys.type);
 
-      final d4 = nodes[3].delta!.toList()[3] as TextInsert;
+      final d4 = nodes[3].delta!.toList()[0] as TextInsert;
       expect(d4.text, text2);
       expect(d4.attributes, null);
 
-      final d5 = nodes[4].delta!.toList()[4] as TextInsert;
+      final d5 = nodes[4].delta!.toList()[0] as TextInsert;
       expect(d5.text, text3);
       expect(d5.attributes, null);
     });

--- a/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/text_robot/markdown_text_robot_test.dart
@@ -487,6 +487,63 @@ void main() {
       );
       expect(d7.attributes, null);
     });
+
+    test('replace markdown text with selection from start to end', () async {
+      final document = Document(
+        root: pageNode(
+          children: [
+            paragraphNode(delta: Delta()..insert(text1)),
+            paragraphNode(delta: Delta()..insert(text2)),
+            paragraphNode(delta: Delta()..insert(text3)),
+          ],
+        ),
+      );
+      final editorState = EditorState(document: document);
+
+      editorState.selection = Selection(
+        start: Position(path: [0]),
+        end: Position(path: [0], offset: text1.length),
+      );
+
+      final markdownText = '''1. $text1
+
+2. $text1
+
+3. $text1''';
+      final markdownTextRobot = MarkdownTextRobot(
+        editorState: editorState,
+      );
+      await markdownTextRobot.replace(
+        selection: editorState.selection!,
+        markdownText: markdownText,
+      );
+
+      final nodes = editorState.document.root.children;
+      expect(nodes.length, 5);
+
+      final d1 = nodes[0].delta!.toList()[0] as TextInsert;
+      expect(d1.text, text1);
+      expect(d1.attributes, null);
+      expect(nodes[0].type, NumberedListBlockKeys.type);
+
+      final d2 = nodes[1].delta!.toList()[1] as TextInsert;
+      expect(d2.text, text1);
+      expect(d2.attributes, null);
+      expect(nodes[1].type, NumberedListBlockKeys.type);
+
+      final d3 = nodes[2].delta!.toList()[2] as TextInsert;
+      expect(d3.text, text1);
+      expect(d3.attributes, null);
+      expect(nodes[2].type, NumberedListBlockKeys.type);
+
+      final d4 = nodes[3].delta!.toList()[3] as TextInsert;
+      expect(d4.text, text2);
+      expect(d4.attributes, null);
+
+      final d5 = nodes[4].delta!.toList()[4] as TextInsert;
+      expect(d5.text, text3);
+      expect(d5.attributes, null);
+    });
   });
 
   group('markdown text robot - replace in multiple lines:', () {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Improve markdown text replacement functionality in the document editor to handle full text selection and multi-node markdown conversion

Bug Fixes:
- Fix issue with replacing markdown text when the entire text node is selected, ensuring proper node replacement and preservation of subsequent content

Enhancements:
- Enhance markdown text robot to handle different selection scenarios, including full node replacement and partial text replacement

Tests:
- Add a test case to verify markdown text replacement with selection from start to end of a text node