### PR TITLE
fix: database view tooltip not displayed

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/tab_bar/desktop/tab_bar_header.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/tab_bar/desktop/tab_bar_header.dart
@@ -292,25 +292,29 @@ class _TabBarItemButtonState extends State<TabBarItemButton> {
         );
       },
       child: IntrinsicWidth(
-        child: FlowyButton(
-          radius: Corners.s6Border,
-          hoverColor: AFThemeExtension.of(context).greyHover,
-          onTap: () {
-            if (widget.isSelected) menuController.show();
-            widget.onTap.call();
-          },
-          margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
-          onSecondaryTap: () {
-            menuController.show();
-          },
-          leftIcon: _buildViewIcon(),
-          text: FlowyText(
-            widget.view.nameOrDefault,
-            lineHeight: 1.0,
-            textAlign: TextAlign.center,
-            overflow: TextOverflow.ellipsis,
-            color: color,
-            fontWeight: widget.isSelected ? FontWeight.w500 : FontWeight.w400,
+        child: FlowyTooltip(
+          message: widget.view.nameOrDefault,
+          preferBelow: false,
+          child: FlowyButton(
+            radius: Corners.s6Border,
+            hoverColor: AFThemeExtension.of(context).greyHover,
+            onTap: () {
+              if (widget.isSelected) menuController.show();
+              widget.onTap.call();
+            },
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+            onSecondaryTap: () {
+              menuController.show();
+            },
+            leftIcon: _buildViewIcon(),
+            text: FlowyText(
+              widget.view.nameOrDefault,
+              lineHeight: 1.0,
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              color: color,
+              fontWeight: widget.isSelected ? FontWeight.w500 : FontWeight.w400,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Show tooltip with view name for database view tabs in the desktop header.