### PR TITLE
refactor: view selector

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/ai.dart
+++ b/frontend/appflowy_flutter/lib/ai/ai.dart
@@ -5,6 +5,7 @@ export 'service/appflowy_ai_service.dart';
 export 'service/error.dart';
 export 'service/ai_model_state_notifier.dart';
 export 'service/select_model_bloc.dart';
+export 'service/view_selector_cubit.dart';
 export 'widgets/loading_indicator.dart';
 export 'widgets/prompt_input/action_buttons.dart';
 export 'widgets/prompt_input/desktop_prompt_input.dart';

--- a/frontend/appflowy_flutter/lib/ai/service/view_selector_cubit.dart
+++ b/frontend/appflowy_flutter/lib/ai/service/view_selector_cubit.dart
@@ -289,7 +289,7 @@ class ViewSelectorCubit extends Cubit<ViewSelectorState> {
         : children;
   }
 
-  void toggleSelectedStatus(ViewSelectorItem item) {
+  void toggleSelectedStatus(ViewSelectorItem item, bool isSelectedSection) {
     if (item.view.isSpace) {
       return;
     }
@@ -309,6 +309,13 @@ class ViewSelectorCubit extends Cubit<ViewSelectorState> {
           selectedSourceIds.remove(id);
         }
       }
+    }
+
+    if (isSelectedSection) {
+      item.selectedStatusNotifier.value = item.selectedStatus.isUnselected ||
+              item.selectedStatus.isPartiallySelected
+          ? ViewSelectedStatus.selected
+          : ViewSelectedStatus.unselected;
     }
 
     updateSelectedStatus();

--- a/frontend/appflowy_flutter/lib/ai/service/view_selector_cubit.dart
+++ b/frontend/appflowy_flutter/lib/ai/service/view_selector_cubit.dart
@@ -6,13 +6,12 @@ import 'package:appflowy_result/appflowy_result.dart';
 import 'package:bloc/bloc.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-part 'chat_select_sources_cubit.freezed.dart';
+part 'view_selector_cubit.freezed.dart';
 
