### PR TITLE
chore: fix ios build

### DIFF
--- a/frontend/rust-lib/.cargo/config.toml
+++ b/frontend/rust-lib/.cargo/config.toml
@@ -4,3 +4,11 @@ rustflags = ["-C", "link-arg=-mmacosx-version-min=11.0"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-arg=-mmacosx-version-min=11.0"]
+
+[env]
+IPHONEOS_DEPLOYMENT_TARGET = "10.0"
+CFLAGS = "-miphoneos-version-min=10.0"
+LDFLAGS = "-miphoneos-version-min=10.0"
+
+[target.aarch64-apple-ios]
+rustflags = ["-C", "link-arg=-miphoneos-version-min=10.0"]


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Set minimum iOS deployment target to 10.0 in the Rust library configuration to resolve iOS build issues.

Bug Fixes:
- Fix iOS build failures by enforcing a deployment target of 10.0

Build:
- Add IPHONEOS_DEPLOYMENT_TARGET, CFLAGS, and LDFLAGS environment variables for iOS builds
- Configure rustflags for aarch64-apple-ios to specify the minimum iOS version