### PR TITLE
fix: make retry work in ai generated images

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/resizeable_image.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/image/resizeable_image.dart
@@ -285,9 +285,14 @@ class _ImageLoadFailedWidget extends StatelessWidget {
               maxLines: 2,
             ),
           const VSpace(12),
-          OutlinedRoundedButton(
-            text: LocaleKeys.chat_retry.tr(),
-            onTap: onRetry,
+          Listener(
+            onPointerDown: (event) {
+              onRetry();
+            },
+            child: OutlinedRoundedButton(
+              text: LocaleKeys.chat_retry.tr(),
+              onTap: () {},
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
In the event that a 404 is returned, allow the user to trigger retry. Note that the "discard" dialog will still appear.

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Trigger the retry callback on pointer down for the retry button to ensure retries work after a 404 error in AI-generated images.