### PR TITLE
feat: upgrade ubuntu version to 22.04 in github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
           - {
               arch: x86_64,
               target: x86_64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-22.04,
               extra-build-args: "",
               flutter_profile: production-linux-x86_64,
             }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_parsers/default_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_parsers/default_parser.dart
@@ -1,9 +1,8 @@
 import 'package:appflowy/plugins/document/presentation/editor_plugins/link_preview/custom_link_parser.dart';
 import 'package:appflowy_backend/log.dart';
-
-import 'package:http/http.dart' as http;
 // ignore: depend_on_referenced_packages
 import 'package:html/parser.dart' as html_parser;
+import 'package:http/http.dart' as http;
 
 abstract class LinkInfoParser {
   Future<LinkInfo?> parse(
@@ -70,7 +69,7 @@ class DefaultParser implements LinkInfoParser {
       }
 
       final favicon =
-          'https://www.google.com/s2/favicons?sz=64&domain=${link.host}';
+          'https://www.faviconextractor.com/favicon/${link.host}?larger=true';
 
       return LinkInfo(
         url: '$link',

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
@@ -593,7 +593,7 @@ impl UserManager {
     if let Ok(member_record) = select_workspace_member(db, &workspace_id.to_string(), uid) {
       if is_older_than_n_minutes(member_record.updated_at, 10) {
         self
-          .get_workspace_member_info_from_remote(&workspace_id, uid)
+          .get_workspace_member_info_from_remote(workspace_id, uid)
           .await?;
       }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

- [x] upgrade Ubuntu version to 22.04
- [x] use third party favicon extractor

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Upgrade Ubuntu version in GitHub Actions and update favicon extraction method

Enhancements:
- Replace Google favicon service with Favicon Extractor service for link previews

CI:
- Update GitHub Actions workflow to use Ubuntu 22.04 instead of Ubuntu 20.04