### PR TITLE
fix: LR issues

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_ask_ai_entrance.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_ask_ai_entrance.dart
@@ -36,6 +36,9 @@ class _AskAIFor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = AppFlowyTheme.of(context),
+        spaceM = theme.spacing.m,
+        spaceL = theme.spacing.l;
     return GestureDetector(
       onTap: () {
         context
@@ -46,9 +49,11 @@ class _AskAIFor extends StatelessWidget {
       },
       behavior: HitTestBehavior.opaque,
       child: Container(
-        height: 48,
-        margin: EdgeInsets.only(top: 16),
-        padding: EdgeInsets.fromLTRB(8, 12, 8, 12),
+        margin: EdgeInsets.only(top: spaceM),
+        padding: EdgeInsets.symmetric(
+          horizontal: spaceM,
+          vertical: spaceL,
+        ),
         child: Row(
           children: [
             SizedBox.square(
@@ -108,9 +113,12 @@ class _AISearching extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = AppFlowyTheme.of(context),
+        spaceM = theme.spacing.m,
+        spaceL = theme.spacing.l;
     return Container(
-      padding: EdgeInsets.symmetric(vertical: 8),
-      margin: EdgeInsets.only(top: 8),
+      padding: EdgeInsets.fromLTRB(0, spaceM, 0, spaceL),
+      margin: EdgeInsets.only(top: spaceM),
       child: SizedBox(
         height: 24,
         child: Row(
@@ -142,14 +150,17 @@ class _AIOverview extends StatelessWidget {
     if (summaries.isEmpty) {
       return const SizedBox.shrink();
     }
+    final theme = AppFlowyTheme.of(context),
+        spaceM = theme.spacing.m,
+        spaceL = theme.spacing.l;
     return Container(
-      margin: EdgeInsets.only(top: 8),
+      margin: EdgeInsets.only(top: spaceM),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          VSpace(8),
+          VSpace(spaceM),
           buildHeader(context),
-          VSpace(12),
+          VSpace(spaceL),
           LayoutBuilder(
             builder: (context, constrains) {
               final summary = summaries.first;

--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_cell.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_cell.dart
@@ -1,8 +1,8 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/search/mobile_search_special_styles.dart';
 import 'package:appflowy/workspace/application/command_palette/command_palette_bloc.dart';
-import 'package:appflowy/workspace/application/command_palette/search_result_ext.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
+import 'package:appflowy/workspace/presentation/command_palette/widgets/search_icon.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-search/result.pb.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
@@ -14,8 +14,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'mobile_view_ancestors.dart';
 
 class MobileSearchResultCell extends StatelessWidget {
-  const MobileSearchResultCell({super.key, required this.item, this.query});
+  const MobileSearchResultCell({
+    super.key,
+    required this.item,
+    this.query,
+    this.view,
+  });
   final SearchResultItem item;
+  final ViewPB? view;
   final String? query;
 
   @override
@@ -25,6 +31,7 @@ class MobileSearchResultCell extends StatelessWidget {
     final displayName = item.displayName.isEmpty
         ? LocaleKeys.menuAppHeader_defaultNewPageName.tr()
         : item.displayName;
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
       child: Row(
@@ -32,7 +39,10 @@ class MobileSearchResultCell extends StatelessWidget {
         children: [
           SizedBox.square(
             dimension: 24,
-            child: Center(child: buildIcon(theme)),
+            child: Center(
+              child: (view?.toSearchResultItem().icon ?? item.icon)
+                  .buildIcon(context),
+            ),
           ),
           HSpace(12),
           Flexible(
@@ -58,19 +68,6 @@ class MobileSearchResultCell extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  Widget buildIcon(AppFlowyThemeData theme) {
-    final icon = item.icon;
-    if (icon.ty == ResultIconTypePB.Emoji) {
-      return icon.getIcon(size: 20) ?? SizedBox.shrink();
-    } else {
-      return icon.getIcon(
-            size: 20,
-            iconColor: theme.iconColorScheme.secondary,
-          ) ??
-          SizedBox.shrink();
-    }
   }
 
   Widget buildPath(CommandPaletteState state, AppFlowyThemeData theme) {

--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_icon.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_icon.dart
@@ -1,0 +1,24 @@
+import 'package:appflowy/workspace/application/command_palette/search_result_ext.dart';
+import 'package:appflowy_backend/protobuf/flowy-search/result.pb.dart';
+import 'package:appflowy_ui/appflowy_ui.dart';
+import 'package:flutter/material.dart';
+
+
+extension MobileSearchIconItemExtension on ResultIconPB {
+  Widget? buildIcon(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
+
+    if (ty == ResultIconTypePB.Emoji) {
+      return SizedBox(
+        width: 20,
+        child: getIcon(size: 20) ?? SizedBox.shrink(),
+      );
+    } else {
+      return getIcon(
+            size: 20,
+            iconColor: theme.iconColorScheme.secondary,
+          ) ??
+          SizedBox.shrink();
+    }
+  }
+}

--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_result.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_result.dart
@@ -5,11 +5,9 @@ import 'package:appflowy/mobile/presentation/search/mobile_search_special_styles
 import 'package:appflowy/shared/icon_emoji_picker/tab.dart';
 import 'package:appflowy/workspace/application/command_palette/command_palette_bloc.dart';
 import 'package:appflowy/workspace/application/recent/recent_views_bloc.dart';
-import 'package:appflowy/workspace/application/view/view_service.dart';
 import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
 import 'package:appflowy_backend/log.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
-import 'package:appflowy_result/appflowy_result.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
@@ -110,11 +108,10 @@ class MobileSearchResultList extends StatelessWidget {
           physics: const NeverScrollableScrollPhysics(),
           itemBuilder: (context, index) {
             final item = items[index];
+            final view = state.cachedViews[item.id];
             return GestureDetector(
               behavior: HitTestBehavior.opaque,
               onTap: () async {
-                final view =
-                    await ViewBackendService.getView(item.id).toNullable();
                 if (view != null && context.mounted) {
                   await _goToView(context, view);
                 } else {
@@ -129,6 +126,7 @@ class MobileSearchResultList extends StatelessWidget {
               },
               child: MobileSearchResultCell(
                 item: item,
+                view: view,
                 query: state.query,
               ),
             );

--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_textfield.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_textfield.dart
@@ -193,7 +193,7 @@ class _MobileSearchTextfieldState extends State<MobileSearchTextfield> {
                 padding: const EdgeInsets.fromLTRB(4, 10, 8, 10),
                 child: FlowySvg(
                   FlowySvgs.search_clear_m,
-                  color: theme.iconColorScheme.secondary,
+                  color: theme.iconColorScheme.tertiary,
                   size: const Size.square(20),
                 ),
               ),

--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_view_ancestors.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_view_ancestors.dart
@@ -108,20 +108,21 @@ extension ViewAncestorTextExtension on ViewAncestorState {
     if (ancestors.length > 2) {
       displayPath = [ancestors.first.name, '...', ancestors.last.name];
     }
-    return RichText(
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      text: TextSpan(
+    return SizedBox(
+      height: 18,
+      child: Row(
         children: [
-          WidgetSpan(
-            child: Padding(
-              padding: EdgeInsets.symmetric(horizontal: 8),
-              child: Text('-', style: context.searchPanelPath),
-            ),
+          HSpace(8),
+          Text(
+            '-',
+            style: context.searchPanelPath.copyWith(height: 1),
           ),
-          TextSpan(
-            text: displayPath.join(' / '),
-            style: context.searchPanelPath,
+          HSpace(8),
+          Text(
+            displayPath.join(' / '),
+            style: context.searchPanelPath.copyWith(height: 1),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/frontend/appflowy_flutter/lib/workspace/application/command_palette/command_palette_bloc.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/command_palette/command_palette_bloc.dart
@@ -41,6 +41,7 @@ class CommandPaletteBloc
     on<_GoingToAskAI>(_onGoingToAskAI);
     on<_AskedAI>(_onAskedAI);
     on<_RefreshCachedViews>(_onRefreshCachedViews);
+    on<_UpdateCachedViews>(_onUpdateCachedViews);
 
     _initTrash();
     _refreshCachedViews();
@@ -88,11 +89,18 @@ class CommandPaletteBloc
     final repeatedViewPB =
         (await ViewBackendService.getAllViews()).toNullable();
     if (repeatedViewPB == null || isClosed) return;
-    add(CommandPaletteEvent.refreshCachedViews(views: repeatedViewPB.items));
+    add(CommandPaletteEvent.updateCachedViews(views: repeatedViewPB.items));
   }
 
   FutureOr<void> _onRefreshCachedViews(
     _RefreshCachedViews event,
+    Emitter<CommandPaletteState> emit,
+  ) {
+    _refreshCachedViews();
+  }
+
+  FutureOr<void> _onUpdateCachedViews(
+    _UpdateCachedViews event,
     Emitter<CommandPaletteState> emit,
   ) {
     final cachedViews = <String, ViewPB>{};
@@ -354,9 +362,10 @@ class CommandPaletteEvent with _$CommandPaletteEvent {
     @Default(null) List<SearchSourcePB>? sources,
   }) = _GoingToAskAI;
   const factory CommandPaletteEvent.askedAI() = _AskedAI;
-  const factory CommandPaletteEvent.refreshCachedViews({
+  const factory CommandPaletteEvent.refreshCachedViews() = _RefreshCachedViews;
+  const factory CommandPaletteEvent.updateCachedViews({
     required List<ViewPB> views,
-  }) = _RefreshCachedViews;
+  }) = _UpdateCachedViews;
 }
 
 class SearchResultItem {

--- a/frontend/appflowy_flutter/lib/workspace/application/command_palette/search_result_ext.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/command_palette/search_result_ext.dart
@@ -13,19 +13,25 @@ extension GetIcon on ResultIconPB {
   }) {
     final iconValue = value, iconType = ty;
     if (iconType == ResultIconTypePB.Emoji) {
-      return iconValue.isNotEmpty
-          ? Text(
-              iconValue,
-              strutStyle: StrutStyle(
-                fontSize: size,
-                height: lineHeight,
+      if (iconValue.isEmpty) return null;
+      if (UniversalPlatform.isMobile) {
+        return Text(
+          iconValue,
+          strutStyle: StrutStyle(
+            fontSize: size,
+            height: lineHeight,
 
-                /// currently [forceStrutHeight] set to true seems only work in iOS
-                forceStrutHeight: UniversalPlatform.isIOS,
-                leadingDistribution: TextLeadingDistribution.even,
-              ),
-            )
-          : null;
+            /// currently [forceStrutHeight] set to true seems only work in iOS
+            forceStrutHeight: UniversalPlatform.isIOS,
+            leadingDistribution: TextLeadingDistribution.even,
+          ),
+        );
+      }
+      return RawEmojiIconWidget(
+        emoji: EmojiIconData.emoji(iconValue),
+        emojiSize: size,
+        lineHeight: lineHeight,
+      );
     } else if (iconType == ResultIconTypePB.Icon ||
         iconType == ResultIconTypePB.Url) {
       if (_resultIconValueTypes.contains(iconValue)) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
@@ -203,6 +203,7 @@ class CommandPaletteModal extends StatelessWidget {
           final theme = AppFlowyTheme.of(context);
           final noQuery = state.query?.isEmpty ?? true, hasQuery = !noQuery;
           final hasResult = state.combinedResponseItems.isNotEmpty;
+          final spaceXl = theme.spacing.xl;
           return FlowyDialog(
             alignment: Alignment.topCenter,
             insetPadding: const EdgeInsets.only(top: 100),
@@ -216,7 +217,7 @@ class CommandPaletteModal extends StatelessWidget {
             child: shortcutBuilder(
               // Change mainAxisSize to max so Expanded works correctly.
               Padding(
-                padding: EdgeInsets.all(theme.spacing.xl),
+                padding: EdgeInsets.fromLTRB(spaceXl, spaceXl, spaceXl, 0),
                 child: Column(
                   children: [
                     SearchField(query: state.query, isLoading: state.searching),
@@ -226,17 +227,15 @@ class CommandPaletteModal extends StatelessWidget {
                           onSelected: () => FlowyOverlay.pop(context),
                         ),
                       ),
-                    if (hasResult && hasQuery) ...[
-                      AFDivider(),
+                    if (hasResult && hasQuery)
                       Flexible(
                         child: SearchResultList(
-                          trash: state.trash,
+                          cachedViews: state.cachedViews,
                           resultItems:
                               state.combinedResponseItems.values.toList(),
                           resultSummaries: state.resultSummaries,
                         ),
-                      ),
-                    ]
+                      )
                     // When there are no results and the query is not empty and not loading,
                     // show the no results message, centered in the available space.
                     else if (hasQuery && !state.searching) ...[

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
@@ -207,6 +207,7 @@ class CommandPaletteModal extends StatelessWidget {
           final hasResult = state.combinedResponseItems.isNotEmpty;
           final spaceXl = theme.spacing.xl;
           return FlowyDialog(
+            backgroundColor: theme.surfaceColorScheme.layer01,
             alignment: Alignment.topCenter,
             insetPadding: const EdgeInsets.only(top: 100),
             constraints: const BoxConstraints(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
@@ -123,14 +123,16 @@ class _CommandPaletteControllerState extends State<_CommandPaletteController> {
       _isOpen = true;
       final workspaceBloc = _toggleNotifier.value.userWorkspaceBloc;
       final spaceBloc = _toggleNotifier.value.spaceBloc;
+      final commandBloc = context.read<CommandPaletteBloc>();
       Log.info(
         'CommandPalette onToggle: workspaceType ${workspaceBloc?.state.userProfile.workspaceType}',
       );
+      commandBloc.add(CommandPaletteEvent.refreshCachedViews());
       FlowyOverlay.show(
         context: context,
         builder: (_) => MultiBlocProvider(
           providers: [
-            BlocProvider.value(value: context.read<CommandPaletteBloc>()),
+            BlocProvider.value(value: commandBloc),
             if (workspaceBloc != null) BlocProvider.value(value: workspaceBloc),
             if (spaceBloc != null) BlocProvider.value(value: spaceBloc),
           ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/page_preview.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/page_preview.dart
@@ -36,8 +36,9 @@ class PagePreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = AppFlowyTheme.of(context);
-    final backgroundColor =
-        Theme.of(context).isLightMode ? Color(0xffF8FAFF) : Color(0xff32343F);
+    final backgroundColor = Theme.of(context).isLightMode
+        ? Color(0xffF8FAFF)
+        : theme.surfaceColorScheme.layer02;
 
     return BlocProvider(
       create: (context) => DocumentImmersiveCoverBloc(view: view)

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
@@ -75,7 +75,7 @@ class RecentViewsList extends StatelessWidget {
                       children: [
                         if (showAskingAI) SearchAskAiEntrance(),
                         buildTitle(context),
-                        buildViewList(state, context),
+                        buildViewList(state, context, hidePreview),
                         VSpace(8),
                       ],
                     ),
@@ -104,7 +104,7 @@ class RecentViewsList extends StatelessWidget {
     );
   }
 
-  Widget buildViewList(RecentViewsState state, BuildContext context) {
+  Widget buildViewList(RecentViewsState state, BuildContext context, bool hidePreview) {
     final recentViews = state.views.map((e) => e.item).toSet().toList();
 
     if (recentViews.isEmpty) {
@@ -124,6 +124,7 @@ class RecentViewsList extends StatelessWidget {
           ),
           view: view,
           onSelected: onSelected,
+          isNarrowWindow: hidePreview,
         );
       },
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
@@ -104,7 +104,11 @@ class RecentViewsList extends StatelessWidget {
     );
   }
 
-  Widget buildViewList(RecentViewsState state, BuildContext context, bool hidePreview) {
+  Widget buildViewList(
+    RecentViewsState state,
+    BuildContext context,
+    bool hidePreview,
+  ) {
     final recentViews = state.views.map((e) => e.item).toSet().toList();
 
     if (recentViews.isEmpty) {
@@ -118,6 +122,7 @@ class RecentViewsList extends StatelessWidget {
         final view = recentViews[index];
 
         return SearchRecentViewCell(
+          key: ValueKey(view.id),
           icon: SizedBox.square(
             dimension: 20,
             child: Center(child: view.buildIcon(context)),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
@@ -1,11 +1,10 @@
-import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/workspace/application/action_navigation/action_navigation_bloc.dart';
 import 'package:appflowy/workspace/application/action_navigation/navigation_action.dart';
 import 'package:appflowy/workspace/application/recent/recent_views_bloc.dart';
 import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
-import 'package:appflowy/workspace/application/view/view_ext.dart';
+import 'package:appflowy/workspace/presentation/command_palette/widgets/search_icon.dart';
 import 'package:appflowy/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart';
 import 'package:appflowy/workspace/presentation/command_palette/widgets/search_special_styles.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/workspace.pbenum.dart';
@@ -106,7 +105,6 @@ class RecentViewsList extends StatelessWidget {
   }
 
   Widget buildViewList(RecentViewsState state, BuildContext context) {
-    final theme = AppFlowyTheme.of(context);
     final recentViews = state.views.map((e) => e.item).toSet().toList();
 
     if (recentViews.isEmpty) {
@@ -119,26 +117,10 @@ class RecentViewsList extends StatelessWidget {
       itemBuilder: (_, index) {
         final view = recentViews[index];
 
-        final icon = view.icon.value.isNotEmpty
-            ? Text(
-                view.icon.value,
-                strutStyle: StrutStyle(
-                  fontSize: 16,
-                  height: 20 / 16,
-                  forceStrutHeight: true,
-                  leadingDistribution: TextLeadingDistribution.even,
-                ),
-              )
-            : FlowySvg(
-                view.iconData,
-                size: const Size.square(18),
-                color: theme.iconColorScheme.secondary,
-              );
-
         return SearchRecentViewCell(
           icon: SizedBox.square(
             dimension: 20,
-            child: Center(child: icon),
+            child: Center(child: view.buildIcon(context)),
           ),
           view: view,
           onSelected: onSelected,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_field.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_field.dart
@@ -71,7 +71,7 @@ class _SearchFieldState extends State<SearchField> {
               child: Center(
                 child: FlowySvg(
                   FlowySvgs.search_clear_m,
-                  color: AppFlowyTheme.of(context).iconColorScheme.secondary,
+                  color: AppFlowyTheme.of(context).iconColorScheme.tertiary,
                   size: const Size.square(20),
                 ),
               ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_icon.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_icon.dart
@@ -17,10 +17,7 @@ extension SearchIconExtension on ViewPB {
             child: RawEmojiIconWidget(
               emoji: icon.toEmojiIconData(),
               emojiSize: 16,
-
-              /// there is an align issue with emoji in text [https://github.com/flutter/flutter/issues/119623]
-              /// sets the line height as 21 / 16 to fix it
-              lineHeight: 21 / 16,
+              lineHeight: 20 / 16,
             ),
           )
         : FlowySvg(
@@ -39,9 +36,7 @@ extension SearchIconItemExtension on ResultIconPB {
     if (ty == ResultIconTypePB.Emoji) {
       return SizedBox(
         width: 16,
-        /// there is an align issue with emoji in text [https://github.com/flutter/flutter/issues/119623]
-        /// sets the line height as 21 / 16 to fix it
-        child: getIcon(size: 16, lineHeight: 21 / 16, iconColor: color) ??
+        child: getIcon(size: 16, lineHeight: 20 / 16, iconColor: color) ??
             SizedBox.shrink(),
       );
     } else {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_icon.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_icon.dart
@@ -1,0 +1,51 @@
+import 'package:appflowy/generated/flowy_svgs.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/header/emoji_icon_widget.dart';
+import 'package:appflowy/shared/icon_emoji_picker/flowy_icon_emoji_picker.dart';
+import 'package:appflowy/workspace/application/command_palette/search_result_ext.dart';
+import 'package:appflowy/workspace/application/view/view_ext.dart';
+import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
+import 'package:appflowy_backend/protobuf/flowy-search/result.pb.dart';
+import 'package:appflowy_ui/appflowy_ui.dart';
+import 'package:flutter/material.dart';
+
+extension SearchIconExtension on ViewPB {
+  Widget buildIcon(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
+    return icon.value.isNotEmpty
+        ? SizedBox(
+            width: 16,
+            child: RawEmojiIconWidget(
+              emoji: icon.toEmojiIconData(),
+              emojiSize: 16,
+
+              /// there is an align issue with emoji in text [https://github.com/flutter/flutter/issues/119623]
+              /// sets the line height as 21 / 16 to fix it
+              lineHeight: 21 / 16,
+            ),
+          )
+        : FlowySvg(
+            iconData,
+            size: const Size.square(18),
+            color: theme.iconColorScheme.secondary,
+          );
+  }
+}
+
+extension SearchIconItemExtension on ResultIconPB {
+  Widget? buildIcon(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
+    final color = theme.iconColorScheme.secondary;
+
+    if (ty == ResultIconTypePB.Emoji) {
+      return SizedBox(
+        width: 16,
+        /// there is an align issue with emoji in text [https://github.com/flutter/flutter/issues/119623]
+        /// sets the line height as 21 / 16 to fix it
+        child: getIcon(size: 16, lineHeight: 21 / 16, iconColor: color) ??
+            SizedBox.shrink(),
+      );
+    } else {
+      return getIcon(iconColor: color) ?? SizedBox.shrink();
+    }
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
@@ -20,11 +20,13 @@ class SearchRecentViewCell extends StatefulWidget {
     required this.icon,
     required this.view,
     required this.onSelected,
+    required this.isNarrowWindow,
   });
 
   final Widget icon;
   final ViewPB view;
   final VoidCallback onSelected;
+  final bool isNarrowWindow;
 
   @override
   State<SearchRecentViewCell> createState() => _SearchRecentViewCellState();
@@ -46,7 +48,7 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
     final theme = AppFlowyTheme.of(context);
     final sapceM = theme.spacing.m, spaceL = theme.spacing.l;
     final bloc = context.read<RecentViewsBloc>(), state = bloc.state;
-    final hoveredView = state.hoveredView;
+    final hoveredView = state.hoveredView, hasHovered = hoveredView != null;
     final hovering = hoveredView == view;
 
     return GestureDetector(
@@ -74,7 +76,7 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
           },
           style: HoverStyle(
             borderRadius: BorderRadius.circular(8),
-            hoverColor: Theme.of(context).colorScheme.secondary,
+            hoverColor: theme.fillColorScheme.contentHover,
             foregroundColorOnHover: AFThemeExtension.of(context).textColor,
           ),
           isSelected: () => hovering,
@@ -85,11 +87,17 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
               children: [
                 widget.icon,
                 HSpace(8),
-                Text(
-                  view.nameOrDefault,
-                  maxLines: 1,
-                  style: context.searchPanelTitle2,
-                  overflow: TextOverflow.ellipsis,
+                Container(
+                  constraints: BoxConstraints(
+                    maxWidth:
+                        (!widget.isNarrowWindow && hasHovered) ? 480.0 : 680.0,
+                  ),
+                  child: Text(
+                    view.nameOrDefault,
+                    maxLines: 1,
+                    style: context.searchPanelTitle2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
                 Flexible(child: buildPath(theme)),
               ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
@@ -82,25 +82,28 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
           isSelected: () => hovering,
           child: Padding(
             padding: EdgeInsets.symmetric(vertical: spaceL, horizontal: sapceM),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                widget.icon,
-                HSpace(8),
-                Container(
-                  constraints: BoxConstraints(
-                    maxWidth:
-                        (!widget.isNarrowWindow && hasHovered) ? 480.0 : 680.0,
+            child: SizedBox(
+              height: 20,
+              child: Row(
+                children: [
+                  widget.icon,
+                  HSpace(8),
+                  Container(
+                    constraints: BoxConstraints(
+                      maxWidth: (!widget.isNarrowWindow && hasHovered)
+                          ? 480.0
+                          : 680.0,
+                    ),
+                    child: Text(
+                      view.nameOrDefault,
+                      maxLines: 1,
+                      style: context.searchPanelTitle2.copyWith(height: 1),
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   ),
-                  child: Text(
-                    view.nameOrDefault,
-                    maxLines: 1,
-                    style: context.searchPanelTitle2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                Flexible(child: buildPath(theme)),
-              ],
+                  Flexible(child: buildPath(theme)),
+                ],
+              ),
             ),
           ),
         ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
@@ -115,35 +115,40 @@ class _SearchResultCellState extends State<SearchResultCell> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    SizedBox.square(
-                      dimension: 20,
-                      child: Center(child: buildIcon(theme)),
-                    ),
-                    HSpace(8),
-                    Container(
-                      constraints: BoxConstraints(
-                        maxWidth: (!widget.isNarrowWindow && hasHovered)
-                            ? 480.0
-                            : 680.0,
+                SizedBox(
+                  height: 20,
+                  child: Row(
+                    children: [
+                      SizedBox.square(
+                        dimension: 20,
+                        child: Center(child: buildIcon(theme)),
                       ),
-                      child: RichText(
-                        maxLines: 1,
-                        textAlign: TextAlign.center,
-                        overflow: TextOverflow.ellipsis,
-                        text: buildHighLightSpan(
-                          content: title,
-                          normal: context.searchPanelTitle2,
-                          highlight: context.searchPanelTitle2.copyWith(
-                            backgroundColor: theme.fillColorScheme.themeSelect,
+                      HSpace(8),
+                      Container(
+                        constraints: BoxConstraints(
+                          maxWidth: (!widget.isNarrowWindow && hasHovered)
+                              ? 480.0
+                              : 680.0,
+                        ),
+                        child: RichText(
+                          maxLines: 1,
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                          text: buildHighLightSpan(
+                            content: title,
+                            normal:
+                                context.searchPanelTitle2.copyWith(height: 1),
+                            highlight: context.searchPanelTitle2.copyWith(
+                              backgroundColor:
+                                  theme.fillColorScheme.themeSelect,
+                              height: 1,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    Flexible(child: buildPath(theme)),
-                  ],
+                      Flexible(child: buildPath(theme)),
+                    ],
+                  ),
                 ),
                 ...buildSummary(theme),
               ],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
@@ -22,6 +22,7 @@ class SearchResultCell extends StatefulWidget {
   const SearchResultCell({
     super.key,
     required this.item,
+    required this.isNarrowWindow,
     this.view,
     this.query,
     this.isHovered = false,
@@ -31,6 +32,7 @@ class SearchResultCell extends StatefulWidget {
   final ViewPB? view;
   final String? query;
   final bool isHovered;
+  final bool isNarrowWindow;
 
   @override
   State<SearchResultCell> createState() => _SearchResultCellState();
@@ -61,6 +63,8 @@ class _SearchResultCellState extends State<SearchResultCell> {
     final title = item.displayName.orDefault(
       LocaleKeys.menuAppHeader_defaultNewPageName.tr(),
     );
+    final searchResultBloc = context.read<SearchResultListBloc>();
+    final hasHovered = searchResultBloc.state.hoveredResult != null;
 
     final theme = AppFlowyTheme.of(context);
     return GestureDetector(
@@ -78,12 +82,12 @@ class _SearchResultCellState extends State<SearchResultCell> {
         },
         onFocusChange: (hasFocus) {
           setState(() {
-            context.read<SearchResultListBloc>().add(
-                  SearchResultListEvent.onHoverResult(
-                    item: item,
-                    userHovered: true,
-                  ),
-                );
+            searchResultBloc.add(
+              SearchResultListEvent.onHoverResult(
+                item: item,
+                userHovered: true,
+              ),
+            );
             _hasFocus = hasFocus;
           });
         },
@@ -99,7 +103,7 @@ class _SearchResultCellState extends State<SearchResultCell> {
           isSelected: () => _hasFocus || widget.isHovered,
           style: HoverStyle(
             borderRadius: BorderRadius.circular(8),
-            hoverColor: Theme.of(context).colorScheme.secondary,
+            hoverColor: theme.fillColorScheme.contentHover,
             foregroundColorOnHover: AFThemeExtension.of(context).textColor,
           ),
           child: Padding(
@@ -119,15 +123,22 @@ class _SearchResultCellState extends State<SearchResultCell> {
                       child: Center(child: buildIcon(theme)),
                     ),
                     HSpace(8),
-                    RichText(
-                      maxLines: 1,
-                      textAlign: TextAlign.center,
-                      overflow: TextOverflow.ellipsis,
-                      text: buildHighLightSpan(
-                        content: title,
-                        normal: context.searchPanelTitle2,
-                        highlight: context.searchPanelTitle2.copyWith(
-                          backgroundColor: theme.fillColorScheme.themeSelect,
+                    Container(
+                      constraints: BoxConstraints(
+                        maxWidth: (!widget.isNarrowWindow && hasHovered)
+                            ? 480.0
+                            : 680.0,
+                      ),
+                      child: RichText(
+                        maxLines: 1,
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                        text: buildHighLightSpan(
+                          content: title,
+                          normal: context.searchPanelTitle2,
+                          highlight: context.searchPanelTitle2.copyWith(
+                            backgroundColor: theme.fillColorScheme.themeSelect,
+                          ),
                         ),
                       ),
                     ),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
@@ -150,6 +150,7 @@ class _SearchResultListState extends State<SearchResultList> {
                             final item = resultItems[index];
                             return SearchResultCell(
                               item: item,
+                              isNarrowWindow: hidePreview,
                               view: widget.cachedViews[item.id],
                               isHovered: hoveredId == item.id,
                               query: context

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
@@ -149,6 +149,7 @@ class _SearchResultListState extends State<SearchResultList> {
                           itemBuilder: (_, index) {
                             final item = resultItems[index];
                             return SearchResultCell(
+                              key: ValueKey(item.id),
                               item: item,
                               isNarrowWindow: hidePreview,
                               view: widget.cachedViews[item.id],

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_summary_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_summary_cell.dart
@@ -6,6 +6,7 @@ import 'package:appflowy/workspace/application/action_navigation/action_navigati
 import 'package:appflowy/workspace/application/action_navigation/navigation_action.dart';
 import 'package:appflowy/workspace/application/command_palette/command_palette_bloc.dart';
 import 'package:appflowy/workspace/application/command_palette/search_result_ext.dart';
+import 'package:appflowy/workspace/presentation/command_palette/widgets/search_icon.dart';
 import 'package:appflowy_backend/protobuf/flowy-search/result.pb.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
@@ -337,6 +338,8 @@ class ReferenceSources extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = AppFlowyTheme.of(context);
+    final bloc = context.read<CommandPaletteBloc?>(), state = bloc?.state;
+
     return Container(
       decoration: ShapeDecoration(
         color: theme.surfaceColorScheme.primary,
@@ -365,6 +368,8 @@ class ReferenceSources extends StatelessWidget {
               physics: const NeverScrollableScrollPhysics(),
               itemBuilder: (context, index) {
                 final source = sources[index];
+                final view = state?.cachedViews[source.id];
+
                 final displayName = source.displayName.isEmpty
                     ? LocaleKeys.menuAppHeader_defaultNewPageName.tr()
                     : source.displayName;
@@ -397,7 +402,10 @@ class ReferenceSources extends StatelessWidget {
                     children: [
                       SizedBox.square(
                         dimension: 20,
-                        child: Center(child: buildIcon(source.icon, theme)),
+                        child: Center(
+                          child: view?.buildIcon(context) ??
+                              source.icon.buildIcon(context),
+                        ),
                       ),
                       HSpace(8),
                       Flexible(
@@ -431,7 +439,7 @@ class ReferenceSources extends StatelessWidget {
 
   Widget buildIcon(ResultIconPB icon, AppFlowyThemeData theme) {
     if (icon.ty == ResultIconTypePB.Emoji) {
-      return icon.getIcon(size: 16, lineHeight: 20 / 16) ?? SizedBox.shrink();
+      return icon.getIcon(size: 16, lineHeight: 21 / 16) ?? SizedBox.shrink();
     } else {
       return icon.getIcon(iconColor: theme.iconColorScheme.primary) ??
           SizedBox.shrink();


### PR DESCRIPTION
- fix: the position of emoji of search result is incorrect
- fix: padding issue
- fix: page title should have a max width 
- fix: double lines
- fix: inconsistent background colors

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Ensure command palette displays icons reliably by caching view data and centralizing icon rendering, while refining layout and styles to fix emoji alignment, padding, and text overflow issues

New Features:
- Cache and refresh view metadata in CommandPaletteBloc to ensure consistent icon data
- Introduce a shared SearchIconExtension to centralize icon rendering for views and search results

Bug Fixes:
- Correct emoji alignment and positioning in search result and preview icons
- Prevent double-line titles by constraining max widths for page names in search and recent view cells
- Standardize hover background colors and adjust padding for consistent UI spacing

Enhancements:
- Simplify SearchResultPreview by removing async fetch and using preloaded views directly
- Refactor desktop and mobile search/result cells to use unified icon building logic