### PR TITLE
fix: mobile slash menu position error

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/selection_menu/mobile_selection_menu.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/selection_menu/mobile_selection_menu.dart
@@ -215,16 +215,21 @@ class MobileSelectionMenu extends SelectionMenuService {
     final editorHeight = editorState.renderBox!.size.height;
     final screenHeight = screenSize.height;
     final editorWidth = editorState.renderBox!.size.width;
+    final rectHeight = rect.height;
 
     // show below default
     _alignment = Alignment.bottomRight;
     final bottomRight = rect.topLeft;
     final offset = bottomRight;
     final limitX = editorWidth + editorOffset.dx - menuWidth,
-        limitY = screenHeight - editorHeight + editorOffset.dy - menuHeight - 20;
+        limitY = screenHeight -
+            editorHeight +
+            editorOffset.dy -
+            menuHeight -
+            rectHeight;
     _offset = Offset(
       editorWidth - offset.dx - menuWidth,
-      screenHeight - offset.dy - menuHeight - 20,
+      screenHeight - offset.dy - menuHeight - rectHeight,
     );
 
     if (offset.dy + menuHeight >= editorOffset.dy + editorHeight) {

--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -98,8 +98,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "361b99c38370abeeb19656f89e8c31cb3666623b"
-      resolved-ref: "361b99c38370abeeb19656f89e8c31cb3666623b"
+      ref: "4967ed5"
+      resolved-ref: "4967ed57d9190948c08f868972c0babfdc470ba7"
       url: "https://github.com/AppFlowy-IO/appflowy-editor.git"
     source: git
     version: "5.1.0"

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -185,7 +185,7 @@ dependency_overrides:
   appflowy_editor:
     git:
       url: https://github.com/AppFlowy-IO/appflowy-editor.git
-      ref: '361b99c38370abeeb19656f89e8c31cb3666623b'
+      ref: '4967ed5'
 
   appflowy_editor_plugins:
     git:


### PR DESCRIPTION
Fix:
- Mobile slash menu position error
- Sometimes mobile slash menu not showing up

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Improve mobile selection menu positioning to handle different screen sizes and selection locations more robustly

Bug Fixes:
- Fix the positioning of the mobile slash menu to correctly adapt to different screen sizes and selection locations

Enhancements:
- Enhance the selection menu positioning logic to handle edge cases near screen boundaries
- Improve menu alignment and offset calculations for better user experience