-const int _kMaxSelectedParentPageCount = 3;
-
-enum SourceSelectedStatus {
+enum ViewSelectedStatus {
   unselected,
   selected,
   partiallySelected;
@@ -22,45 +21,46 @@ enum SourceSelectedStatus {
   bool get isPartiallySelected => this == partiallySelected;
 }
 
-class ChatSource {
-  ChatSource({
+class ViewSelectorItem {
+  ViewSelectorItem({
     required this.view,
     required this.parentView,
     required this.children,
     required bool isExpanded,
-    required SourceSelectedStatus selectedStatus,
-    required IgnoreViewType ignoreStatus,
+    required ViewSelectedStatus selectedStatus,
+    required bool isDisabled,
   })  : isExpandedNotifier = ValueNotifier(isExpanded),
         selectedStatusNotifier = ValueNotifier(selectedStatus),
-        ignoreStatusNotifier = ValueNotifier(ignoreStatus);
+        isDisabledNotifier = ValueNotifier(isDisabled);
 
   final ViewPB view;
   final ViewPB? parentView;
-  final List<ChatSource> children;
+  final List<ViewSelectorItem> children;
   final ValueNotifier<bool> isExpandedNotifier;
-  final ValueNotifier<SourceSelectedStatus> selectedStatusNotifier;
-  final ValueNotifier<IgnoreViewType> ignoreStatusNotifier;
+  final ValueNotifier<bool> isDisabledNotifier;
+  final ValueNotifier<ViewSelectedStatus> selectedStatusNotifier;
 
   bool get isExpanded => isExpandedNotifier.value;
-  SourceSelectedStatus get selectedStatus => selectedStatusNotifier.value;
-  IgnoreViewType get ignoreStatus => ignoreStatusNotifier.value;
+  ViewSelectedStatus get selectedStatus => selectedStatusNotifier.value;
+  bool get isDisabled => isDisabledNotifier.value;
 
   void toggleIsExpanded() {
-    isExpandedNotifier.value = !isExpanded;
+    isExpandedNotifier.value = !isExpandedNotifier.value;
   }
 
-  ChatSource copy() {
-    return ChatSource(
+  ViewSelectorItem copy() {
+    return ViewSelectorItem(
       view: view,
       parentView: parentView,
-      children: children.map<ChatSource>((child) => child.copy()).toList(),
-      ignoreStatus: ignoreStatus,
-      isExpanded: isExpanded,
-      selectedStatus: selectedStatus,
+      children:
+          children.map<ViewSelectorItem>((child) => child.copy()).toList(),
+      isDisabled: isDisabledNotifier.value,
+      isExpanded: isExpandedNotifier.value,
+      selectedStatus: selectedStatusNotifier.value,
     );
   }
 
-  ChatSource? findChildBySourceId(String sourceId) {
+  ViewSelectorItem? findChildBySourceId(String sourceId) {
     if (view.id == sourceId) {
       return this;
     }
@@ -73,20 +73,11 @@ class ChatSource {
     return null;
   }
 
-  void resetIgnoreViewTypeRecursive() {
-    ignoreStatusNotifier.value = view.layout.isDocumentView
-        ? IgnoreViewType.none
-        : IgnoreViewType.disable;
+  void setIsDisabledRecursive(bool Function(ViewPB) newIsDisabled) {
+    isDisabledNotifier.value = newIsDisabled(view);
 
     for (final child in children) {
-      child.resetIgnoreViewTypeRecursive();
-    }
-  }
-
-  void updateIgnoreViewTypeRecursive(IgnoreViewType newIgnoreViewType) {
-    ignoreStatusNotifier.value = newIgnoreViewType;
-    for (final child in children) {
-      child.updateIgnoreViewTypeRecursive(newIgnoreViewType);
+      child.setIsDisabledRecursive(newIsDisabled);
     }
   }
 
@@ -96,21 +87,25 @@ class ChatSource {
     }
     isExpandedNotifier.dispose();
     selectedStatusNotifier.dispose();
-    ignoreStatusNotifier.dispose();
+    isDisabledNotifier.dispose();
   }
 }
 
-class ChatSettingsCubit extends Cubit<ChatSettingsState> {
-  ChatSettingsCubit({
-    this.hideDisabled = false,
-  }) : super(ChatSettingsState.initial());
+class ViewSelectorCubit extends Cubit<ViewSelectorState> {
+  ViewSelectorCubit({
+    required this.getIgnoreViewType,
+    this.maxSelectedParentPageCount,
+  }) : super(ViewSelectorState.initial()) {
+    filterTextController.addListener(onFilterChanged);
+  }
 
-  final bool hideDisabled;
+  final IgnoreViewType Function(ViewPB) getIgnoreViewType;
+  final int? maxSelectedParentPageCount;
 
   final List<String> selectedSourceIds = [];
-  final List<ChatSource> sources = [];
-  final List<ChatSource> selectedSources = [];
-  String filter = '';
+  final List<ViewSelectorItem> sources = [];
+  final List<ViewSelectorItem> selectedSources = [];
+  final filterTextController = TextEditingController();
 
   void updateSelectedSources(List<String> newSelectedSourceIds) {
     selectedSourceIds.clear();
@@ -118,7 +113,7 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
   }
 
   void refreshSources(List<ViewPB> spaceViews, ViewPB? currentSpace) async {
-    filter = "";
+    filterTextController.clear();
 
     final newSources = await Future.wait(
       spaceViews.map((view) => _recursiveBuild(view, null)),
@@ -155,29 +150,30 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
       ..addAll(selected.map((e) => e.copy()));
   }
 
-  Future<ChatSource> _recursiveBuild(ViewPB view, ViewPB? parentView) async {
-    SourceSelectedStatus selectedStatus = SourceSelectedStatus.unselected;
+  Future<ViewSelectorItem> _recursiveBuild(
+    ViewPB view,
+    ViewPB? parentView,
+  ) async {
+    ViewSelectedStatus selectedStatus = ViewSelectedStatus.unselected;
     final isThisSourceSelected = selectedSourceIds.contains(view.id);
 
     final childrenViews =
         await ViewBackendService.getChildViews(viewId: view.id).toNullable();
 
     int selectedCount = 0;
-    final children = <ChatSource>[];
+    final children = <ViewSelectorItem>[];
 
     if (childrenViews != null) {
       for (final childView in childrenViews) {
-        if (childView.layout == ViewLayoutPB.Chat) {
+        if (getIgnoreViewType(childView) == IgnoreViewType.hide) {
           continue;
         }
-        if (childView.layout != ViewLayoutPB.Document && hideDisabled) {
-          continue;
-        }
-        final childChatSource = await _recursiveBuild(childView, view);
-        if (childChatSource.selectedStatus.isSelected) {
+
+        final childItem = await _recursiveBuild(childView, view);
+        if (childItem.selectedStatus.isSelected) {
           selectedCount++;
         }
-        children.add(childChatSource);
+        children.add(childItem);
       }
 
       final areAllChildrenSelectedOrNoChildren =
@@ -186,47 +182,49 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
           children.any((e) => !e.selectedStatus.isUnselected);
 
       if (isThisSourceSelected && areAllChildrenSelectedOrNoChildren) {
-        selectedStatus = SourceSelectedStatus.selected;
+        selectedStatus = ViewSelectedStatus.selected;
       } else if (isThisSourceSelected || isAnyChildNotUnselected) {
-        selectedStatus = SourceSelectedStatus.partiallySelected;
+        selectedStatus = ViewSelectedStatus.partiallySelected;
       }
     } else if (isThisSourceSelected) {
-      selectedStatus = SourceSelectedStatus.selected;
+      selectedStatus = ViewSelectedStatus.selected;
     }
 
-    return ChatSource(
+    return ViewSelectorItem(
       view: view,
       parentView: parentView,
       children: children,
-      ignoreStatus: view.layout.isDocumentView
-          ? IgnoreViewType.none
-          : IgnoreViewType.disable,
+      isDisabled: getIgnoreViewType(view) == IgnoreViewType.disable,
       isExpanded: false,
       selectedStatus: selectedStatus,
     );
   }
 
-  void _restrictSelectionIfNecessary(List<ChatSource> sources) {
+  void _restrictSelectionIfNecessary(List<ViewSelectorItem> sources) {
+    if (maxSelectedParentPageCount == null) {
+      return;
+    }
     for (final source in sources) {
-      source.resetIgnoreViewTypeRecursive();
+      source.setIsDisabledRecursive((view) {
+        return getIgnoreViewType(view) == IgnoreViewType.disable;
+      });
     }
     if (sources.where((e) => !e.selectedStatus.isUnselected).length >=
-        _kMaxSelectedParentPageCount) {
+        maxSelectedParentPageCount!) {
       sources
-          .where((e) => e.selectedStatus == SourceSelectedStatus.unselected)
+          .where((e) => e.selectedStatus == ViewSelectedStatus.unselected)
           .forEach(
-            (e) => e.updateIgnoreViewTypeRecursive(IgnoreViewType.disable),
+            (e) => e.setIsDisabledRecursive((_) => true),
           );
     }
   }
 
-  void updateFilter(String filter) {
-    this.filter = filter;
+  void onFilterChanged() {
     for (final source in state.visibleSources) {
       source.dispose();
     }
     if (sources.isEmpty) {
-      emit(ChatSettingsState.initial());
+      emit(ViewSelectorState.initial());
     } else {
       final selected =
           selectedSources.map(_buildSearchResults).nonNulls.toList();
@@ -242,13 +240,13 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
   }
 
   /// traverse tree to build up search query
-  ChatSource? _buildSearchResults(ChatSource chatSource) {
-    final isVisible = chatSource.view.nameOrDefault
+  ViewSelectorItem? _buildSearchResults(ViewSelectorItem item) {
+    final isVisible = item.view.nameOrDefault
         .toLowerCase()
-        .contains(filter.toLowerCase());
+        .contains(filterTextController.text.toLowerCase());
 
-    final childrenResults = <ChatSource>[];
-    for (final childSource in chatSource.children) {
+    final childrenResults = <ViewSelectorItem>[];
+    for (final childSource in item.children) {
       final childResult = _buildSearchResults(childSource);
       if (childResult != null) {
         childrenResults.add(childResult);
@@ -256,48 +254,50 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     }
 
     return isVisible || childrenResults.isNotEmpty
-        ? ChatSource(
-            view: chatSource.view,
-            parentView: chatSource.parentView,
+        ? ViewSelectorItem(
+            view: item.view,
+            parentView: item.parentView,
             children: childrenResults,
-            ignoreStatus: chatSource.ignoreStatus,
-            isExpanded: chatSource.isExpanded,
-            selectedStatus: chatSource.selectedStatus,
+            isDisabled: item.isDisabled,
+            isExpanded: item.isExpanded,
+            selectedStatus: item.selectedStatus,
           )
         : null;
   }
 
   /// traverse tree to build up selected sources
-  Iterable<ChatSource> _buildSelectedSources(ChatSource chatSource) {
-    final children = <ChatSource>[];
+  Iterable<ViewSelectorItem> _buildSelectedSources(
+    ViewSelectorItem item,
+  ) {
+    final children = <ViewSelectorItem>[];
 
-    for (final childSource in chatSource.children) {
+    for (final childSource in item.children) {
       children.addAll(_buildSelectedSources(childSource));
     }
 
-    return selectedSourceIds.contains(chatSource.view.id)
+    return selectedSourceIds.contains(item.view.id)
         ? [
-            ChatSource(
-              view: chatSource.view,
-              parentView: chatSource.parentView,
+            ViewSelectorItem(
+              view: item.view,
+              parentView: item.parentView,
               children: children,
-              ignoreStatus: chatSource.ignoreStatus,
-              selectedStatus: chatSource.selectedStatus,
+              isDisabled: item.isDisabled,
+              selectedStatus: item.selectedStatus,
               isExpanded: true,
             ),
           ]
         : children;
   }
 
-  void toggleSelectedStatus(ChatSource chatSource) {
-    if (chatSource.view.isSpace) {
+  void toggleSelectedStatus(ViewSelectorItem item) {
+    if (item.view.isSpace) {
       return;
     }
-    final allIds = _recursiveGetSourceIds(chatSource);
+    final allIds = _recursiveGetSourceIds(item);
 
-    if (chatSource.selectedStatus.isUnselected ||
-        chatSource.selectedStatus.isPartiallySelected &&
-            !chatSource.view.layout.isDocumentView) {
+    if (item.selectedStatus.isUnselected ||
+        item.selectedStatus.isPartiallySelected &&
+            !item.view.layout.isDocumentView) {
       for (final id in allIds) {
         if (!selectedSourceIds.contains(id)) {
           selectedSourceIds.add(id);
@@ -314,10 +314,10 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     updateSelectedStatus();
   }
 
-  List<String> _recursiveGetSourceIds(ChatSource chatSource) {
+  List<String> _recursiveGetSourceIds(ViewSelectorItem item) {
     return [
-      if (chatSource.view.layout.isDocumentView) chatSource.view.id,
-      for (final childSource in chatSource.children)
+      if (item.view.layout.isDocumentView) item.view.id,
+      for (final childSource in item.children)
         ..._recursiveGetSourceIds(childSource),
     ];
   }
@@ -342,44 +342,42 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     );
   }
 
-  SourceSelectedStatus _recursiveUpdateSelectedStatus(ChatSource chatSource) {
-    SourceSelectedStatus selectedStatus = SourceSelectedStatus.unselected;
+  ViewSelectedStatus _recursiveUpdateSelectedStatus(ViewSelectorItem item) {
+    ViewSelectedStatus selectedStatus = ViewSelectedStatus.unselected;
 
     int selectedCount = 0;
-    for (final childSource in chatSource.children) {
+    for (final childSource in item.children) {
       final childStatus = _recursiveUpdateSelectedStatus(childSource);
       if (childStatus.isSelected) {
         selectedCount++;
       }
     }
 
-    final isThisSourceSelected = selectedSourceIds.contains(chatSource.view.id);
+    final isThisSourceSelected = selectedSourceIds.contains(item.view.id);
     final areAllChildrenSelectedOrNoChildren =
-        chatSource.children.length == selectedCount;
+        item.children.length == selectedCount;
     final isAnyChildNotUnselected =
-        chatSource.children.any((e) => !e.selectedStatus.isUnselected);
+        item.children.any((e) => !e.selectedStatus.isUnselected);
 
     if (isThisSourceSelected && areAllChildrenSelectedOrNoChildren) {
-      selectedStatus = SourceSelectedStatus.selected;
+      selectedStatus = ViewSelectedStatus.selected;
     } else if (isThisSourceSelected || isAnyChildNotUnselected) {
-      selectedStatus = SourceSelectedStatus.partiallySelected;
+      selectedStatus = ViewSelectedStatus.partiallySelected;
     }
 
-    chatSource.selectedStatusNotifier.value = selectedStatus;
+    item.selectedStatusNotifier.value = selectedStatus;
     return selectedStatus;
   }
 
-  void toggleIsExpanded(ChatSource chatSource, bool isSelectedSection) {
-    chatSource.toggleIsExpanded();
+  void toggleIsExpanded(ViewSelectorItem item, bool isSelectedSection) {
+    item.toggleIsExpanded();
     if (isSelectedSection) {
       for (final selectedSource in selectedSources) {
-        selectedSource
-            .findChildBySourceId(chatSource.view.id)
-            ?.toggleIsExpanded();
+        selectedSource.findChildBySourceId(item.view.id)?.toggleIsExpanded();
       }
     } else {
       for (final source in sources) {
-        final child = source.findChildBySourceId(chatSource.view.id);
+        final child = source.findChildBySourceId(item.view.id);
         if (child != null) {
           child.toggleIsExpanded();
           break;
@@ -402,18 +400,19 @@ class ChatSettingsCubit extends Cubit<ChatSettingsState> {
     for (final child in state.visibleSources) {
       child.dispose();
     }
+    filterTextController.dispose();
     return super.close();
   }
 }
 
 @freezed
-class ChatSettingsState with _$ChatSettingsState {
-  const factory ChatSettingsState({
-    required List<ChatSource> visibleSources,
-    required List<ChatSource> selectedSources,
-  }) = _ChatSettingsState;
+class ViewSelectorState with _$ViewSelectorState {
+  const factory ViewSelectorState({
+    required List<ViewSelectorItem> visibleSources,
+    required List<ViewSelectorItem> selectedSources,
+  }) = _ViewSelectorState;
 
-  factory ChatSettingsState.initial() => const ChatSettingsState(
+  factory ViewSelectorState.initial() => const ViewSelectorState(
         visibleSources: [],
         selectedSources: [],
       );

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -209,7 +209,7 @@ class _MobileSelectSourcesSheetBody extends StatelessWidget {
                     onSelected: (item) {
                       context
                           .read<ViewSelectorCubit>()
-                          .toggleSelectedStatus(item);
+                          .toggleSelectedStatus(item, false);
                     },
                     height: 40.0,
                   );

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -34,6 +34,7 @@ class PromptInputMobileSelectSourcesButton extends StatefulWidget {
 class _PromptInputMobileSelectSourcesButtonState
     extends State<PromptInputMobileSelectSourcesButton> {
   late final cubit = ViewSelectorCubit(
+    maxSelectedParentPageCount: 3,
     getIgnoreViewType: (view) {
       if (view.isSpace) {
         return IgnoreViewType.none;

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -2,12 +2,13 @@ import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/base/flowy_search_text_field.dart';
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
-import 'package:appflowy/plugins/ai_chat/application/chat_select_sources_cubit.dart';
+import 'package:appflowy/ai/service/view_selector_cubit.dart';
 import 'package:appflowy/plugins/base/drag_handler.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
 import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
+import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
@@ -32,7 +33,17 @@ class PromptInputMobileSelectSourcesButton extends StatefulWidget {
 
 class _PromptInputMobileSelectSourcesButtonState
     extends State<PromptInputMobileSelectSourcesButton> {
-  late final cubit = ChatSettingsCubit();
+  late final cubit = ViewSelectorCubit(
+    getIgnoreViewType: (view) {
+      if (view.isSpace) {
+        return IgnoreViewType.none;
+      }
+      if (view.layout != ViewLayoutPB.Document) {
+        return IgnoreViewType.hide;
+      }
+      return IgnoreViewType.none;
+    },
+  );
 
   @override
   void initState() {
@@ -91,7 +102,7 @@ class _PromptInputMobileSelectSourcesButtonState
                 ),
                 onTap: () async {
                   context
-                      .read<ChatSettingsCubit>()
+                      .read<ViewSelectorCubit>()
                       .refreshSources(state.spaces, state.currentSpace);
                   await showMobileBottomSheet<void>(
                     context,
@@ -129,7 +140,7 @@ class _PromptInputMobileSelectSourcesButtonState
   }
 }
 
-class _MobileSelectSourcesSheetBody extends StatefulWidget {
+class _MobileSelectSourcesSheetBody extends StatelessWidget {
   const _MobileSelectSourcesSheetBody({
     required this.scrollController,
   });
@@ -137,24 +148,9 @@ class _MobileSelectSourcesSheetBody extends StatefulWidget {
   final ScrollController scrollController;
 
   @override
-  State<_MobileSelectSourcesSheetBody> createState() =>
-      _MobileSelectSourcesSheetBodyState();
-}
-
-class _MobileSelectSourcesSheetBodyState
-    extends State<_MobileSelectSourcesSheetBody> {
-  final textController = TextEditingController();
-
-  @override
-  void dispose() {
-    textController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return CustomScrollView(
-      controller: widget.scrollController,
+      controller: scrollController,
       shrinkWrap: true,
       slivers: [
         SliverPersistentHeader(
@@ -183,10 +179,9 @@ class _MobileSelectSourcesSheetBodyState
                     child: SizedBox(
                       height: 44.0,
                       child: FlowySearchTextField(
-                        controller: textController,
-                        onChanged: (value) => context
-                            .read<ChatSettingsCubit>()
-                            .updateFilter(value),
+                        controller: context
+                            .read<ViewSelectorCubit>()
+                            .filterTextController,
                       ),
                     ),
                   ),
@@ -196,27 +191,25 @@ class _MobileSelectSourcesSheetBodyState
             ),
           ),
         ),
-        BlocBuilder<ChatSettingsCubit, ChatSettingsState>(
+        BlocBuilder<ViewSelectorCubit, ViewSelectorState>(
           builder: (context, state) {
-            final sources = state.visibleSources
-                .where((e) => e.ignoreStatus != IgnoreViewType.hide);
             return SliverList(
               delegate: SliverChildBuilderDelegate(
-                childCount: sources.length,
+                childCount: state.visibleSources.length,
                 (context, index) {
-                  final source = sources.elementAt(index);
-                  return ChatSourceTreeItem(
+                  final source = state.visibleSources.elementAt(index);
+                  return ViewSelectorTreeItem(
                     key: ValueKey(
                       'visible_select_sources_tree_item_${source.view.id}',
                     ),
-                    chatSource: source,
+                    viewSelectorItem: source,
                     level: 0,
                     isDescendentOfSpace: source.view.isSpace,
                     isSelectedSection: false,
-                    onSelected: (chatSource) {
+                    onSelected: (item) {
                       context
-                          .read<ChatSettingsCubit>()
-                          .toggleSelectedStatus(chatSource);
+                          .read<ViewSelectorCubit>()
+                          .toggleSelectedStatus(item);
                     },
                     height: 40.0,
                   );

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
@@ -243,7 +243,7 @@ class _PopoverContent extends StatelessWidget {
         isDescendentOfSpace: e.view.isSpace,
         isSelectedSection: true,
         onSelected: (item) {
-          context.read<ViewSelectorCubit>().toggleSelectedStatus(item);
+          context.read<ViewSelectorCubit>().toggleSelectedStatus(item, true);
         },
         height: 30.0,
       ),
@@ -264,7 +264,7 @@ class _PopoverContent extends StatelessWidget {
         isDescendentOfSpace: e.view.isSpace,
         isSelectedSection: false,
         onSelected: (item) {
-          context.read<ViewSelectorCubit>().toggleSelectedStatus(item);
+          context.read<ViewSelectorCubit>().toggleSelectedStatus(item, false);
         },
         height: 30.0,
       ),

--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_menu.dart
@@ -39,6 +39,7 @@ class PromptInputDesktopSelectSourcesButton extends StatefulWidget {
 class _PromptInputDesktopSelectSourcesButtonState
     extends State<PromptInputDesktopSelectSourcesButton> {
   late final cubit = ViewSelectorCubit(
+    maxSelectedParentPageCount: 3,
     getIgnoreViewType: (view) {
       if (view.isSpace) {
         return IgnoreViewType.none;

--- a/frontend/appflowy_flutter/lib/ai/widgets/view_selector.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/view_selector.dart
@@ -1,0 +1,39 @@
+import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
+import 'package:appflowy/workspace/application/user/prelude.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/single_child_widget.dart';
+
+class ViewSelector extends StatelessWidget {
+  const ViewSelector({
+    super.key,
+    required this.viewSelectorCubit,
+    required this.child,
+  });
+
+  final SingleChildWidget viewSelectorCubit;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
+    final userProfile = userWorkspaceBloc.state.userProfile;
+    final workspaceId =
+        userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
+
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) {
+            return SpaceBloc(
+              userProfile: userProfile,
+              workspaceId: workspaceId,
+            )..add(const SpaceEvent.initial(openFirstPage: false));
+          },
+        ),
+        viewSelectorCubit,
+      ],
+      child: child,
+    );
+  }
+}

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/application/ai_chat_prelude.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/application/ai_chat_prelude.dart
@@ -11,5 +11,4 @@ export 'chat_message_service.dart';
 export 'chat_message_stream.dart';
 export 'chat_notification.dart';
 export 'chat_select_message_bloc.dart';
-export 'chat_select_sources_cubit.dart';
 export 'chat_user_message_bloc.dart';

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:appflowy/ai/ai.dart';
+import 'package:appflowy/ai/widgets/view_selector.dart';
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/ai_chat/application/chat_edit_document_service.dart';
@@ -9,7 +10,6 @@ import 'package:appflowy/plugins/document/application/prelude.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
 import 'package:appflowy/workspace/application/tabs/tabs_bloc.dart';
-import 'package:appflowy/workspace/application/user/prelude.dart';
 import 'package:appflowy/workspace/application/view/prelude.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
@@ -134,33 +134,20 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
 
   @override
   Widget build(BuildContext context) {
-    final userWorkspaceBloc = context.read<UserWorkspaceBloc>();
-    final userProfile = userWorkspaceBloc.state.userProfile;
-    final workspaceId =
-        userWorkspaceBloc.state.currentWorkspace?.workspaceId ?? '';
-
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider(
-          create: (context) => SpaceBloc(
-            userProfile: userProfile,
-            workspaceId: workspaceId,
-          )..add(const SpaceEvent.initial(openFirstPage: false)),
-        ),
-        BlocProvider(
-          create: (context) => ViewSelectorCubit(
-            getIgnoreViewType: (view) {
-              if (view.isSpace) {
-                return IgnoreViewType.none;
-              }
-              if (view.layout != ViewLayoutPB.Document) {
-                return IgnoreViewType.hide;
-              }
+    return ViewSelector(
+      viewSelectorCubit: BlocProvider(
+        create: (context) => ViewSelectorCubit(
+          getIgnoreViewType: (view) {
+            if (view.isSpace) {
               return IgnoreViewType.none;
-            },
-          ),
+            }
+            if (view.layout != ViewLayoutPB.Document) {
+              return IgnoreViewType.hide;
+            }
+            return IgnoreViewType.none;
+          },
         ),
-      ],
+      ),
       child: BlocSelector<SpaceBloc, SpaceState, ViewPB?>(
         selector: (state) => state.currentSpace,
         builder: (context, spaceView) {

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
+import 'package:appflowy/ai/ai.dart';
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/ai_chat/application/chat_edit_document_service.dart';
 import 'package:appflowy/plugins/ai_chat/application/chat_select_message_bloc.dart';
-import 'package:appflowy/plugins/ai_chat/application/chat_select_sources_cubit.dart';
 import 'package:appflowy/plugins/document/application/prelude.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
@@ -12,6 +12,7 @@ import 'package:appflowy/workspace/application/tabs/tabs_bloc.dart';
 import 'package:appflowy/workspace/application/user/prelude.dart';
 import 'package:appflowy/workspace/application/view/prelude.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
+import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_result/appflowy_result.dart';
@@ -147,7 +148,17 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
           )..add(const SpaceEvent.initial(openFirstPage: false)),
         ),
         BlocProvider(
-          create: (context) => ChatSettingsCubit(hideDisabled: true),
+          create: (context) => ViewSelectorCubit(
+            getIgnoreViewType: (view) {
+              if (view.isSpace) {
+                return IgnoreViewType.none;
+              }
+              if (view.layout != ViewLayoutPB.Document) {
+                return IgnoreViewType.hide;
+              }
+              return IgnoreViewType.none;
+            },
+          ),
         ),
       ],
       child: BlocSelector<SpaceBloc, SpaceState, ViewPB?>(
@@ -189,7 +200,7 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
                     } else {
                       if (spaceView != null) {
                         context
-                            .read<ChatSettingsCubit>()
+                            .read<ViewSelectorCubit>()
                             .refreshSources([spaceView], spaceView);
                       }
                       popoverController.show();
@@ -210,7 +221,7 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
 
   Widget buildPopover(BuildContext context) {
     return BlocProvider.value(
-      value: context.read<ChatSettingsCubit>(),
+      value: context.read<ViewSelectorCubit>(),
       child: SaveToPagePopoverContent(
         onAddToNewPage: (parentViewId) async {
           await addMessageToNewPage(context, parentViewId);


### PR DESCRIPTION
prerequisite for custom prompt from database

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Refactor the view selector component to create a more generic and reusable implementation for selecting views across different contexts

Enhancements:
- Introduced a generic ViewSelectorCubit to replace ChatSettingsCubit
- Created a more flexible view selection mechanism
- Improved the abstraction of view selection logic

Chores:
- Renamed classes and methods to be more generic
- Moved files to more appropriate locations
- Updated import statements across multiple files