### PR TITLE
fix: notification center mention node rendering issue within heading node

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/shared.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/notifications/widgets/shared.dart
@@ -3,9 +3,12 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/application/notification/notification_reminder_bloc.dart';
 import 'package:appflowy/mobile/application/page_style/document_page_style_bloc.dart';
 import 'package:appflowy/mobile/presentation/notifications/widgets/color.dart';
+import 'package:appflowy/plugins/document/application/document_appearance_cubit.dart';
 import 'package:appflowy/plugins/document/presentation/editor_configuration.dart';
 import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy/user/application/reminder/reminder_extension.dart';
+import 'package:appflowy/util/string_extension.dart';
+import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
@@ -324,6 +327,28 @@ class NotificationDocumentContent extends StatelessWidget {
       editable: false,
       customPadding: (node) => EdgeInsets.zero,
     );
+
+    final headingBuilder = blockBuilders[HeadingBlockKeys.type];
+    if (headingBuilder != null &&
+        headingBuilder is HeadingBlockComponentBuilder) {
+      final newHeadingBuilder = HeadingBlockComponentBuilder(
+        configuration: headingBuilder.configuration,
+        textStyleBuilder: (v) {
+          final fontFamily = context
+              .read<DocumentAppearanceCubit>()
+              .state
+              .fontFamily
+              .orDefault(
+                context.read<AppearanceSettingsCubit>().state.font,
+              );
+          return styleCustomizer.baseTextStyle(
+            fontFamily,
+            fontWeight: FontWeight.w600,
+          );
+        },
+      );
+      blockBuilders[HeadingBlockKeys.type] = newHeadingBuilder;
+    }
 
     return IgnorePointer(
       child: Opacity(


### PR DESCRIPTION
Before : 

<img width="666" alt="image" src="https://github.com/user-attachments/assets/49ebd970-4b10-46b5-a034-a23fbd382991" />


After : 

<img width="668" alt="image" src="https://github.com/user-attachments/assets/8db89456-475f-43b4-a5cf-15c6af2be5a2" />


### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.
