### PR TITLE
fix: refocus editor after selecting image on Android

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/add_attachment_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mobile_toolbar_v3/add_attachment_item.dart
@@ -60,7 +60,9 @@ final addAttachmentItem = AppFlowyMobileToolbarItem(
           );
 
           if (didAddAttachment != true) {
-            unawaited(editorState.updateSelectionWithReason(selection));
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              editorState.updateSelectionWithReason(selection);
+            });
           }
         });
       },
@@ -185,6 +187,11 @@ class _AddAttachmentMenu extends StatelessWidget {
 
     if (image != null && context.mounted) {
       await insertImage(context, image);
+    } else {
+      // refocus the editor
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        editorState.updateSelectionWithReason(selection);
+      });
     }
 
     if (context.mounted) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/math_equation_node_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/math_equation_node_parser.dart
@@ -9,6 +9,6 @@ class MathEquationNodeParser extends NodeParser {
 
   @override
   String transform(Node node, DocumentMarkdownEncoder? encoder) {
-    return '\$\$${node.attributes[id]}\$\$';
+    return '\$\$${node.attributes[MathEquationBlockKeys.formula]}\$\$';
   }
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
@@ -198,7 +198,7 @@ class _ToggleListBlockComponentWidgetState
             left: cachedLeft,
             top: padding.top,
             child: Container(
-              width: double.infinity,
+              width: UniversalPlatform.isDesktop ? double.infinity : null,
               color: backgroundColor,
             ),
           ),

--- a/frontend/appflowy_flutter/test/unit_test/editor/share_markdown_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/editor/share_markdown_test.dart
@@ -15,7 +15,7 @@ void main() {
             {
                 "type":"math_equation",
                 "data":{
-                    "math_equation":"E = MC^2"
+                    "formula":"E = MC^2"
                 }
             }
         ]


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Wrap editorState.updateSelectionWithReason calls in post-frame callbacks to restore focus after adding or canceling image attachments on Android