### PR TITLE
fix: arrow key sometimes jumps to wrong index in search panel

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
@@ -207,6 +207,8 @@ class CommandPaletteModal extends StatelessWidget {
           final hasResult = state.combinedResponseItems.isNotEmpty,
               searching = state.searching;
           final spaceXl = theme.spacing.xl;
+          final showRencentList = noQuery,
+              showResultList = hasResult && hasQuery;
           return FlowyDialog(
             backgroundColor: theme.surfaceColorScheme.layer01,
             alignment: Alignment.topCenter,
@@ -224,14 +226,15 @@ class CommandPaletteModal extends StatelessWidget {
                 padding: EdgeInsets.fromLTRB(spaceXl, spaceXl, spaceXl, 0),
                 child: Column(
                   children: [
-                    SearchField(query: state.query, isLoading: searching),
-                    if (noQuery)
+                    if (!showRencentList && !showResultList)
+                      SearchField(query: state.query, isLoading: searching),
+                    if (showRencentList)
                       Flexible(
                         child: RecentViewsList(
                           onSelected: () => FlowyOverlay.pop(context),
                         ),
                       ),
-                    if (hasResult && hasQuery)
+                    if (showResultList)
                       Flexible(
                         child: SearchResultList(
                           cachedViews: state.cachedViews,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/command_palette.dart
@@ -207,7 +207,7 @@ class CommandPaletteModal extends StatelessWidget {
           final hasResult = state.combinedResponseItems.isNotEmpty,
               searching = state.searching;
           final spaceXl = theme.spacing.xl;
-          final showRencentList = noQuery,
+          final showRecentList = noQuery,
               showResultList = hasResult && hasQuery;
           return FlowyDialog(
             backgroundColor: theme.surfaceColorScheme.layer01,
@@ -226,9 +226,9 @@ class CommandPaletteModal extends StatelessWidget {
                 padding: EdgeInsets.fromLTRB(spaceXl, spaceXl, spaceXl, 0),
                 child: Column(
                   children: [
-                    if (!showRencentList && !showResultList)
+                    if (!showRecentList && !showResultList)
                       SearchField(query: state.query, isLoading: searching),
-                    if (showRencentList)
+                    if (showRecentList)
                       Flexible(
                         child: RecentViewsList(
                           onSelected: () => FlowyOverlay.pop(context),

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/keyboard_scroller.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/keyboard_scroller.dart
@@ -1,0 +1,156 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class KeyboardScroller<T> extends StatefulWidget {
+  const KeyboardScroller({
+    super.key,
+    required this.controller,
+    required this.list,
+    required this.onSelect,
+    required this.idGetter,
+    required this.selectedIndexGetter,
+    required this.builder,
+  });
+
+  final ScrollController controller;
+  final List<T> list;
+  final ValueGetter<int> selectedIndexGetter;
+  final ValueChanged<int> onSelect;
+  final IdGetter<T> idGetter;
+  final KeyboardScrollerBuilder builder;
+
+  @override
+  State<KeyboardScroller<T>> createState() => _KeyboardScrollerState<T>();
+}
+
+class _KeyboardScrollerState<T> extends State<KeyboardScroller<T>> {
+  int get length => widget.list.length;
+
+  final AreaDetectors areaDetector = AreaDetectors();
+
+  @override
+  void dispose() {
+    areaDetector._dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Shortcuts(
+      shortcuts: {
+        SingleActivator(LogicalKeyboardKey.arrowUp):
+            VoidCallbackIntent(() => _moveSelection(AxisDirection.up, context)),
+        SingleActivator(LogicalKeyboardKey.arrowDown): VoidCallbackIntent(
+          () => _moveSelection(AxisDirection.down, context),
+        ),
+      },
+      child: widget.builder.call(context, areaDetector),
+    );
+  }
+
+  bool _moveSelection(AxisDirection direction, BuildContext context) {
+    if (length == 0) return false;
+    final index = widget.selectedIndexGetter.call();
+    int newIndex = index;
+    final isUp = direction == AxisDirection.up;
+    if (index < 0) {
+      newIndex = isUp ? length - 1 : 0;
+    } else {
+      if (isUp) {
+        newIndex = index == 0 ? length - 1 : index - 1;
+      } else {
+        newIndex = index == length - 1 ? 0 : index + 1;
+      }
+    }
+    widget.onSelect(newIndex);
+    _scrollToItem(index, newIndex, context);
+    return true;
+  }
+
+  void _scrollToItem(
+    int from,
+    int to,
+    BuildContext context,
+  ) {
+    if (!context.mounted) return;
+
+    /// scroll to the end
+    if (to == length - 1) {
+      widget.controller.jumpTo(widget.controller.position.maxScrollExtent);
+      return;
+    } else if (to == 0) {
+      /// scroll to the start
+      widget.controller.jumpTo(0);
+      return;
+    }
+    final id = widget.idGetter(widget.list[to]);
+
+    final isTopArea = areaDetector.getAreaType(id) == AreaType.top;
+
+    final currentPosition = widget.controller.position.pixels;
+    if (isTopArea && from > to) {
+      widget.controller.jumpTo(max(0, currentPosition - 50));
+    } else if (!isTopArea && from < to) {
+      widget.controller.jumpTo(
+        min(currentPosition + 50, widget.controller.position.maxScrollExtent),
+      );
+    }
+  }
+}
+
+typedef KeyboardScrollerBuilder = Widget Function(
+  BuildContext context,
+  AreaDetectors detectors,
+);
+
+typedef IdGetter<T> = String Function(T t);
+
+enum AreaType { top, bottom }
+
+extension AreaTypeSearchPanelExtension on GlobalKey {
+    AreaType? getAreaType(BuildContext context) {
+    final renderObject = currentContext?.findRenderObject();
+    if (renderObject is RenderBox) {
+      final searchPanelHeight = min(MediaQuery.of(context).size.height - 100, 640);
+      final position = renderObject.localToGlobal(Offset.zero);
+      if (position.dy < searchPanelHeight / 2) {
+        return AreaType.top;
+      } else {
+        return AreaType.bottom;
+      }
+    }
+    return null;
+  }
+}
+
+class AreaDetectors {
+  final Map<String, Set<ValueGetter<AreaType?>>> _detectors = {};
+
+  void addDetector(String key, ValueGetter<AreaType?> detector) {
+    final set = _detectors[key] ?? {};
+    set.add(detector);
+    _detectors[key] = set;
+  }
+
+  void removeDetector(String key, ValueGetter<AreaType?> detector) {
+    final set = _detectors[key] ?? {};
+    set.remove(detector);
+    if (set.isEmpty) {
+      _detectors.remove(key);
+    } else {
+      _detectors[key] = set;
+    }
+  }
+
+  AreaType? getAreaType(String key) {
+    final set = _detectors[key] ?? {};
+    if (set.isEmpty) return null;
+    return set.first.call();
+  }
+
+  void _dispose() {
+    _detectors.clear();
+  }
+}

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
@@ -44,6 +44,10 @@ class RecentViewsList extends StatelessWidget {
                     onSelect: (index) {
                       bloc.add(RecentViewsEvent.hoverView(recentViews[index]));
                     },
+                    onConfirm: (index) {
+                      recentViews[index].id.navigateTo();
+                      onSelected();
+                    },
                     idGetter: (item) => item.id,
                     list: recentViews,
                     controller: controller,

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/recent_views_list.dart
@@ -1,9 +1,11 @@
 import 'package:appflowy/features/workspace/logic/workspace_bloc.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/workspace/application/command_palette/command_palette_bloc.dart';
 import 'package:appflowy/workspace/application/recent/recent_views_bloc.dart';
 import 'package:appflowy/workspace/presentation/command_palette/navigation_bloc_extension.dart';
 import 'package:appflowy/workspace/presentation/command_palette/widgets/search_icon.dart';
 import 'package:appflowy/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart';
+import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/workspace.pbenum.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -11,8 +13,10 @@ import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'keyboard_scroller.dart';
 import 'page_preview.dart';
 import 'search_ask_ai_entrance.dart';
+import 'search_field.dart';
 
 class RecentViewsList extends StatelessWidget {
   const RecentViewsList({super.key, required this.onSelected});
@@ -26,15 +30,54 @@ class RecentViewsList extends StatelessWidget {
           RecentViewsBloc()..add(const RecentViewsEvent.initial()),
       child: BlocBuilder<RecentViewsBloc, RecentViewsState>(
         builder: (context, state) {
+          final recentViews = state.views.map((e) => e.item).toSet().toList();
+          final bloc = context.read<RecentViewsBloc>();
           return LayoutBuilder(
             builder: (context, constrains) {
               final maxWidth = constrains.maxWidth;
               final hidePreview = maxWidth < 884;
-              return Row(
-                children: [
-                  buildLeftPanel(state, context, hidePreview),
-                  if (!hidePreview) buildPreview(state),
-                ],
+              final commandPaletteState =
+                  context.read<CommandPaletteBloc>().state;
+              return ScrollControllerBuilder(
+                builder: (context, controller) {
+                  return KeyboardScroller<ViewPB>(
+                    onSelect: (index) {
+                      bloc.add(RecentViewsEvent.hoverView(recentViews[index]));
+                    },
+                    idGetter: (item) => item.id,
+                    list: recentViews,
+                    controller: controller,
+                    selectedIndexGetter: () => recentViews.indexWhere(
+                      (item) => item.id == bloc.state.hoveredView?.id,
+                    ),
+                    builder: (context, detectors) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SearchField(
+                            query: commandPaletteState.query,
+                            isLoading: commandPaletteState.searching,
+                          ),
+                          Flexible(
+                            child: Row(
+                              children: [
+                                buildLeftPanel(
+                                  state: state,
+                                  context: context,
+                                  hidePreview: hidePreview,
+                                  controller: controller,
+                                  detectors: detectors,
+                                ),
+                                if (!hidePreview) buildPreview(state),
+                              ],
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
               );
             },
           );
@@ -43,45 +86,48 @@ class RecentViewsList extends StatelessWidget {
     );
   }
 
-  Widget buildLeftPanel(
-    RecentViewsState state,
-    BuildContext context,
-    bool hidePreview,
-  ) {
+  Widget buildLeftPanel({
+    required RecentViewsState state,
+    required BuildContext context,
+    required bool hidePreview,
+    required ScrollController controller,
+    required AreaDetectors detectors,
+  }) {
     final workspaceState = context.read<UserWorkspaceBloc?>()?.state;
     final showAskingAI =
         workspaceState?.userProfile.workspaceType == WorkspaceTypePB.ServerW;
     return Flexible(
       child: Align(
         alignment: Alignment.topLeft,
-        child: ScrollControllerBuilder(
-          builder: (context, controller) {
-            return Padding(
-              padding: EdgeInsets.only(right: hidePreview ? 0 : 6),
-              child: FlowyScrollbar(
-                controller: controller,
-                thumbVisibility: false,
-                child: SingleChildScrollView(
-                  controller: controller,
-                  physics: const ClampingScrollPhysics(),
-                  child: Padding(
-                    padding: EdgeInsets.only(
-                      right: hidePreview ? 0 : 6,
+        child: Padding(
+          padding: EdgeInsets.only(right: hidePreview ? 0 : 6),
+          child: FlowyScrollbar(
+            controller: controller,
+            thumbVisibility: false,
+            child: SingleChildScrollView(
+              controller: controller,
+              physics: const ClampingScrollPhysics(),
+              child: Padding(
+                padding: EdgeInsets.only(
+                  right: hidePreview ? 0 : 6,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (showAskingAI) SearchAskAiEntrance(),
+                    buildTitle(context),
+                    buildViewList(
+                      state: state,
+                      context: context,
+                      hidePreview: hidePreview,
+                      detectors: detectors,
                     ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (showAskingAI) SearchAskAiEntrance(),
-                        buildTitle(context),
-                        buildViewList(state, context, hidePreview),
-                        VSpace(16),
-                      ],
-                    ),
-                  ),
+                    VSpace(16),
+                  ],
                 ),
               ),
-            );
-          },
+            ),
+          ),
         ),
       ),
     );
@@ -107,11 +153,12 @@ class RecentViewsList extends StatelessWidget {
     );
   }
 
-  Widget buildViewList(
-    RecentViewsState state,
-    BuildContext context,
-    bool hidePreview,
-  ) {
+  Widget buildViewList({
+    required RecentViewsState state,
+    required BuildContext context,
+    required bool hidePreview,
+    required AreaDetectors detectors,
+  }) {
     final recentViews = state.views.map((e) => e.item).toSet().toList();
 
     if (recentViews.isEmpty) {
@@ -133,6 +180,7 @@ class RecentViewsList extends StatelessWidget {
           view: view,
           onSelected: onSelected,
           isNarrowWindow: hidePreview,
+          detectors: detectors,
         );
       },
     );

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_ask_ai_entrance.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_ask_ai_entrance.dart
@@ -40,6 +40,7 @@ class _AskAIFor extends StatelessWidget {
       padding: EdgeInsets.symmetric(vertical: theme.spacing.xs),
       child: AFBaseButton(
         borderRadius: spaceM,
+        showFocusRing: false,
         padding: EdgeInsets.all(spaceL),
         backgroundColor: (context, isHovering, disable) {
           if (isHovering) {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_field.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_field.dart
@@ -7,7 +7,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flowy_infra_ui/style_widget/text_field.dart';
 import 'package:flowy_infra_ui/widget/flowy_tooltip.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SearchField extends StatefulWidget {
@@ -28,7 +27,7 @@ class _SearchFieldState extends State<SearchField> {
   void initState() {
     super.initState();
     controller = TextEditingController(text: widget.query);
-    focusNode = FocusNode(onKeyEvent: _handleKeyEvent);
+    focusNode = FocusNode();
     focusNode.requestFocus();
     // Update the text selection after the first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -37,16 +36,6 @@ class _SearchFieldState extends State<SearchField> {
         extentOffset: controller.text.length,
       );
     });
-  }
-
-  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
-    if (node.hasFocus &&
-        event is KeyDownEvent &&
-        event.logicalKey == LogicalKeyboardKey.arrowDown) {
-      node.nextFocus();
-      return KeyEventResult.handled;
-    }
-    return KeyEventResult.ignored;
   }
 
   @override

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
@@ -11,6 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'keyboard_scroller.dart';
+
 class SearchRecentViewCell extends StatefulWidget {
   const SearchRecentViewCell({
     super.key,
@@ -18,12 +20,14 @@ class SearchRecentViewCell extends StatefulWidget {
     required this.view,
     required this.onSelected,
     required this.isNarrowWindow,
+    required this.detectors,
   });
 
   final Widget icon;
   final ViewPB view;
   final VoidCallback onSelected;
   final bool isNarrowWindow;
+  final AreaDetectors detectors;
 
   @override
   State<SearchRecentViewCell> createState() => _SearchRecentViewCellState();
@@ -31,12 +35,23 @@ class SearchRecentViewCell extends StatefulWidget {
 
 class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
   final focusNode = FocusNode();
+  final itemKey = GlobalKey();
 
   ViewPB get view => widget.view;
+
+  AreaDetectors get detectors => widget.detectors;
+
+  @override
+  void initState() {
+    super.initState();
+    detectors.addDetector(view.id, getAreaType);
+  }
 
   @override
   void dispose() {
     focusNode.dispose();
+    detectors.removeDetector(view.id, getAreaType);
+
     super.dispose();
   }
 
@@ -49,6 +64,7 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
     final hovering = hoveredView == view;
 
     return GestureDetector(
+      key: itemKey,
       behavior: HitTestBehavior.opaque,
       onTap: () => _handleSelection(view.id),
       child: Focus(
@@ -60,11 +76,6 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;
-        },
-        onFocusChange: (hasFocus) {
-          if (hasFocus && !hovering) {
-            bloc.add(RecentViewsEvent.hoverView(view));
-          }
         },
         child: FlowyHover(
           onHover: (value) {
@@ -124,4 +135,6 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
     widget.onSelected();
     id.navigateTo();
   }
+
+  AreaType? getAreaType() => itemKey.getAreaTypeInSearchPanel(context);
 }

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_recent_view_cell.dart
@@ -8,7 +8,6 @@ import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'keyboard_scroller.dart';
@@ -69,14 +68,6 @@ class _SearchRecentViewCellState extends State<SearchRecentViewCell> {
       onTap: () => _handleSelection(view.id),
       child: Focus(
         focusNode: focusNode,
-        onKeyEvent: (node, event) {
-          if (event is! KeyDownEvent) return KeyEventResult.ignored;
-          if (event.logicalKey == LogicalKeyboardKey.enter) {
-            _handleSelection(view.id);
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
         child: FlowyHover(
           onHover: (value) {
             if (hoveredView == view) return;

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_result_cell.dart
@@ -12,7 +12,6 @@ import 'package:flowy_infra/theme_extension.dart';
 import 'package:flowy_infra_ui/style_widget/hover.dart';
 import 'package:flowy_infra_ui/widget/spacing.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'keyboard_scroller.dart';
@@ -82,14 +81,6 @@ class _SearchResultCellState extends State<SearchResultCell> {
       key: itemKey,
       child: Focus(
         focusNode: focusNode,
-        onKeyEvent: (node, event) {
-          if (event is! KeyDownEvent) return KeyEventResult.ignored;
-          if (event.logicalKey == LogicalKeyboardKey.enter) {
-            _handleSelection();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
         child: FlowyHover(
           onHover: (value) {
             bloc.add(

--- a/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/command_palette/widgets/search_results_list.dart
@@ -91,6 +91,13 @@ class _SearchResultListState extends State<SearchResultList> {
                           ),
                         );
                       },
+                      onConfirm: (index) {
+                        bloc.add(
+                          SearchResultListEvent.openPage(
+                            pageId: resultItems[index].id,
+                          ),
+                        );
+                      },
                       idGetter: (item) => item.id,
                       list: resultItems,
                       controller: controller,


### PR DESCRIPTION
### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Integrate a new KeyboardScroller utility with area detectors to unify arrow-key navigation and scrolling logic in the command palette’s search results and recent views panels, refactor list and cell widgets to wrap content in scroll controllers, reposition the search field, and simplify focus handling.

New Features:
- Add KeyboardScroller component to manage arrow-key navigation and auto-scrolling across list panels

Bug Fixes:
- Fix arrow-key navigation jumping to wrong index in the search panel by integrating KeyboardScroller and area detectors

Enhancements:
- Refactor SearchResultList and RecentViewsList to use ScrollControllerBuilder and KeyboardScroller for unified navigation
- Move SearchField into scrollable list views and simplify its focus handling
- Enhance result and recent view cells to register AreaDetectors for correct auto-scrolling behavior
- Adjust CommandPaletteModal to conditionally display the search field, recent list, or result list based on query state