### PR TITLE
chore: bumped device_info_plus to 11.2.2

### DIFF
--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -533,10 +533,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      sha256: "72d146c6d7098689ff5c5f66bcf593ac11efc530095385356e131070333e64da"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.2"
+    version: "11.3.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -177,7 +177,7 @@ dev_dependencies:
 
 dependency_overrides:
   http: ^1.0.0
-  device_info_plus: ^10.1.0
+  device_info_plus: ^11.2.2
 
   url_protocol:
     git:


### PR DESCRIPTION
### Bug Resolution

fixes https://github.com/AppFlowy-IO/AppFlowy/issues/6422
and the related issues:
https://github.com/AppFlowy-IO/AppFlowy/issues/6677
https://github.com/AppFlowy-IO/AppFlowy/issues/6979
https://github.com/AppFlowy-IO/AppFlowy/issues/5874

Bug: When running AppFlowy.exe on some Windows machines, an uncaught error stopped all app processes resulting in the window never appearing and the application processes to be stuck in 'Background processes' in Task Manager. Unlike some similar reports, this case was not caused by the window appearing offscreen or corrupted AppData files.

Cause: A system call to `GetPhysicallyInstalledSystemMemory` returns an unexpected `0`, causing device_info_plus to throw an error when used to retrieve a deviceId. See device_info_plus issue https://github.com/fluttercommunity/plus_plugins/issues/2957 for their discussion. After doing more research into this on my own, I found the root cause. 

On Windows, device_info_plus calls `GetPhysicallyInstalledSystemMemory` to get the amount of system memory. This function is known to fail in Windows VMs, but I found that it also fails when Microsoft Hyper-V is active on the computer. I believe Hyper-V to be the missing commonality between the multiple issues linked above. Hyper-V is enabled to meet various requirements, such as WSL, Docker Desktop, or running other hypervisors in order to pass CPU based virtualization to other VMs.

The device_info_plus fix was to return 0 when `GetPhysicallyInstalledSystemMemory` failed, which prevents the crash although does not actually provide the memory information. This is not an issue for AppFlowy since we only need the deviceId, although I will recommend they include a fallback call to `GlobalMemoryStatusEx` to actually retrieve the system memory information when the existing call fails. 

For reference, this is their comment on this solution from the linked issue. The other two properties mentioned involve calls to GetComputerNameEx and GetUserName. In my tests, neither of these have shown vulnerable to the VM/Hyper-V condition, and regardless neither of these omissions affect AppFlowy.

> There are three properties that will throw a WindowsException when the result is 0, which has been like that since 2022 when it was originally implemented, so I am kind of surprised no one proposed a change.
> 
> I will do a PR returning default values instead of throwing, as I don't see the benefit of throwing an error, specially if 3rd party packages are not taking care of caching possible errors.

Fix description: the device_info_plus dependency override was updated to 11.2.2, which was the first to integrate the 2957 fix. (There are newer 11.3.x releases but I found dependency clashes when trying the latest version in AppFlowy)

---

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Update device_info_plus dependency to version 11.2.2 to resolve Windows-specific memory retrieval issues

Bug Fixes:
- Fixed an issue causing application crashes on Windows machines with Hyper-V enabled by updating the device_info_plus package to handle memory information retrieval errors

Chores:
- Updated pubspec.yaml to override device_info_plus dependency to version 11.2.2