### PR TITLE
chore: select source when user is not anon

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/desktop_prompt_input.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/desktop_prompt_input.dart
@@ -1,5 +1,6 @@
 import 'package:appflowy/ai/ai.dart';
 import 'package:appflowy/plugins/ai_chat/application/chat_input_control_cubit.dart';
+import 'package:appflowy/plugins/ai_chat/application/chat_user_cubit.dart';
 import 'package:appflowy/plugins/ai_chat/presentation/layout_define.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/util/theme_extension.dart';
@@ -48,6 +49,7 @@ class _DesktopPromptInputState extends State<DesktopPromptInput> {
   final layerLink = LayerLink();
   final overlayController = OverlayPortalController();
   final inputControlCubit = ChatInputControlCubit();
+  final chatUserCubit = ChatUserCubit();
   final focusNode = FocusNode();
 
   late SendButtonState sendButtonState;
@@ -56,6 +58,7 @@ class _DesktopPromptInputState extends State<DesktopPromptInput> {
   @override
   void initState() {
     super.initState();
+    chatUserCubit.fetchUserProfile();
 
     widget.textController.addListener(handleTextControllerChanged);
     focusNode
@@ -90,13 +93,17 @@ class _DesktopPromptInputState extends State<DesktopPromptInput> {
     focusNode.dispose();
     widget.textController.removeListener(handleTextControllerChanged);
     inputControlCubit.close();
+    chatUserCubit.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: inputControlCubit,
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: inputControlCubit),
+        BlocProvider.value(value: chatUserCubit),
+      ],
       child: BlocListener<ChatInputControlCubit, ChatInputControlState>(
         listener: (context, state) {
           state.maybeWhen(
@@ -656,7 +663,9 @@ class _PromptBottomActions extends StatelessWidget {
 
               const Spacer(),
 
-              _selectSourcesButton(),
+              if (context.read<ChatUserCubit>().supportSelectSource())
+                _selectSourcesButton(),
+
               if (extraBottomActionButton != null) extraBottomActionButton!,
               // _mentionButton(context),
               if (state.supportChatWithFile) _attachmentButton(context),

--- a/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_user_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/ai_chat/application/chat_user_cubit.dart
@@ -1,0 +1,78 @@
+import 'package:appflowy/startup/startup.dart';
+import 'package:appflowy/user/application/auth/auth_service.dart';
+import 'package:appflowy_backend/protobuf/flowy-error/errors.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/user_profile.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/workspace.pb.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// ChatUserCubit is responsible for fetching and storing the user profile
+class ChatUserCubit extends Cubit<ChatUserState> {
+  ChatUserCubit() : super(ChatUserLoadingState()) {
+    fetchUserProfile();
+  }
+
+  /// Fetches the user profile from the AuthService
+  Future<void> fetchUserProfile() async {
+    emit(ChatUserLoadingState());
+    final userOrFailure = await getIt<AuthService>().getUser();
+
+    userOrFailure.fold(
+      (userProfile) => emit(ChatUserSuccessState(userProfile)),
+      (error) => emit(ChatUserFailureState(error)),
+    );
+  }
+
+  bool supportSelectSource() {
+    if (state is ChatUserSuccessState) {
+      final userProfile = (state as ChatUserSuccessState).userProfile;
+      if (userProfile.userAuthType == AuthTypePB.Server) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isValueWorkspace() {
+    if (state is ChatUserSuccessState) {
+      final userProfile = (state as ChatUserSuccessState).userProfile;
+      return userProfile.workspaceType == WorkspaceTypePB.LocalW &&
+          userProfile.userAuthType != AuthTypePB.Local;
+    }
+    return false;
+  }
+
+  /// Refreshes the user profile data
+  Future<void> refresh() async {
+    await fetchUserProfile();
+  }
+}
+
+/// Base state class for ChatUserCubit
+abstract class ChatUserState extends Equatable {
+  const ChatUserState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Loading state when fetching user profile
+class ChatUserLoadingState extends ChatUserState {}
+
+/// Success state when user profile is fetched successfully
+class ChatUserSuccessState extends ChatUserState {
+  const ChatUserSuccessState(this.userProfile);
+  final UserProfilePB userProfile;
+
+  @override
+  List<Object?> get props => [userProfile];
+}
+
+/// Failure state when fetching user profile fails
+class ChatUserFailureState extends ChatUserState {
+  const ChatUserFailureState(this.error);
+  final FlowyError error;
+
+  @override
+  List<Object?> get props => [error];
+}

--- a/frontend/rust-lib/event-integration-test/tests/chat/mod.rs
+++ b/frontend/rust-lib/event-integration-test/tests/chat/mod.rs
@@ -1,2 +1,1 @@
 mod chat_message_test;
-mod local_chat_test;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Introduce a ChatUserCubit to fetch and store the user profile and use it in the chat input widget to conditionally display the source selection button only for server-authenticated users.

New Features:
- Add ChatUserCubit for loading and storing user profile with supportSelectSource and isValueWorkspace checks
- Fetch user profile on DesktopPromptInput initialization and manage its lifecycle
- Render the select sources button only when the user is authenticated via the server

Enhancements:
- Wrap DesktopPromptInput in a MultiBlocProvider to inject ChatUserCubit alongside ChatInputControlCubit