### PR TITLE
chore: gitignore build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ pubspec.lock
 frontend/package
 frontend/*.deb
 
+**/build/
+
 **/Cargo.toml.bak
 
 **/.cargo/**


### PR DESCRIPTION
I'm not sure why the build folders are not added to .gitignore, so I just added that quickly. My git changes were getting filled up while building. 

Feel free to close this PR if there is a reason for tracking any folders named `build`

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Chores:
- Update .gitignore to exclude build directories from version control