### PR TITLE
fix: the link name should be a required field

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_toolbar_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_toolbar_test.dart
@@ -366,5 +366,88 @@ void main() {
       expect(getLinkFromNode(node), link);
       expect(getNodeText(node), afterText);
     });
+
+    testWidgets('insert link and clear link name', (tester) async {
+      const text = 'edit link', link = 'https://test.appflowy.cloud';
+      await prepareForToolbar(tester, text);
+
+      /// tap link button to show CreateLinkMenu
+      final linkButton = find.byFlowySvg(FlowySvgs.toolbar_link_m);
+      await tester.tapButton(linkButton);
+
+      /// search for page and select it
+      final textField = find.descendant(
+        of: find.byType(LinkCreateMenu),
+        matching: find.byType(TextFormField),
+      );
+      await tester.enterText(textField, link);
+      await tester.pumpAndSettle();
+      await tester.simulateKeyEvent(LogicalKeyboardKey.enter);
+      Node node = tester.editor.getNodeAtPath([0]);
+      expect(getLinkFromNode(node), link);
+      await tester.simulateKeyEvent(LogicalKeyboardKey.escape);
+
+      /// hover link
+      await tester.hoverOnWidget(find.byType(LinkHoverTrigger));
+
+      /// click edit button to show LinkEditMenu
+      final editButton = find.byFlowySvg(FlowySvgs.toolbar_link_edit_m);
+      await tester.tapButton(editButton);
+      final linkEditMenu = find.byType(LinkEditMenu);
+      expect(linkEditMenu, findsOneWidget);
+
+      /// clear the link name
+      final titleField = find.descendant(
+        of: linkEditMenu,
+        matching: find.byType(TextFormField),
+      );
+      await tester.enterText(titleField, '');
+      await tester.pumpAndSettle();
+      await tester.simulateKeyEvent(LogicalKeyboardKey.enter);
+      node = tester.editor.getNodeAtPath([0]);
+      expect(getNodeText(node), link);
+    });
+
+    testWidgets('insert link and clear link name and remove link', (tester) async {
+      const text = 'edit link', link = 'https://test.appflowy.cloud';
+      await prepareForToolbar(tester, text);
+
+      /// tap link button to show CreateLinkMenu
+      final linkButton = find.byFlowySvg(FlowySvgs.toolbar_link_m);
+      await tester.tapButton(linkButton);
+
+      /// search for page and select it
+      final textField = find.descendant(
+        of: find.byType(LinkCreateMenu),
+        matching: find.byType(TextFormField),
+      );
+      await tester.enterText(textField, link);
+      await tester.pumpAndSettle();
+      await tester.simulateKeyEvent(LogicalKeyboardKey.enter);
+      Node node = tester.editor.getNodeAtPath([0]);
+      expect(getLinkFromNode(node), link);
+      await tester.simulateKeyEvent(LogicalKeyboardKey.escape);
+
+      /// hover link
+      await tester.hoverOnWidget(find.byType(LinkHoverTrigger));
+
+      /// click edit button to show LinkEditMenu
+      final editButton = find.byFlowySvg(FlowySvgs.toolbar_link_edit_m);
+      await tester.tapButton(editButton);
+      final linkEditMenu = find.byType(LinkEditMenu);
+      expect(linkEditMenu, findsOneWidget);
+
+      /// clear the link name
+      final titleField = find.descendant(
+        of: linkEditMenu,
+        matching: find.byType(TextFormField),
+      );
+      await tester.enterText(titleField, '');
+      await tester.pumpAndSettle();
+      await tester.tapButton(find.byFlowySvg(FlowySvgs.toolbar_link_unlink_m));
+      node = tester.editor.getNodeAtPath([0]);
+      expect(getNodeText(node), link);
+      expect(getLinkFromNode(node), null);
+    });
   });
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_extension.dart
@@ -27,11 +27,12 @@ extension LinkExtension on EditorState {
     final node = getNodeAtPath(selection.start.path);
     if (node == null) return;
     final transaction = this.transaction;
+    final linkName = info.name.isEmpty ? info.link : info.name;
     transaction.replaceText(
       node,
       selection.startIndex,
       selection.length,
-      info.name,
+      linkName,
       attributes: info.toAttribute(),
     );
     apply(transaction);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
@@ -186,8 +186,11 @@ class _LinkHoverTriggerState extends State<LinkHoverTrigger> {
         linkInfo: LinkInfo(name: title, link: href, isPage: isPage),
         onDismiss: () => editMenuController.close(),
         onApply: (info) => editorState.applyLink(selection, info),
-        onRemoveLink: (linkinfo) =>
-            onRemoveAndReplaceLink(editorState, selection, linkinfo.name),
+        onRemoveLink: (linkinfo) {
+          final replaceText =
+              linkinfo.name.isEmpty ? linkinfo.link : linkinfo.name;
+          onRemoveAndReplaceLink(editorState, selection, replaceText);
+        },
       ),
       child: child,
     );


### PR DESCRIPTION
### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Require the link name field for links, defaulting to the link URL if the name is empty, and add tests to validate link editing and removal scenarios.

Bug Fixes:
- Ensure that the link name field is required and defaults to the link URL if left empty when editing or removing links.

Tests:
- Add integration tests to verify link insertion, clearing the link name, and link removal behaviors.