### PR TITLE
fix: fetch subscription info assertion

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/user/user_workspace_bloc.dart
@@ -77,6 +77,13 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
           fetchWorkspaceSubscriptionInfo: (workspaceId) async {
             await _handleFetchWorkspaceSubscriptionInfo(emit, workspaceId);
           },
+          updateSubscriptionInfo: (subscriptionInfo) {
+            emit(
+              state.copyWith(
+                workspaceSubscriptionInfo: subscriptionInfo,
+              ),
+            );
+          },
         );
       },
     );
@@ -141,9 +148,9 @@ class UserWorkspaceBloc extends Bloc<UserWorkspaceEvent, UserWorkspaceState> {
             'fetch workspace subscription info: $workspaceId, $workspaceSubscriptionInfo',
           );
 
-          emit(
-            state.copyWith(
-              workspaceSubscriptionInfo: workspaceSubscriptionInfo,
+          add(
+            UserWorkspaceEvent.updateSubscriptionInfo(
+              workspaceSubscriptionInfo,
             ),
           );
         },
@@ -688,6 +695,9 @@ class UserWorkspaceEvent with _$UserWorkspaceEvent {
   const factory UserWorkspaceEvent.fetchWorkspaceSubscriptionInfo(
     String workspaceId,
   ) = FetchWorkspaceSubscriptionInfo;
+  const factory UserWorkspaceEvent.updateSubscriptionInfo(
+    WorkspaceSubscriptionInfoPB subscriptionInfo,
+  ) = UpdateSubscriptionInfo;
 }
 
 enum UserWorkspaceActionType {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Improve the handling of workspace subscription info updates in the user workspace BLoC by introducing a dedicated event and ensuring state is updated correctly after fetching subscription info.

Bug Fixes:
- Fix incorrect state update when fetching workspace subscription info by dispatching an explicit update event.

Enhancements:
- Add new event and handler for updating workspace subscription info in the user workspace BLoC.