### PR TITLE
test: add view selector tests

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/base/flowy_search_text_field.dart';
@@ -102,9 +104,12 @@ class _PromptInputMobileSelectSourcesButtonState
                   ],
                 ),
                 onTap: () async {
-                  context
-                      .read<ViewSelectorCubit>()
-                      .refreshSources(state.spaces, state.currentSpace);
+                  unawaited(
+                    context
+                        .read<ViewSelectorCubit>()
+                        .refreshSources(state.spaces, state.currentSpace),
+                  );
+
                   await showMobileBottomSheet<void>(
                     context,
                     backgroundColor: Theme.of(context).colorScheme.surface,

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/chat_message_selector_banner.dart
@@ -185,9 +185,11 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
                       await updateSelection(documentId);
                     } else {
                       if (spaceView != null) {
-                        context
-                            .read<ViewSelectorCubit>()
-                            .refreshSources([spaceView], spaceView);
+                        unawaited(
+                          context
+                              .read<ViewSelectorCubit>()
+                              .refreshSources([spaceView], spaceView),
+                        );
                       }
                       popoverController.show();
                     }

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/presentation/message/ai_message_action_bar.dart
@@ -578,9 +578,11 @@ class _SaveToPageButtonState extends State<SaveToPageButton> {
           } else {
             widget.onOverrideVisibility?.call(true);
             if (spaceView != null) {
-              context
-                  .read<ViewSelectorCubit>()
-                  .refreshSources([spaceView], spaceView);
+              unawaited(
+                context
+                    .read<ViewSelectorCubit>()
+                    .refreshSources([spaceView], spaceView),
+              );
             }
             popoverController.show();
           }

--- a/frontend/appflowy_flutter/lib/workspace/application/view/view_ext.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/view/view_ext.dart
@@ -298,6 +298,21 @@ extension ViewExtension on ViewPB {
       return PageStyleFontLayout.normal;
     }
   }
