### PR TITLE
chore: add a tooltip for database tab bar items

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/desktop_field_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/desktop_field_cell.dart
@@ -94,12 +94,16 @@ class _GridFieldCellState extends State<GridFieldCell> {
                 onFieldInserted: widget.onFieldInsertedOnEitherSide,
               );
             },
-            child: SizedBox(
-              height: GridSize.headerHeight,
-              child: FieldCellButton(
-                field: widget.fieldInfo.field,
-                onTap: widget.onTap,
-                margin: const EdgeInsetsDirectional.fromSTEB(12, 9, 10, 9),
+            child: FlowyTooltip(
+              message: widget.fieldInfo.name,
+              preferBelow: false,
+              child: SizedBox(
+                height: GridSize.headerHeight,
+                child: FieldCellButton(
+                  field: widget.fieldInfo.field,
+                  onTap: widget.onTap,
+                  margin: const EdgeInsetsDirectional.fromSTEB(12, 9, 10, 9),
+                ),
               ),
             ),
           );


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Enhancements:
- Wrap database grid header field cells in FlowyTooltip to show field names