### PR TITLE
fix: don't switch to space if on same space

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/desktop_home_screen.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/desktop_home_screen.dart
@@ -318,7 +318,9 @@ class DesktopHomeScreen extends StatelessWidget {
           ancestors.items.firstWhereOrNull((ancestor) => ancestor.isSpace),
       (error) => null,
     );
-    switchToSpaceNotifier.value = space;
+    if (space?.id != switchToSpaceNotifier.value?.id) {
+      switchToSpaceNotifier.value = space;
+    }
   }
 }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Prevent switching to the same space if already active by checking space IDs before updating the notifier.