### PR TITLE
fix: #7949 Latex BuildException

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/math_equation/math_equation_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/math_equation/math_equation_block_component.dart
@@ -222,9 +222,15 @@ class MathEquationBlockComponentWidgetState
   }
 
   Widget _buildMathEquation(BuildContext context) {
+	String _safeLatex(String raw) {
+		if (raw.contains(r'\\') && !raw.contains(r'\begin{')) {
+			return r'\begin{aligned}' + raw + r'\end{aligned}';
+		}
+		return raw;
+	}
     return Center(
       child: Math.tex(
-        formula,
+        _safeLatex(formula),
         textStyle: const TextStyle(fontSize: 20),
       ),
     );


### PR DESCRIPTION
#### PR Checklist

- [x] My code adheres to [[AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

### Summary by Sourcery

Bug Fixes:

- Fixes a `BuildException` that occurs when importing LaTeX equations containing raw `\\` line breaks from external sources (e.g., Notion).  This fix introduces a preprocessing step that wraps such input in an `aligned` environment, preventing `CrNode` exceptions without modifying the math rendering library.
- Related to #7949 