+
+  @visibleForTesting
+  set isSpace(bool value) {
+    try {
+      if (extra.isEmpty) {
+        extra = jsonEncode({ViewExtKeys.isSpaceKey: value});
+      } else {
+        final ext = jsonDecode(extra);
+        ext[ViewExtKeys.isSpaceKey] = value;
+        extra = jsonEncode(ext);
+      }
+    } catch (e) {
+      extra = jsonEncode({ViewExtKeys.isSpaceKey: value});
+    }
+  }
 }
 
 extension ViewLayoutExtension on ViewLayoutPB {

--- a/frontend/appflowy_flutter/test/bloc_test/view_selector_test.dart
+++ b/frontend/appflowy_flutter/test/bloc_test/view_selector_test.dart
@@ -1,0 +1,363 @@
+import 'package:appflowy/ai/service/view_selector_cubit.dart';
+import 'package:appflowy/workspace/application/view/view_ext.dart';
+import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
+import 'package:appflowy_backend/protobuf/flowy-folder/protobuf.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ViewPB testView(
+    String id,
+    String name,
+    ViewLayoutPB layout, [
+    bool isSpace = false,
+    List<ViewPB> children = const [],
+  ]) {
+    return ViewPB()
+      ..id = id
+      ..name = name
+      ..layout = layout
+      ..isSpace = isSpace
+      ..childViews.addAll(children);
+  }
+
+  List<ViewPB> createTestViews() {
+    return [
+      testView('1', 'View 1', ViewLayoutPB.Document, true, [
+        testView('1-1', 'View 1-1', ViewLayoutPB.Document),
+        testView('1-2', 'View 1-2', ViewLayoutPB.Document),
+      ]),
+      testView('2', 'View 2', ViewLayoutPB.Document, false, [
+        testView('2-1', 'View 2-1', ViewLayoutPB.Document),
+        testView('2-2', 'View 2-2', ViewLayoutPB.Grid),
+        testView('2-3', 'View 2-3', ViewLayoutPB.Document, false, [
+          testView('2-3-1', 'View 2-3-1', ViewLayoutPB.Document),
+        ]),
+      ]),
+      testView('3', 'View 3', ViewLayoutPB.Document, true, [
+        testView('3-1', 'View 3-1', ViewLayoutPB.Grid, false, [
+          testView('3-1-1', 'View 3-1-1', ViewLayoutPB.Board),
+        ]),
+      ]),
+      testView('4', 'View 4', ViewLayoutPB.Document, true, [
+        testView('4-1', 'View 4-1', ViewLayoutPB.Chat),
+        testView('4-2', 'View 4-2', ViewLayoutPB.Document, false, [
+          testView('4-2-1', 'View 4-2-1', ViewLayoutPB.Document),
+          testView('4-2-2', 'View 4-2-2', ViewLayoutPB.Document),
+        ]),
+      ]),
+    ];
+  }
+
+  Map<String, ViewSelectedStatus> getSelectedStatus(
+    List<ViewSelectorItem> items,
+  ) {
+    return {
+      for (final item in items) item.view.id: item.selectedStatus,
+      for (final item in items)
+        if (item.children.isNotEmpty) ...getSelectedStatus(item.children),
+    };
+  }
+
+  group('ViewSelectorCubit test:', () {
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'initial state',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 1,
+      ),
+      act: (_) {},
+      verify: (cubit) {
+        final s = cubit.state;
+        expect(s.visibleSources, isEmpty);
+        expect(s.selectedSources, isEmpty);
+      },
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'update sources',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 1,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        await cubit.refreshSources(views, views.first);
+      },
+      verify: (cubit) {
+        final s = cubit.state;
+        expect(s.visibleSources.length, 4);
+        expect(s.visibleSources[0].isExpanded, isTrue);
+        expect(s.visibleSources[0].children.length, 2);
+        expect(s.visibleSources[1].children.length, 3);
+        expect(s.visibleSources[2].children.length, 1);
+        expect(s.visibleSources[3].children.length, 2);
+        expect(s.selectedSources.isEmpty, isTrue);
+      },
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'update sources multiple times',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 1,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        await cubit.refreshSources([], null);
+        await cubit.refreshSources(views, null);
+        await cubit.refreshSources([], null);
+      },
+      expect: () => [
+        predicate<ViewSelectorState>(
+          (s) => s.visibleSources.isEmpty && s.selectedSources.isEmpty,
+        ),
+        predicate<ViewSelectorState>(
+          (s) => s.visibleSources.isNotEmpty && s.selectedSources.isEmpty,
+        ),
+        predicate<ViewSelectorState>(
+          (s) => s.visibleSources.isEmpty && s.selectedSources.isEmpty,
+        ),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'update selected sources',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        cubit.updateSelectedSources([
+          '2-3-1',
+          '3-1',
+          '3-1-1',
+          '4-2',
+          '4-2-1',
+        ]);
+        await cubit.refreshSources(views, null);
+      },
+      skip: 1,
+      expect: () => [
+        predicate<ViewSelectorState>((s) {
+          final lengthCheck =
+              s.visibleSources.length == 4 && s.selectedSources.length == 3;
+
+          final expected = {
+            '1': ViewSelectedStatus.unselected,
+            '1-1': ViewSelectedStatus.unselected,
+            '1-2': ViewSelectedStatus.unselected,
+            '2': ViewSelectedStatus.partiallySelected,
+            '2-1': ViewSelectedStatus.unselected,
+            '2-2': ViewSelectedStatus.unselected,
+            '2-3': ViewSelectedStatus.partiallySelected,
+            '2-3-1': ViewSelectedStatus.selected,
+            '3': ViewSelectedStatus.partiallySelected,
+            '3-1': ViewSelectedStatus.selected,
+            '3-1-1': ViewSelectedStatus.selected,
+            '4': ViewSelectedStatus.partiallySelected,
+            '4-1': ViewSelectedStatus.unselected,
+            '4-2': ViewSelectedStatus.partiallySelected,
+            '4-2-1': ViewSelectedStatus.selected,
+            '4-2-2': ViewSelectedStatus.unselected,
+          };
+
+          final actual = getSelectedStatus(s.visibleSources);
+
+          return lengthCheck && mapEquals(expected, actual);
+        }),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'select a source 1',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        await cubit.refreshSources(views, null);
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[1].children[2].children[0], // '2-3-1',
+          false,
+        );
+      },
+      skip: 1,
+      expect: () => [
+        predicate<ViewSelectorState>((s) {
+          return getSelectedStatus(s.visibleSources)
+              .values
+              .every((value) => value == ViewSelectedStatus.unselected);
+        }),
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['2-3'] ==
+                  ViewSelectedStatus.partiallySelected &&
+              selectedStatusMap['2-3-1'] == ViewSelectedStatus.selected;
+        }),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'select a source 2',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        await cubit.refreshSources(views, null);
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[1].children[2], // '2-3',
+          false,
+        );
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[1].children[2].children[0], // '2-3-1',
+          false,
+        );
+      },
+      skip: 2,
+      expect: () => [
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['2-3'] == ViewSelectedStatus.selected &&
+              selectedStatusMap['2-3-1'] == ViewSelectedStatus.selected;
+        }),
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['2-3'] ==
+                  ViewSelectedStatus.partiallySelected &&
+              selectedStatusMap['2-3-1'] == ViewSelectedStatus.unselected;
+        }),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'select a source 3',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        cubit.updateSelectedSources(['2-3', '2-3-1']);
+        await cubit.refreshSources(views, null);
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[1].children[2], // '2-3',
+          false,
+        );
+      },
+      skip: 1,
+      expect: () => [
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['2-3'] == ViewSelectedStatus.selected &&
+              selectedStatusMap['2-3-1'] == ViewSelectedStatus.selected;
+        }),
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['2-3'] == ViewSelectedStatus.unselected &&
+              selectedStatusMap['2-3-1'] == ViewSelectedStatus.unselected;
+        }),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'select a source 4',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        cubit.updateSelectedSources(['4-2', '4-2-1']);
+        await cubit.refreshSources(views, null);
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[3].children[1].children[1], // 4-2-2,
+          false,
+        );
+      },
+      skip: 1,
+      expect: () => [
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['4-2'] ==
+                  ViewSelectedStatus.partiallySelected &&
+              selectedStatusMap['4-2-1'] == ViewSelectedStatus.selected &&
+              selectedStatusMap['4-2-2'] == ViewSelectedStatus.unselected;
+        }),
+        predicate<ViewSelectorState>((s) {
+          final selectedStatusMap = getSelectedStatus(s.visibleSources);
+          return selectedStatusMap['4-2'] == ViewSelectedStatus.selected &&
+              selectedStatusMap['4-2-1'] == ViewSelectedStatus.selected &&
+              selectedStatusMap['4-2-2'] == ViewSelectedStatus.selected;
+        }),
+      ],
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'select a source 5',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 100,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        cubit.updateSelectedSources(['4-2', '4-2-1']);
+        await cubit.refreshSources(views, null);
+        cubit.toggleSelectedStatus(
+          cubit.state.visibleSources[3].children[1], // 4-2
+          false,
+        );
+      },
+      verify: (cubit) {
+        final selectedStatusMap = getSelectedStatus(cubit.state.visibleSources);
+        expect(selectedStatusMap['4-2'], ViewSelectedStatus.unselected);
+        expect(selectedStatusMap['4-2-1'], ViewSelectedStatus.unselected);
+        expect(selectedStatusMap['4-2-2'], ViewSelectedStatus.unselected);
+      },
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'cannot select more than maximum selection limit',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 2,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        cubit.updateSelectedSources(['1-1', '2-1']);
+        await cubit.refreshSources(views, null);
+      },
+      verify: (cubit) {
+        final s = cubit.state;
+        expect(s.visibleSources[0].children[0].isDisabled, isFalse);
+        expect(s.visibleSources[0].children[1].isDisabled, isFalse);
+        expect(s.visibleSources[1].children[0].isDisabled, isFalse);
+        expect(s.visibleSources[1].children[1].isDisabled, isFalse);
+        expect(s.visibleSources[2].children[0].isDisabled, isTrue);
+      },
+    );
+
+    blocTest<ViewSelectorCubit, ViewSelectorState>(
+      'filter sources correctly',
+      build: () => ViewSelectorCubit(
+        getIgnoreViewType: (_) => IgnoreViewType.none,
+        maxSelectedParentPageCount: 1,
+      ),
+      act: (cubit) async {
+        final views = createTestViews();
+        await cubit.refreshSources(views, null);
+        cubit.filterTextController.text = 'View 1';
+      },
+      verify: (cubit) {
+        final s = cubit.state;
+        expect(s.visibleSources.length, 1);
+        expect(s.visibleSources[0].children.length, 2);
+      },
+    );
+  });
+}


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Add comprehensive tests for the view selector functionality in the AppFlowy application

Enhancements:
- Extended ViewPB with a testing-specific setter for isSpace
- Modified ViewSelectorCubit to support testing scenarios

Tests:
- Implemented a comprehensive test suite for ViewSelectorCubit
- Added test cases covering various scenarios of view selection, filtering, and state management