### PR TITLE
test: add get database meta test

### DIFF
--- a/frontend/rust-lib/event-integration-test/src/database_event.rs
+++ b/frontend/rust-lib/event-integration-test/src/database_event.rs
@@ -584,6 +584,17 @@ impl EventIntegrationTest {
       .parse::<RepeatedRelatedRowDataPB>()
       .rows
   }
+
+  pub async fn get_database_meta(&self, database_id: &str) -> DatabaseMetaPB {
+    EventBuilder::new(self.clone())
+      .event(DatabaseEvent::GetDatabaseMeta)
+      .payload(DatabaseIdPB {
+        value: database_id.to_string(),
+      })
+      .async_send()
+      .await
+      .parse::<DatabaseMetaPB>()
+  }
 }
 
 pub struct TestRowBuilder<'a> {

--- a/frontend/rust-lib/event-integration-test/tests/database/local_test/event_test.rs
+++ b/frontend/rust-lib/event-integration-test/tests/database/local_test/event_test.rs
@@ -797,6 +797,23 @@ async fn create_calendar_event_test() {
 }
 
 #[tokio::test]
+async fn get_database_meta_test() {
+  let test = EventIntegrationTest::new_anon().await;
+  let current_workspace = test.get_current_workspace().await;
+  let grid_view = test
+    .create_grid(&current_workspace.id, "my grid view".to_owned(), vec![])
+    .await;
+
+  let database_id = test.get_database(&grid_view.id).await.id;
+
+  let database_meta = test.get_database_meta(&database_id).await;
+  let inline_view_id = database_meta.inline_view_id.clone();
+  let database_from_inline_view_id = test.get_database(&inline_view_id).await;
+
+  assert_eq!(database_meta.database_id, database_from_inline_view_id.id);
+}
+
+#[tokio::test]
 async fn update_relation_cell_test() {
   let test = EventIntegrationTest::new_anon().await;
   let current_workspace = test.get_current_workspace().await;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Add a test for retrieving database metadata in the event integration test suite

New Features:
- Add a method to get database metadata in the event integration test helper

Tests:
- Implement a new test case to verify retrieving database metadata, including checking the relationship between database and inline view IDs