### PR TITLE
chore: bump collab

### DIFF
--- a/frontend/rust-lib/Cargo.lock
+++ b/frontend/rust-lib/Cargo.lock
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "collab"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "collab-database"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "collab-document"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "collab-entity"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "collab-folder"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "collab-importer"
 version = "0.1.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1162,7 +1162,7 @@ dependencies = [
 [[package]]
 name = "collab-plugins"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "collab-user"
 version = "0.2.0"
-source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=33f6844954f9b631693cac11aef573cf376d04f8#33f6844954f9b631693cac11aef573cf376d04f8"
+source = "git+https://github.com/AppFlowy-IO/AppFlowy-Collab?rev=8cad313d87af611f225df8b222fb744f279ef4d6#8cad313d87af611f225df8b222fb744f279ef4d6"
 dependencies = [
  "anyhow",
  "collab",
@@ -1487,7 +1487,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.8.0",
  "smallvec",
 ]
 

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -147,13 +147,13 @@ rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "1710120
 # To switch to the local path, run:
 # scripts/tool/update_collab_source.sh
 # ⚠️⚠️⚠️️
-collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
-collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "33f6844954f9b631693cac11aef573cf376d04f8" }
+collab = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-entity = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-folder = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-document = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-database = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-plugins = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
+collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "8cad313d87af611f225df8b222fb744f279ef4d6" }
 
 langchain-rust = { version = "4.6.0", git = "https://github.com/appflowy/langchain-rust", branch = "af" }

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
@@ -2094,7 +2094,7 @@ impl DatabaseViewOperation for DatabaseViewOperationImpl {
     let mut all_rows = vec![];
     let read_guard = self.database.read().await;
     let rows_stream = read_guard
-      .get_rows_from_row_orders(&row_orders, 10, None)
+      .get_rows_from_row_orders(row_orders, 10, None)
       .await;
     pin_mut!(rows_stream);
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bump AppFlowy-Collab crates to the latest upstream revision and adjust DatabaseEditor code to use the updated get_rows_from_row_orders signature

Enhancements:
- Update get_rows_from_row_orders call to pass row_orders by value instead of by reference

Chores:
- Update collab, collab-entity, collab-folder, collab-document, collab-database, collab-plugins, collab-user, and collab-importer dependencies to revision 8cad313