### PR TITLE
fix: database padding issue with max document width

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_reference_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/search/mobile_search_reference_bottom_sheet.dart
@@ -12,7 +12,6 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
-import 'package:universal_platform/universal_platform.dart';
 
 class SearchSourceReferenceBottomSheet extends StatelessWidget {
   const SearchSourceReferenceBottomSheet(this.sources, {super.key});
@@ -37,12 +36,11 @@ class SearchSourceReferenceBottomSheet extends StatelessWidget {
           showDragHandle: true,
           showDivider: false,
           enableDraggableScrollable: true,
-          maxChildSize: 1.0,
-          minChildSize: 1.0,
-          initialChildSize: 1.0,
+          maxChildSize: 0.95,
+          minChildSize: 0.95,
+          initialChildSize: 0.95,
           backgroundColor: theme.surfaceColorScheme.primary,
-          dragHandleBuilder:
-              UniversalPlatform.isAndroid ? (_) => const _DragHandler() : null,
+          dragHandleBuilder: (_) => const _DragHandler(),
           builder: (_) => SizedBox(
             height: MediaQuery.of(context).size.height,
             child: MobileViewPage(

--- a/frontend/appflowy_flutter/lib/plugins/database/board/presentation/widgets/board_hidden_groups.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/board/presentation/widgets/board_hidden_groups.dart
@@ -46,7 +46,10 @@ class HiddenGroupsColumn extends StatelessWidget {
         }
         final isCollapsed = layoutSettings.collapseHiddenGroups;
         final leftPadding = margin.left +
-            context.read<DatabasePluginWidgetBuilderSize>().horizontalPadding;
+            context.read<DatabasePluginWidgetBuilderSize>().paddingLeft;
+        final leftPaddingWithMaxDocWidth = context
+            .read<DatabasePluginWidgetBuilderSize>()
+            .paddingLeftWithMaxDocumentWidth;
         return AnimatedSize(
           alignment: AlignmentDirectional.topStart,
           curve: Curves.easeOut,
@@ -55,14 +58,17 @@ class HiddenGroupsColumn extends StatelessWidget {
               ? SizedBox(
                   height: 50,
                   child: Padding(
-                    padding: const EdgeInsets.only(left: 80, right: 8),
+                    padding: EdgeInsets.only(
+                      left: 80 + leftPaddingWithMaxDocWidth,
+                      right: 8,
+                    ),
                     child: Center(
                       child: _collapseExpandIcon(context, isCollapsed),
                     ),
                   ),
                 )
               : Container(
-                  width: 274,
+                  width: 274 + leftPaddingWithMaxDocWidth,
                   padding: EdgeInsets.only(
                     left: leftPadding,
                     right: margin.right + 4,

--- a/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
@@ -221,6 +221,8 @@ class _CalendarPageState extends State<CalendarPage> {
     return LayoutBuilder(
       // must specify MonthView width for useAvailableVerticalSpace to work properly
       builder: (context, constraints) {
+        final paddingLeft =
+            context.read<DatabasePluginWidgetBuilderSize>().paddingLeft;
         EdgeInsets padding = UniversalPlatform.isMobile
             ? CalendarSize.contentInsetsMobile
             : CalendarSize.contentInsets +
@@ -230,6 +232,7 @@ class _CalendarPageState extends State<CalendarPage> {
         if (horizontalPadding == 0) {
           padding = padding.copyWith(left: 0, right: 0);
         }
+        padding = padding.copyWith(left: paddingLeft + padding.left);
         return Padding(
           padding: padding,
           child: ScrollConfiguration(

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/grid_page.dart
@@ -409,6 +409,10 @@ class _GridRowsState extends State<_GridRows> {
 
   @override
   Widget build(BuildContext context) {
+    final paddingLeft = context
+            .read<DatabasePluginWidgetBuilderSize?>()
+            ?.paddingLeftWithMaxDocumentWidth ??
+        0.0;
     Widget child;
     if (widget.shrinkWrap) {
       child = Scrollbar(
@@ -420,9 +424,10 @@ class _GridRowsState extends State<_GridRows> {
             constraints: BoxConstraints(
               maxWidth: GridLayout.headerWidth(
                 context
-                        .read<DatabasePluginWidgetBuilderSize>()
-                        .horizontalPadding *
-                    3,
+                            .read<DatabasePluginWidgetBuilderSize>()
+                            .horizontalPadding *
+                        3 +
+                    paddingLeft,
                 context.read<GridBloc>().state.fields,
               ),
             ),
@@ -459,13 +464,16 @@ class _GridRowsState extends State<_GridRows> {
 
   Widget _shrinkWrapRenderList(BuildContext context) {
     final state = context.read<GridBloc>().state;
-    final horizontalPadding =
-        context.read<DatabasePluginWidgetBuilderSize?>()?.horizontalPadding ??
-            0.0;
+    final databaseSize = context.read<DatabasePluginWidgetBuilderSize?>();
     return ListView(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
-      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      padding: EdgeInsets.fromLTRB(
+        databaseSize?.paddingLeft ?? 0.0,
+        0,
+        databaseSize?.horizontalPadding ?? 0.0,
+        0,
+      ),
       children: [
         widget.shrinkWrap
             ? _reorderableListView(state)

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/grid_header.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/header/grid_header.dart
@@ -39,9 +39,9 @@ class _GridHeaderSliverAdaptorState extends State<GridHeaderSliverAdaptor> {
   Widget build(BuildContext context) {
     final fieldController =
         context.read<GridBloc>().databaseController.fieldController;
-    final horizontalPadding =
-        context.read<DatabasePluginWidgetBuilderSize?>()?.horizontalPadding ??
-            0.0;
+    final databaseSize = context.read<DatabasePluginWidgetBuilderSize?>();
+    final horizontalPadding = databaseSize?.horizontalPadding ?? 0.0;
+    final paddingLeft = databaseSize?.paddingLeftWithMaxDocumentWidth ?? 0.0;
     return BlocProvider(
       create: (context) {
         return GridHeaderBloc(
@@ -54,7 +54,12 @@ class _GridHeaderSliverAdaptorState extends State<GridHeaderSliverAdaptor> {
         controller: widget.anchorScrollController,
         child: Padding(
           padding: widget.shrinkWrap
-              ? EdgeInsets.symmetric(horizontal: horizontalPadding)
+              ? EdgeInsets.fromLTRB(
+                  horizontalPadding + paddingLeft,
+                  0,
+                  horizontalPadding,
+                  0,
+                )
               : EdgeInsets.zero,
           child: _GridHeader(
             viewId: widget.viewId,


### PR DESCRIPTION
- fix: database padding issue with max document width
- fix: adjust the drag area of bottom sheet menu in mobole search page 


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Fix horizontal padding in database views when a max document width is set by computing and injecting dynamic left padding, and refine the bottom sheet drag area on mobile search.

Bug Fixes:
- Center database content correctly by adjusting padding based on the max document width.
- Limit and standardize the drag area of the mobile search bottom sheet to 95% height and always show the drag handle.

Enhancements:
- Refactor the database tab bar view to wrap content in a LayoutBuilder and provide calculated padding via a new DatabaseWidgetPaddingWithMaxWidth provider.
- Update grid, board hidden groups, header, and calendar widgets to consume the injected padding for consistent alignment.
- Simplify mobile bottom sheet implementation by removing platform-specific drag handle logic and using a fixed drag handle builder.