### PR TITLE
chore: remove include time icon

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/date/date_time_format.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/date/date_time_format.dart
@@ -241,10 +241,12 @@ class IncludeTimeButton extends StatelessWidget {
     super.key,
     required this.onChanged,
     required this.includeTime,
+    this.showIcon = true,
   });
 
   final Function(bool value) onChanged;
   final bool includeTime;
+  final bool showIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -254,11 +256,13 @@ class IncludeTimeButton extends StatelessWidget {
         padding: GridSize.typeOptionContentInsets,
         child: Row(
           children: [
-            FlowySvg(
-              FlowySvgs.clock_alarm_s,
-              color: Theme.of(context).iconTheme.color,
-            ),
-            const HSpace(6),
+            if (showIcon) ...[
+              FlowySvg(
+                FlowySvgs.clock_alarm_s,
+                color: Theme.of(context).iconTheme.color,
+              ),
+              const HSpace(6),
+            ],
             FlowyText(LocaleKeys.grid_field_includeTime.tr()),
             const Spacer(),
             Toggle(

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/timestamp.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/timestamp.dart
@@ -30,6 +30,8 @@ class TimestampTypeOptionEditorFactory implements TypeOptionEditorFactory {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12.0),
           child: IncludeTimeButton(
+            includeTime: typeOption.includeTime,
+            showIcon: false,
             onChanged: (value) {
               final newTypeOption = _updateTypeOption(
                 typeOption: typeOption,
@@ -37,7 +39,6 @@ class TimestampTypeOptionEditorFactory implements TypeOptionEditorFactory {
               );
               onTypeOptionUpdated(newTypeOption.writeToBuffer());
             },
-            includeTime: typeOption.includeTime,
           ),
         ),
       ],


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Introduce a showIcon flag to the IncludeTimeButton and hide the clock icon in the timestamp editor

Enhancements:
- Add a showIcon parameter to IncludeTimeButton to conditionally render the time icon
- Disable the time icon in TimestampTypeOptionEditor by setting showIcon to false