### PR TITLE
fix: text color for local ai model picker

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/setting_ai_view/ollama_setting.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/setting_ai_view/ollama_setting.dart
@@ -154,6 +154,7 @@ class LocalAIModelSelection extends StatelessWidget {
               height: 40,
               child: SettingsDropdown<AIModelPB>(
                 key: const Key('_AIModelSelection'),
+                textStyle: Theme.of(context).textTheme.bodySmall,
                 onChanged: (model) => context
                     .read<OllamaSettingBloc>()
                     .add(OllamaSettingEvent.setDefaultModel(model)),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_dropdown.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/shared/settings_dropdown.dart
@@ -17,6 +17,7 @@ class SettingsDropdown<T> extends StatefulWidget {
     this.actions,
     this.expandWidth = true,
     this.selectOptionCompare,
+    this.textStyle,
   });
 
   final T selectedOption;
@@ -25,6 +26,7 @@ class SettingsDropdown<T> extends StatefulWidget {
   final void Function(T)? onChanged;
   final List<Widget>? actions;
   final bool expandWidth;
+  final TextStyle? textStyle;
 
   @override
   State<SettingsDropdown<T>> createState() => _SettingsDropdownState<T>();
@@ -55,10 +57,11 @@ class _SettingsDropdownState<T> extends State<SettingsDropdown<T>> {
             initialSelection: widget.selectedOption,
             dropdownMenuEntries: widget.options,
             selectOptionCompare: widget.selectOptionCompare,
-            textStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  fontFamily: fontFamilyUsed,
-                  fontWeight: FontWeight.w400,
-                ),
+            textStyle: widget.textStyle ??
+                Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      fontFamily: fontFamilyUsed,
+                      fontWeight: FontWeight.w400,
+                    ),
             menuStyle: MenuStyle(
               maximumSize:
                   const WidgetStatePropertyAll(Size(double.infinity, 250)),


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Allow customizing the text style in `SettingsDropdown` and apply it to the local AI model picker.

Bug Fixes:
- Set the correct text style for the local AI model selection dropdown in Ollama settings.

Enhancements:
- Add an optional `textStyle` parameter to the `SettingsDropdown` widget.