### PR TITLE
fix: workspace name conflicts

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
@@ -241,7 +241,9 @@ class _WorkspaceNameSetting extends StatefulWidget {
 class _WorkspaceNameSettingState extends State<_WorkspaceNameSetting> {
   final TextEditingController workspaceNameController = TextEditingController();
   final focusNode = FocusNode();
-  Timer? _debounce;
+
+  Timer? debounce;
+  bool isSaving = false;
 
   @override
   void dispose() {
@@ -254,6 +256,10 @@ class _WorkspaceNameSettingState extends State<_WorkspaceNameSetting> {
   Widget build(BuildContext context) {
     return BlocConsumer<WorkspaceSettingsBloc, WorkspaceSettingsState>(
       listener: (_, state) {
+        if (isSaving) {
+          return;
+        }
+
         final newName = state.workspace?.name;
         if (newName != null && newName != workspaceNameController.text) {
           workspaceNameController.text = newName;
@@ -287,10 +293,15 @@ class _WorkspaceNameSettingState extends State<_WorkspaceNameSetting> {
   }
 
   void _debounceSaveName(String name) {
-    _debounce?.cancel();
-    _debounce = Timer(
+    isSaving = true;
+
+    debounce?.cancel();
+    debounce = Timer(
       const Duration(milliseconds: 300),
-      () => _saveWorkspaceName(name: name),
+      () {
+        _saveWorkspaceName(name: name);
+        isSaving = false;
+      },
     );
   }
 


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Fix conflicts in workspace name editing by adding a saving flag to prevent unwanted controller updates, rename the debounce timer for clarity, expose the widget for testing, and introduce comprehensive widget tests to validate role-based display, debouncing behavior, and state updates.

Bug Fixes:
- Prevent workspace name input from being overwritten during save operations by introducing an `isSaving` flag
- Resolve variable name conflict by renaming the debounce timer field

Enhancements:
- Annotate the workspace name setting widget with `@visibleForTesting` to facilitate testing

Tests:
- Add widget tests that verify read-only and editable views based on user role
- Add tests for debounced name updates, empty input handling, and state-driven text updates