### PR TITLE
chore: fetch subscription when start

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/shared/feature_flags.dart';
 import 'package:appflowy/startup/startup.dart';
@@ -71,6 +73,9 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
               ),
             );
           },
+          fetchWorkspaceSubscriptionInfo: (workspaceId) async {
+            await _handleFetchWorkspaceSubscriptionInfo(emit, workspaceId);
+          },
         );
       },
     );
@@ -110,6 +115,34 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
     );
   }
 
+  Future<void> _handleFetchWorkspaceSubscriptionInfo(
+    Emitter<UserWorkspaceState> emit,
+    String workspaceId,
+  ) async {
+    unawaited(UserBackendService.getWorkspaceSubscriptionInfo(workspaceId).fold(
+      (workspaceSubscriptionInfo) {
+        if (!isClosed) {
+          return;
+        }
+
+        if (state.currentWorkspace?.workspaceId != workspaceId) {
+          return;
+        }
+
+        Log.debug(
+          'fetch workspace subscription info: $workspaceId, $workspaceSubscriptionInfo',
+        );
+
+        emit(
+          state.copyWith(
+            workspaceSubscriptionInfo: workspaceSubscriptionInfo,
+          ),
+        );
+      },
+      (e) => Log.error('fetch workspace subscription info error: $e'),
+    ));
+  }
+
   Future<void> _initializeWorkspaces(Emitter<UserWorkspaceState> emit) async {
     final result = await _fetchWorkspaces(
       initialWorkspaceId: initialWorkspaceId,
@@ -124,6 +157,14 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
       'init workspace, current workspace: ${currentWorkspace?.workspaceId}, '
       'workspaces: ${workspaces.map((e) => e.workspaceId)}, isCollabWorkspaceOn: $isCollabWorkspaceOn',
     );
+
+    if (currentWorkspace != null) {
+      add(
+        UserWorkspaceEvent.fetchWorkspaceSubscriptionInfo(
+          currentWorkspace.workspaceId,
+        ),
+      );
+    }
 
     if (currentWorkspace != null && result.$3 == true) {
       Log.info('init open workspace: ${currentWorkspace.workspaceId}');
@@ -343,6 +384,12 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
 
     result
       ..onSuccess((s) {
+        add(
+          UserWorkspaceEvent.fetchWorkspaceSubscriptionInfo(
+            workspaceId,
+          ),
+        );
+
         Log.info(
           'open workspace success: $workspaceId, current workspace: ${currentWorkspace?.toProto3Json()}',
         );
@@ -629,6 +676,9 @@ class UserWorkspaceEvent with _$UserWorkspaceEvent {
   const factory UserWorkspaceEvent.updateUserProfile(
     UserProfilePB userProfile,
   ) = UpdateUserProfile;
+  const factory UserWorkspaceEvent.fetchWorkspaceSubscriptionInfo(
+    String workspaceId,
+  ) = FetchWorkspaceSubscriptionInfo;
 }
 
 enum UserWorkspaceActionType {
@@ -669,6 +719,7 @@ class UserWorkspaceState with _$UserWorkspaceState {
     @Default(null) UserWorkspaceActionResult? actionResult,
     @Default(false) bool isCollabWorkspaceOn,
     required UserProfilePB userProfile,
+    @Default(null) WorkspaceSubscriptionInfoPB? workspaceSubscriptionInfo,
   }) = _UserWorkspaceState;
 
   factory UserWorkspaceState.initial(UserProfilePB userProfile) =>


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Introduce automatic fetching of workspace subscription information during workspace initialization and opening, with corresponding event and state updates in the user workspace BLoC.

New Features:
- Fetch and store workspace subscription information when initializing or opening a workspace.

Enhancements:
- Add new event and state property for handling workspace subscription info in the user workspace BLoC.