### PR TITLE
fix: user name stay no change when reopen the setting menu after renaming

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -54,7 +54,7 @@ class _PromptInputMobileSelectSourcesButtonState
   Widget build(BuildContext context) {
     return BlocBuilder<UserWorkspaceBloc, UserWorkspaceState>(
       builder: (context, state) {
-        final userProfile = context.read<UserWorkspaceBloc>().userProfile;
+        final userProfile = context.read<UserWorkspaceBloc>().state.userProfile;
         final workspaceId = state.currentWorkspace?.workspaceId ?? '';
         return MultiBlocProvider(
           providers: [

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
@@ -60,7 +60,7 @@ class _PromptInputDesktopSelectSourcesButtonState
   @override
   Widget build(BuildContext context) {
     final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
-    final userProfile = userWorkspaceBloc.userProfile;
+    final userProfile = userWorkspaceBloc.state.userProfile;
     final workspaceId =
         userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
 

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
@@ -134,7 +134,7 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
   @override
   Widget build(BuildContext context) {
     final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
-    final userProfile = userWorkspaceBloc.userProfile;
+    final userProfile = userWorkspaceBloc.state.userProfile;
     final workspaceId =
         userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
 

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -516,7 +516,7 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
   @override
   Widget build(BuildContext context) {
     final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
-    final userProfile = userWorkspaceBloc.userProfile;
+    final userProfile = userWorkspaceBloc.state.userProfile;
     final workspaceId =
         userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/image_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/custom_image_block_component/image_menu.dart
@@ -144,7 +144,7 @@ class _ImageMenuState extends State<ImageMenu> {
     showDialog(
       context: context,
       builder: (_) => InteractiveImageViewer(
-        userProfile: context.read<UserWorkspaceBloc?>()?.userProfile ??
+        userProfile: context.read<UserWorkspaceBloc?>()?.state.userProfile ??
             context.read<DocumentBloc>().state.userProfilePB,
         imageProvider: AFBlockImageProvider(
           images: [

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/layouts/image_browser_layout.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/multi_image_block_component/layouts/image_browser_layout.dart
@@ -53,7 +53,7 @@ class _ImageBrowserLayoutState extends State<ImageBrowserLayout> {
   @override
   void initState() {
     super.initState();
-    _userProfile = context.read<UserWorkspaceBloc?>()?.userProfile ??
+    _userProfile = context.read<UserWorkspaceBloc?>()?.state.userProfile ??
         context.read<DocumentBloc>().state.userProfilePB;
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/resizeable_image.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/resizeable_image.dart
@@ -73,7 +73,7 @@ class _ResizableImageState extends State<ResizableImage> {
 
     imageWidth = widget.width;
 
-    _userProfilePB = context.read<UserWorkspaceBloc?>()?.userProfile ??
+    _userProfilePB = context.read<UserWorkspaceBloc?>()?.state.userProfile ??
         context.read<DocumentBloc>().state.userProfilePB;
   }
 

--- a/frontend/appflowy_flutter/lib/user/application/user_listener.dart
+++ b/frontend/appflowy_flutter/lib/user/application/user_listener.dart
@@ -46,7 +46,7 @@ class UserListener {
   ///
   DidUpdateUserWorkspaceCallback? onUserWorkspaceUpdated;
   DidUpdateUserWorkspaceSetting? onUserWorkspaceSettingUpdated;
-
+  DidUpdateUserWorkspaceCallback? onUserWorkspaceOpened;
   void start({
     void Function(UserProfileNotifyValue)? onProfileUpdated,
     DidUpdateUserWorkspacesCallback? onUserWorkspaceListUpdated,
@@ -60,7 +60,6 @@ class UserListener {
     this.onUserWorkspaceListUpdated = onUserWorkspaceListUpdated;
     this.onUserWorkspaceUpdated = onUserWorkspaceUpdated;
     this.onUserWorkspaceSettingUpdated = onUserWorkspaceSettingUpdated;
-
     _userParser = UserNotificationParser(
       id: _userProfile.id.toString(),
       callback: _userNotificationCallback,
@@ -105,6 +104,13 @@ class UserListener {
         result.map(
           (r) => onUserWorkspaceSettingUpdated
               ?.call(WorkspaceSettingsPB.fromBuffer(r)),
+        );
+        break;
+      case user.UserNotification.DidOpenWorkspace:
+        result.fold(
+          (payload) => _profileNotifier?.value =
+              FlowyResult.success(UserProfilePB.fromBuffer(payload)),
+          (error) => _profileNotifier?.value = FlowyResult.failure(error),
         );
         break;
       default:

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/settings_dialog_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/settings_dialog_bloc.dart
@@ -31,7 +31,7 @@ enum SettingsPage {
 class SettingsDialogBloc
     extends Bloc<SettingsDialogEvent, SettingsDialogState> {
   SettingsDialogBloc(
-    this.userProfile,
+    UserProfilePB userProfile,
     this.currentWorkspaceMemberRole, {
     SettingsPage? initPage,
   })  : _userListener = UserListener(userProfile: userProfile),
@@ -39,7 +39,6 @@ class SettingsDialogBloc
     _dispatch();
   }
 
-  final UserProfilePB userProfile;
   final AFRolePB? currentWorkspaceMemberRole;
   final UserListener _userListener;
 
@@ -57,7 +56,7 @@ class SettingsDialogBloc
             _userListener.start(onProfileUpdated: _profileUpdated);
 
             final isBillingEnabled = await _isBillingEnabled(
-              userProfile,
+              state.userProfile,
               currentWorkspaceMemberRole,
             );
             if (isBillingEnabled) {
@@ -79,8 +78,11 @@ class SettingsDialogBloc
     FlowyResult<UserProfilePB, FlowyError> userProfileOrFailed,
   ) {
     userProfileOrFailed.fold(
-      (newUserProfile) =>
-          add(SettingsDialogEvent.didReceiveUserProfile(newUserProfile)),
+      (newUserProfile) {
+        if (!isClosed) {
+          add(SettingsDialogEvent.didReceiveUserProfile(newUserProfile));
+        }
+      },
       (err) => Log.error(err),
     );
   }

--- a/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
@@ -41,11 +41,13 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
               onUserWorkspaceListUpdated: (workspaces) =>
                   add(UserWorkspaceEvent.updateWorkspaces(workspaces)),
               onUserWorkspaceUpdated: (workspace) {
-                // If currentWorkspace is updated, eg. Icon or Name, we should notify
-                // the UI to render the updated information.
-                final currentWorkspace = state.currentWorkspace;
-                if (currentWorkspace?.workspaceId == workspace.workspaceId) {
-                  add(UserWorkspaceEvent.updateCurrentWorkspace(workspace));
+                if (!isClosed) {
+                  // If currentWorkspace is updated, eg. Icon or Name, we should notify
+                  // the UI to render the updated information.
+                  final currentWorkspace = state.currentWorkspace;
+                  if (currentWorkspace?.workspaceId == workspace.workspaceId) {
+                    add(UserWorkspaceEvent.updateCurrentWorkspace(workspace));
+                  }
                 }
               },
             );

--- a/frontend/appflowy_flutter/lib/workspace/application/view_info/view_info_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/view_info/view_info_bloc.dart
@@ -1,6 +1,9 @@
 import 'package:appflowy/util/int64_extension.dart';
 import 'package:appflowy/util/string_extension.dart';
+import 'package:appflowy_backend/dispatch/dispatch.dart';
+import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/workspace.pb.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:bloc/bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -49,6 +52,22 @@ class ViewInfoBloc extends Bloc<ViewInfoEvent, ViewInfoState> {
             ),
           );
         },
+        workspaceTypeChanged: (s) {
+          emit(
+            state.copyWith(workspaceType: s),
+          );
+        },
+      );
+    });
+
+    UserEventGetUserProfile().send().then((value) {
+      value.fold(
+        (s) {
+          if (!isClosed) {
+            add(ViewInfoEvent.workspaceTypeChanged(s.workspaceType));
+          }
+        },
+        (e) => Log.error('Failed to get user profile: $e'),
       );
     });
   }
@@ -86,6 +105,10 @@ class ViewInfoEvent with _$ViewInfoEvent {
   const factory ViewInfoEvent.wordCountChanged() = _WordCountChanged;
 
   const factory ViewInfoEvent.titleChanged(String title) = _TitleChanged;
+
+  const factory ViewInfoEvent.workspaceTypeChanged(
+    WorkspaceTypePB workspaceType,
+  ) = _WorkspaceTypeChanged;
 }
 
 @freezed
@@ -94,11 +117,13 @@ class ViewInfoState with _$ViewInfoState {
     required Counters? documentCounters,
     required Counters? titleCounters,
     required DateTime? createdAt,
+    required WorkspaceTypePB? workspaceType,
   }) = _ViewInfoState;
 
   factory ViewInfoState.initial() => const ViewInfoState(
         documentCounters: null,
         titleCounters: null,
         createdAt: null,
+        workspaceType: null,
       );
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -206,7 +206,7 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     ),
 
     // Open settings dialog
-    openSettingsHotKey(context, widget.userProfile),
+    openSettingsHotKey(context),
   ];
 
   @override

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/footer/sidebar_toast.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/footer/sidebar_toast.dart
@@ -105,7 +105,6 @@ class SidebarToast extends StatelessWidget {
     if (role.isOwner) {
       showSettingsDialog(
         context,
-        userProfile: userProfile,
         userWorkspaceBloc: userWorkspaceBloc,
         initPage: SettingsPage.plan,
       );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/header/sidebar_user.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/header/sidebar_user.dart
@@ -44,7 +44,7 @@ class SidebarUser extends StatelessWidget {
             ),
             const HSpace(8),
             Expanded(child: _buildUserName(context, state)),
-            UserSettingButton(userProfile: state.userProfile),
+            UserSettingButton(),
             const HSpace(8.0),
             const NotificationButton(),
             const HSpace(10.0),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/sidebar_workspace.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/workspace/sidebar_workspace.dart
@@ -83,7 +83,6 @@ class _SidebarWorkspaceState extends State<SidebarWorkspace> {
                       ),
                     ),
                     UserSettingButton(
-                      userProfile: widget.userProfile,
                       isHover: onHover,
                     ),
                     const HSpace(8.0),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/settings_dialog.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/settings_dialog.dart
@@ -94,21 +94,17 @@ class SettingsDialog extends StatelessWidget {
                     axis: Axis.vertical,
                     color: theme.borderColorScheme.primary,
                   ),
-                  Expanded(
-                    child: getSettingsView(
-                      context
-                          .read<UserWorkspaceBloc>()
-                          .state
-                          .currentWorkspace!
-                          .workspaceId,
-                      context.read<SettingsDialogBloc>().state.page,
-                      context.read<SettingsDialogBloc>().state.userProfile,
-                      context
-                          .read<UserWorkspaceBloc>()
-                          .state
-                          .currentWorkspace
-                          ?.role,
-                    ),
+                  BlocBuilder<UserWorkspaceBloc, UserWorkspaceState>(
+                    builder: (context, state) {
+                      return Expanded(
+                        child: getSettingsView(
+                          state.currentWorkspace!.workspaceId,
+                          context.read<SettingsDialogBloc>().state.page,
+                          state.userProfile,
+                          state.currentWorkspace?.role,
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
@@ -14,7 +14,6 @@ import 'package:appflowy_backend/dispatch/dispatch.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-error/errors.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
-import 'package:appflowy_backend/protobuf/flowy-user/user_setting.pb.dart';
 import 'package:appflowy_result/appflowy_result.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra/size.dart';

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
@@ -69,7 +69,8 @@ class AppFlowyCloudViewSetting extends StatelessWidget {
           return Column(
             children: [
               const VSpace(8),
-              const AppFlowyCloudEnableSync(),
+              if (state.workspaceType == WorkspaceTypePB.ServerW)
+                const AppFlowyCloudEnableSync(),
               const VSpace(6),
               // const AppFlowyCloudSyncLogEnabled(),
               const VSpace(12),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/widgets/more_view_actions/more_view_actions.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/widgets/more_view_actions/more_view_actions.dart
@@ -66,7 +66,7 @@ class _MoreViewActionsState extends State<MoreViewActions> {
 
   Widget _buildPopup(ViewInfoState viewInfoState) {
     final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
-    final userProfile = userWorkspaceBloc.userProfile;
+    final userProfile = userWorkspaceBloc.state.userProfile;
     final workspaceId =
         userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
 
@@ -142,7 +142,8 @@ class _MoreViewActionsState extends State<MoreViewActions> {
           mutex: popoverMutex,
         ),
       ],
-      if (widget.view.isDocument || widget.view.isDatabase) ...[
+      if (state.workspaceType == WorkspaceTypePB.ServerW &&
+          (widget.view.isDocument || widget.view.isDatabase)) ...[
         LockPageAction(
           view: view,
         ),

--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -2819,14 +2819,11 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "chrono",
  "client-api",
  "collab",
- "collab-document",
  "collab-entity",
  "collab-folder",
  "collab-integrate",
- "collab-plugins",
  "dashmap 6.0.1",
  "flowy-codegen",
  "flowy-derive",
@@ -2835,12 +2832,10 @@ dependencies = [
  "flowy-notification",
  "flowy-search-pub",
  "flowy-sqlite",
- "flowy-user-pub",
  "futures",
- "lazy_static",
  "lib-dispatch",
  "lib-infra",
- "nanoid",
+ "num_enum",
  "protobuf",
  "regex",
  "serde",
@@ -3086,6 +3081,7 @@ dependencies = [
  "lazy_static",
  "lib-dispatch",
  "lib-infra",
+ "num_enum",
  "protobuf",
  "quickcheck",
  "quickcheck_macros",
@@ -4866,6 +4862,27 @@ checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.94",
 ]
 
 [[package]]

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -102,6 +102,7 @@ derive_builder = "0.20.2"
 tantivy = { version = "0.24.0" }
 af-plugin = { version = "0.1" }
 af-local-ai = { version = "0.1" }
+num_enum = "0.7.3"
 
 # Please using the following command to update the revision id
 # Current directory: frontend

--- a/frontend/rust-lib/flowy-folder/Cargo.toml
+++ b/frontend/rust-lib/flowy-folder/Cargo.toml
@@ -8,13 +8,10 @@ edition = "2021"
 [dependencies]
 collab = { workspace = true }
 collab-folder = { workspace = true }
-collab-document = { workspace = true }
 collab-entity = { workspace = true }
-collab-plugins = { workspace = true }
 collab-integrate = { workspace = true }
 flowy-folder-pub = { workspace = true }
 flowy-search-pub = { workspace = true }
-flowy-user-pub = { workspace = true }
 flowy-sqlite = { workspace = true }
 flowy-derive.workspace = true
 flowy-notification = { workspace = true }
@@ -29,9 +26,6 @@ lib-dispatch = { workspace = true }
 bytes.workspace = true
 lib-infra = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
-nanoid = "0.4.0"
-lazy_static = "1.4.0"
-chrono = { workspace = true, default-features = false, features = ["clock"] }
 strum_macros = "0.21"
 protobuf.workspace = true
 uuid.workspace = true
@@ -44,6 +38,7 @@ client-api = { workspace = true }
 regex = "1.9.5"
 futures = "0.3.31"
 dashmap.workspace = true
+num_enum.workspace = true
 
 
 [build-dependencies]

--- a/frontend/rust-lib/flowy-folder/src/manager.rs
+++ b/frontend/rust-lib/flowy-folder/src/manager.rs
@@ -9,9 +9,7 @@ use crate::manager_observer::{
   notify_child_views_changed, notify_did_update_workspace, notify_parent_view_did_change,
   ChildViewChangeReason,
 };
-use crate::notification::{
-  folder_notification_builder, send_current_workspace_notification, FolderNotification,
-};
+use crate::notification::{folder_notification_builder, FolderNotification};
 use crate::publish_util::{generate_publish_name, view_pb_to_publish_view};
 use crate::share::{ImportData, ImportItem, ImportParams};
 use crate::util::{folder_not_init_error, workspace_data_not_sync_error};
@@ -1255,7 +1253,12 @@ impl FolderManager {
       workspace_id: workspace_id.to_string(),
       latest_view: view,
     };
-    send_current_workspace_notification(FolderNotification::DidUpdateWorkspaceSetting, setting);
+    folder_notification_builder(
+      self.user.user_id()?,
+      FolderNotification::DidUpdateWorkspaceSetting,
+    )
+    .payload(setting)
+    .send();
     Ok(())
   }
 

--- a/frontend/rust-lib/flowy-user/Cargo.toml
+++ b/frontend/rust-lib/flowy-user/Cargo.toml
@@ -46,6 +46,7 @@ tokio-stream = "0.1.14"
 semver = "1.0.22"
 validator = { workspace = true, features = ["derive"] }
 rayon = "1.10.0"
+num_enum.workspace = true
 
 [dev-dependencies]
 fake = "2.0.0"

--- a/frontend/rust-lib/flowy-user/src/entities/workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/workspace.rs
@@ -10,7 +10,6 @@ use flowy_user_pub::cloud::{AFWorkspaceSettings, AFWorkspaceSettingsChange};
 use flowy_user_pub::entities::{
   AuthType, Role, WorkspaceInvitation, WorkspaceMember, WorkspaceType,
 };
-use flowy_user_pub::sql::WorkspaceSettingsTable;
 use lib_infra::validator_fn::required_not_empty_str;
 
 #[derive(ProtoBuf, Default, Clone)]
@@ -485,6 +484,9 @@ pub struct WorkspaceSettingsPB {
 
   #[pb(index = 2)]
   pub ai_model: String,
+
+  #[pb(index = 3)]
+  pub workspace_type: WorkspaceTypePB,
 }
 
 impl From<&AFWorkspaceSettings> for WorkspaceSettingsPB {
@@ -492,15 +494,7 @@ impl From<&AFWorkspaceSettings> for WorkspaceSettingsPB {
     Self {
       disable_search_indexing: value.disable_search_indexing,
       ai_model: value.ai_model.clone(),
-    }
-  }
-}
-
-impl From<WorkspaceSettingsTable> for WorkspaceSettingsPB {
-  fn from(value: WorkspaceSettingsTable) -> Self {
-    Self {
-      disable_search_indexing: value.disable_search_indexing,
-      ai_model: value.ai_model,
+      workspace_type: WorkspaceTypePB::ServerW,
     }
   }
 }

--- a/frontend/rust-lib/flowy-user/src/notification.rs
+++ b/frontend/rust-lib/flowy-user/src/notification.rs
@@ -1,11 +1,13 @@
+use crate::entities::AuthStateChangedPB;
 use flowy_derive::ProtoBuf_Enum;
 use flowy_notification::NotificationBuilder;
-
-use crate::entities::AuthStateChangedPB;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use tracing::trace;
 
 const USER_OBSERVABLE_SOURCE: &str = "User";
 
-#[derive(ProtoBuf_Enum, Debug, Default)]
+#[derive(ProtoBuf_Enum, Debug, Default, IntoPrimitive, TryFromPrimitive, Clone)]
+#[repr(i32)]
 pub(crate) enum UserNotification {
   #[default]
   Unknown = 0,
@@ -18,17 +20,13 @@ pub(crate) enum UserNotification {
   DidLoadUserAwareness = 7,
   // TODO: implement reminder observer
   DidUpdateReminder = 8,
+  DidOpenWorkspace = 9,
 }
 
-impl std::convert::From<UserNotification> for i32 {
-  fn from(notification: UserNotification) -> Self {
-    notification as i32
-  }
-}
-
-#[tracing::instrument(level = "trace")]
-pub(crate) fn send_notification(id: &str, ty: UserNotification) -> NotificationBuilder {
-  NotificationBuilder::new(id, ty, USER_OBSERVABLE_SOURCE)
+#[tracing::instrument(level = "trace", skip_all)]
+pub(crate) fn send_notification<T: ToString>(id: T, ty: UserNotification) -> NotificationBuilder {
+  trace!("UserNotification: id = {}, ty = {:?}", id.to_string(), ty);
+  NotificationBuilder::new(&id.to_string(), ty, USER_OBSERVABLE_SOURCE)
 }
 
 #[tracing::instrument(level = "trace")]

--- a/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
+++ b/frontend/rust-lib/flowy-user/src/user_manager/manager_user_workspace.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use crate::entities::{
   RepeatedUserWorkspacePB, SubscribeWorkspacePB, SuccessWorkspaceSubscriptionPB,
-  UpdateUserWorkspaceSettingPB, UserWorkspacePB, WorkspaceSettingsPB, WorkspaceSubscriptionInfoPB,
-  WorkspaceTypePB,
+  UpdateUserWorkspaceSettingPB, UserProfilePB, UserWorkspacePB, WorkspaceSettingsPB,
+  WorkspaceSubscriptionInfoPB, WorkspaceTypePB,
 };
 use crate::notification::{send_notification, UserNotification};
 use crate::services::billing_check::PeriodicallyCheckBillingState;
@@ -214,6 +214,11 @@ impl UserManager {
         err
       );
     }
+
+    let pb = UserProfilePB::from(profile);
+    send_notification(uid, UserNotification::DidOpenWorkspace)
+      .payload(pb)
+      .send();
 
     Ok(())
   }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Refactor user profile management to improve state handling and synchronization across the application

Bug Fixes:
- Fix user name not updating when reopening the settings menu after renaming

Enhancements:
- Centralize user profile state management in UserWorkspaceBloc
- Add support for dynamically updating user profile across different components

Chores:
- Remove redundant user profile references
- Update multiple components to use centralized user profile state