### PR TITLE
chore: bring back animated theme

### DIFF
--- a/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
@@ -251,7 +251,7 @@ class _ApplicationWidgetState extends State<ApplicationWidget> {
                           .orDefault(defaultFontFamily)
                           .fontFamilyName;
 
-                      return AppFlowyTheme(
+                      return AnimatedAppFlowyTheme(
                         data: brightness == Brightness.light
                             ? themeBuilder.light(fontFamily: fontFamily)
                             : themeBuilder.dark(fontFamily: fontFamily),

--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/theme/appflowy_theme.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/theme/appflowy_theme.dart
@@ -132,7 +132,7 @@ class _AnimatedThemeState
   @override
   Widget build(BuildContext context) {
     return AppFlowyTheme(
-      data: widget.data,
+      data: data!.evaluate(animation),
       child: widget.child,
     );
   }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Reintroduce animated theme transitions by replacing the static theme wrapper with AnimatedAppFlowyTheme and applying interpolated theme data during animation.

Enhancements:
- Wrap the root AppFlowyTheme in AnimatedAppFlowyTheme to enable theme animations
- Use evaluated theme data from the animation instead of the static widget data in AnimatedAppFlowyTheme