### PR TITLE
fix: stream key

### DIFF
--- a/frontend/rust-lib/flowy-ai/src/chat.rs
+++ b/frontend/rust-lib/flowy-ai/src/chat.rs
@@ -252,22 +252,24 @@ impl Chat {
         Err(err) => {
           error!("[Chat] failed to start streaming: {}", err);
           if err.is_ai_response_limit_exceeded() {
-            let _ = answer_sink.send("AI_RESPONSE_LIMIT".to_string()).await;
+            let _ = answer_sink
+              .send(StreamMessage::AIResponseLimitExceeded.to_string())
+              .await;
           } else if err.is_ai_image_response_limit_exceeded() {
             let _ = answer_sink
-              .send("AI_IMAGE_RESPONSE_LIMIT".to_string())
+              .send(StreamMessage::AIImageResponseLimitExceeded.to_string())
               .await;
           } else if err.is_ai_max_required() {
             let _ = answer_sink
-              .send(format!("AI_MAX_REQUIRED:{}", err.msg))
+              .send(StreamMessage::AIMaxRequired(err.msg.clone()).to_string())
               .await;
           } else if err.is_local_ai_not_ready() {
             let _ = answer_sink
-              .send(format!("LOCAL_AI_NOT_READY:{}", err.msg))
+              .send(StreamMessage::LocalAINotReady(err.msg.clone()).to_string())
               .await;
           } else if err.is_local_ai_disabled() {
             let _ = answer_sink
-              .send(format!("LOCAL_AI_DISABLED:{}", err.msg))
+              .send(StreamMessage::LocalAIDisabled(err.msg.clone()).to_string())
               .await;
           } else {
             let _ = answer_sink

--- a/frontend/rust-lib/flowy-ai/src/stream_message.rs
+++ b/frontend/rust-lib/flowy-ai/src/stream_message.rs
@@ -14,6 +14,11 @@ pub enum StreamMessage {
   StartIndexFile { file_name: String },
   EndIndexFile { file_name: String },
   IndexFileError { file_name: String },
+  AIResponseLimitExceeded,
+  AIImageResponseLimitExceeded,
+  AIMaxRequired(String),
+  LocalAINotReady(String),
+  LocalAIDisabled(String),
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -47,6 +52,11 @@ impl Display for StreamMessage {
           write!(f, "ai_follow_up:",)
         }
       },
+      StreamMessage::AIResponseLimitExceeded => write!(f, "ai_response_limit:"),
+      StreamMessage::AIImageResponseLimitExceeded => write!(f, "ai_image_response_limit:"),
+      StreamMessage::AIMaxRequired(message) => write!(f, "ai_max_required:{}", message),
+      StreamMessage::LocalAINotReady(message) => write!(f, "local_ai_not_ready:{}", message),
+      StreamMessage::LocalAIDisabled(message) => write!(f, "local_ai_disabled:{}", message),
     }
   }
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Introduce typed stream messages for AI error conditions and update chat streaming error handling to use them instead of raw string keys.

Enhancements:
- Add new StreamMessage variants for various AI error conditions and implement their Display formatting
- Refactor chat.rs error handling to send StreamMessage variants instead of hardcoded error strings