### PR TITLE
feat: implement afdivider

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/component.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/component.dart
@@ -1,3 +1,4 @@
 export 'button/button.dart';
+export 'separator/divider.dart';
 export 'modal/modal.dart';
 export 'textfield/textfield.dart';

--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/separator/divider.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/separator/divider.dart
@@ -1,0 +1,53 @@
+import 'package:appflowy_ui/appflowy_ui.dart';
+import 'package:flutter/widgets.dart';
+
+class AFDivider extends StatelessWidget {
+  const AFDivider({
+    super.key,
+    this.axis = Axis.horizontal,
+    this.color,
+    this.thickness = 1.0,
+    this.spacing = 0.0,
+    this.startIndent = 0.0,
+    this.endIndent = 0.0,
+  })  : assert(thickness > 0.0),
+        assert(spacing >= 0.0),
+        assert(startIndent >= 0.0),
+        assert(endIndent >= 0.0);
+
+  final Axis axis;
+  final double thickness;
+  final double spacing;
+  final double startIndent;
+  final double endIndent;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
+    final color = this.color ?? theme.borderColorScheme.greyTertiary;
+
+    return switch (axis) {
+      Axis.horizontal => Container(
+          height: thickness,
+          color: color,
+          margin: EdgeInsetsDirectional.only(
+            start: startIndent,
+            end: endIndent,
+            top: spacing,
+            bottom: spacing,
+          ),
+        ),
+      Axis.vertical => Container(
+          width: thickness,
+          color: color,
+          margin: EdgeInsets.only(
+            left: spacing,
+            right: spacing,
+            top: startIndent,
+            bottom: endIndent,
+          ),
+        ),
+    };
+  }
+}


### PR DESCRIPTION
To create a divider with 4 pixels spacing on the top and bottom:


Using Material's Divider:

```
Divider(
    color: AppFlowyTheme.of(context).borderColorScheme.greyTertiary,
    height: 9.0,
)
```

Using AFDivider:

```
AFDivider(
    spacing: 4.0,
)
```

Note: Material's Divider allows setting thickness to 0 to have a "hairline border". This component doesn't support it and don't plan to either.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
