### PR TITLE
fix: some lr issues

### DIFF
--- a/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
+++ b/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
@@ -39,9 +39,11 @@ Future<bool> afLaunchUri(
     );
   }
 
-  // on Linux or Android, add http scheme to the url if it is not present
+  // on Linux or Android or Windows, add http scheme to the url if it is not present
   if ((UniversalPlatform.isLinux ||
-      UniversalPlatform.isAndroid) && !isURL(url, {'require_protocol': true})) {
+          UniversalPlatform.isAndroid ||
+          UniversalPlatform.isWindows) &&
+      !isURL(url, {'require_protocol': true})) {
     uri = Uri.parse('https://$url');
   }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_edit_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_edit_menu.dart
@@ -423,6 +423,7 @@ class _LinkEditMenuState extends State<LinkEditMenu> {
       return;
     }
     widget.onApply.call(linkInfo);
+    onDismiss();
   }
 
   void onConfirm() {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/home_stack.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/home_stack.dart
@@ -16,6 +16,7 @@ import 'package:appflowy/workspace/presentation/home/home_sizes.dart';
 import 'package:appflowy/workspace/presentation/home/navigation.dart';
 import 'package:appflowy/workspace/presentation/home/tabs/tabs_manager.dart';
 import 'package:appflowy/workspace/presentation/home/toast.dart';
+import 'package:appflowy/workspace/presentation/notifications/number_red_dot.dart';
 import 'package:appflowy_backend/dispatch/dispatch.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
@@ -65,14 +66,7 @@ class _HomeStackState extends State<HomeStack> with WindowListener {
         builder: (context, state) => Column(
           children: [
             if (UniversalPlatform.isWindows)
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  WindowTitleBar(
-                    leftChildren: [_buildToggleMenuButton(context)],
-                  ),
-                ],
-              ),
+              WindowTitleBar(leftChildren: [_buildToggleMenuButton(context)]),
             Padding(
               padding: EdgeInsets.only(left: widget.layout.menuSpacing),
               child: TabsManager(
@@ -149,23 +143,46 @@ class _HomeStackState extends State<HomeStack> with WindowListener {
       ],
     );
 
-    return FlowyTooltip(
-      richMessage: textSpan,
-      child: Listener(
-        behavior: HitTestBehavior.translucent,
-        onPointerDown: (_) => context
-            .read<HomeSettingBloc>()
-            .add(const HomeSettingEvent.changeMenuStatus(MenuStatus.hidden)),
-        child: FlowyHover(
-          child: Container(
-            width: 24,
-            padding: const EdgeInsets.all(4),
-            child: const RotatedBox(
-              quarterTurns: 2,
-              child: FlowySvg(FlowySvgs.hide_menu_s),
+    return SizedBox.square(
+      dimension: 24,
+      child: Stack(
+        children: [
+          FlowyTooltip(
+            richMessage: textSpan,
+            child: GestureDetector(
+              onTap: () {
+                final bloc = context.read<HomeSettingBloc?>();
+                if (bloc == null) return;
+                if (bloc.state.menuStatus == MenuStatus.hidden) {
+                  bloc.add(
+                    const HomeSettingEvent.changeMenuStatus(
+                      MenuStatus.expanded,
+                    ),
+                  );
+                } else {
+                  bloc.add(
+                    const HomeSettingEvent.changeMenuStatus(MenuStatus.hidden),
+                  );
+                }
+              },
+              behavior: HitTestBehavior.opaque,
+              child: FlowyHover(
+                child: Container(
+                  width: 24,
+                  padding: const EdgeInsets.all(4),
+                  child: const RotatedBox(
+                    quarterTurns: 2,
+                    child: FlowySvg(FlowySvgs.hide_menu_s),
+                  ),
+                ),
+              ),
             ),
           ),
-        ),
+          Align(
+            alignment: Alignment.topRight,
+            child: NumberedRedDot.desktop(),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
- [x] On Windows, click to open an inline link doesn’t work for [appflowy.com](http://appflowy.com/) (no https://) as the link 
- [x] On Windows, the link menu doesn’t close automatically after I click Apply 
- [x] The sidebar collapse/uncollapse is broken. The shortcut is not working either. The shortcut displayed in the tooltip on hover is also not the right one. 

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Fix link handling on Windows and restore sidebar toggle functionality.

Bug Fixes:
- Allow opening links without an explicit protocol (e.g., "appflowy.com") on Windows.
- Close the link editing popover automatically after clicking 'Apply'.
- Restore the expand/collapse functionality of the sidebar toggle button.