### PR TITLE
feat: add medium sized text field

### DIFF
--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/continue_with/continue_with_email_and_password.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/continue_with/continue_with_email_and_password.dart
@@ -59,7 +59,6 @@ class _ContinueWithEmailAndPasswordState
             key: emailKey,
             controller: controller,
             hintText: LocaleKeys.signIn_pleaseInputYourEmail.tr(),
-            radius: 10,
             onSubmitted: (value) => _signInWithEmail(
               context,
               value,

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/continue_with/continue_with_magic_link_or_passcode_page.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/continue_with/continue_with_magic_link_or_passcode_page.dart
@@ -101,7 +101,6 @@ class _ContinueWithMagicLinkOrPasscodePageState
         controller: passcodeController,
         hintText: LocaleKeys.signIn_enterCode.tr(),
         keyboardType: TextInputType.number,
-        radius: 10,
         autoFocus: true,
         onSubmitted: (passcode) {
           if (passcode.isEmpty) {

--- a/frontend/appflowy_flutter/packages/appflowy_ui/example/lib/main.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/example/lib/main.dart
@@ -24,6 +24,8 @@ class MyApp extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: themeMode,
       builder: (context, themeMode, child) {
+        final themeData =
+            themeMode == ThemeMode.light ? ThemeData.light() : ThemeData.dark();
         return AppFlowyTheme(
           data: themeMode == ThemeMode.light
               ? AppFlowyThemeData.light()
@@ -31,9 +33,7 @@ class MyApp extends StatelessWidget {
           child: MaterialApp(
             debugShowCheckedModeBanner: false,
             title: 'AppFlowy UI Example',
-            theme: themeMode == ThemeMode.light
-                ? ThemeData.light()
-                : ThemeData.dark(),
+            theme: themeData.copyWith(visualDensity: VisualDensity.standard),
             home: const MyHomePage(
               title: 'AppFlowy UI',
             ),

--- a/frontend/appflowy_flutter/packages/appflowy_ui/example/lib/src/textfield/textfield_page.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/example/lib/src/textfield/textfield_page.dart
@@ -12,6 +12,19 @@ class TextFieldPage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildSection(
+            'TextField Sizes',
+            [
+              AFTextField(
+                hintText: 'Please enter your name',
+                size: AFTextFieldSize.m,
+              ),
+              AFTextField(
+                hintText: 'Please enter your name',
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+          _buildSection(
             'TextField with hint text',
             [
               AFTextField(

--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
@@ -1,4 +1,4 @@
-import 'package:appflowy_ui/src/theme/appflowy_theme.dart';
+import 'package:appflowy_ui/src/theme/theme.dart';
 import 'package:flutter/material.dart';
 
 typedef AFTextFieldValidator = (bool result, String errorText) Function(
@@ -16,7 +16,7 @@ class AFTextField extends StatefulWidget {
     this.hintText,
     this.initialText,
     this.keyboardType,
-    this.radius,
+    this.size = AFTextFieldSize.l,
     this.validator,
     this.controller,
     this.onChanged,
@@ -37,8 +37,8 @@ class AFTextField extends StatefulWidget {
   /// The type of keyboard to display.
   final TextInputType? keyboardType;
 
-  /// The radius of the text field.
-  final double? radius;
+  /// The size variant of the text field.
+  final AFTextFieldSize size;
 
   /// The validator to use for the text field.
   final AFTextFieldValidator? validator;
@@ -94,9 +94,8 @@ class _AFTextFieldState extends AFTextFieldState {
   @override
   Widget build(BuildContext context) {
     final theme = AppFlowyTheme.of(context);
-    final borderRadius = BorderRadius.circular(
-      widget.radius ?? theme.borderRadius.l,
-    );
+    final borderRadius = widget.size.borderRadius(theme);
+    final contentPadding = widget.size.contentPadding(theme);
 
     final errorBorderColor = theme.borderColorScheme.errorThick;
     final defaultBorderColor = theme.borderColorScheme.greyTertiary;
@@ -115,10 +114,9 @@ class _AFTextFieldState extends AFTextFieldState {
         hintStyle: theme.textStyle.body.standard(
           color: theme.textColorScheme.tertiary,
         ),
-        contentPadding: EdgeInsets.symmetric(
-          horizontal: theme.spacing.m,
-          vertical: 10,
-        ),
+        isDense: true,
+        constraints: BoxConstraints(),
+        contentPadding: contentPadding,
         border: OutlineInputBorder(
           borderSide: BorderSide(
             color: hasError ? errorBorderColor : defaultBorderColor,
@@ -203,5 +201,29 @@ class _AFTextFieldState extends AFTextFieldState {
       hasError = false;
       errorText = '';
     });
+  }
+}
+
+enum AFTextFieldSize {
+  m,
+  l;
+
+  EdgeInsetsGeometry contentPadding(AppFlowyThemeData theme) {
+    return EdgeInsets.symmetric(
+      vertical: switch (this) {
+        AFTextFieldSize.m => theme.spacing.s,
+        AFTextFieldSize.l => 10.0,
+      },
+      horizontal: theme.spacing.m,
+    );
+  }
+
+  BorderRadius borderRadius(AppFlowyThemeData theme) {
+    return BorderRadius.circular(
+      switch (this) {
+        AFTextFieldSize.m => theme.borderRadius.m,
+        AFTextFieldSize.l => 10.0,
+      },
+    );
   }
 }

--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
@@ -22,11 +22,7 @@ class AFTextField extends StatefulWidget {
     this.onChanged,
     this.onSubmitted,
     this.autoFocus,
-    this.height = 40.0,
   });
-
-  /// The height of the text field.
-  final double height;
 
   /// The hint text to display when the text field is empty.
   final String? hintText;
@@ -152,8 +148,6 @@ class _AFTextFieldState extends AFTextFieldState {
         hoverColor: theme.borderColorScheme.greyTertiaryHover,
       ),
     );
-
-    child = SizedBox(height: widget.height, child: child);
 
     if (hasError && errorText.isNotEmpty) {
       child = Column(


### PR DESCRIPTION
![Screenshot 2025-04-14 at 11 22 45 AM](https://github.com/user-attachments/assets/bb577f22-dc75-49af-8af6-572d22bd71fc)

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Add a medium-sized variant to the AFTextField component and refactor its styling to use size variants instead of radius for border styling.

New Features:
- Introduce a medium-sized variant for the AFTextField component, allowing for more flexible UI design.

Enhancements:
- Refactor the AFTextField component to use a size variant instead of a radius for border styling, improving consistency and flexibility in design.