### PR TITLE
fix: improve the link menu in read-only mode

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/toolbar/view_database_button.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/toolbar/view_database_button.dart
@@ -18,7 +18,7 @@ class ViewDatabaseButton extends StatelessWidget {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: FlowyIconButton(
-        tooltipText: LocaleKeys.grid_rowPage_openAsFullPage.tr(),
+        tooltipText: LocaleKeys.grid_rowPage_viewDatabase.tr(),
         width: 24,
         height: 24,
         iconPadding: const EdgeInsets.all(3),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/desktop_toolbar/link/link_hover_menu.dart
@@ -145,6 +145,7 @@ class _LinkHoverTriggerState extends State<LinkHoverTrigger> {
       popupBuilder: (context) => LinkHoverMenu(
         attribute: widget.attribute,
         triggerSize: size,
+        editable: editorState.editable,
         onEnter: (_) {
           isHoverMenuHovering = true;
         },
@@ -302,6 +303,7 @@ class LinkHoverMenu extends StatefulWidget {
     required this.attribute,
     required this.onEnter,
     required this.onExit,
+    required this.editable,
     required this.triggerSize,
     required this.onCopyLink,
     required this.onOpenLink,
@@ -318,6 +320,7 @@ class LinkHoverMenu extends StatefulWidget {
   final VoidCallback onOpenLink;
   final VoidCallback onEditLink;
   final VoidCallback onRemoveLink;
+  final bool editable;
   final ValueChanged<LinkConvertMenuCommand> onConvertTo;
 
   @override
@@ -330,6 +333,8 @@ class _LinkHoverMenuState extends State<LinkHoverMenu> {
   late String href = widget.attribute.href ?? '';
   final popoverController = PopoverController();
   bool isConvertButtonSelected = false;
+
+  bool get editable => widget.editable;
 
   @override
   void initState() {
@@ -382,19 +387,21 @@ class _LinkHoverMenuState extends State<LinkHoverMenu> {
                     FlowyIconButton(
                       icon: FlowySvg(FlowySvgs.toolbar_link_edit_m),
                       tooltipText: LocaleKeys.editor_editLink.tr(),
+                      hoverColor: hoverColor,
                       preferBelow: false,
                       width: 36,
                       height: 32,
-                      onPressed: widget.onEditLink,
+                      onPressed: getTapCallback(widget.onEditLink),
                     ),
                     buildConvertButton(),
                     FlowyIconButton(
                       icon: FlowySvg(FlowySvgs.toolbar_link_unlink_m),
                       tooltipText: LocaleKeys.editor_removeLink.tr(),
+                      hoverColor: hoverColor,
                       preferBelow: false,
                       width: 36,
                       height: 32,
-                      onPressed: widget.onRemoveLink,
+                      onPressed: getTapCallback(widget.onRemoveLink),
                     ),
                   ],
                 ),
@@ -460,6 +467,22 @@ class _LinkHoverMenuState extends State<LinkHoverMenu> {
   }
 
   Widget buildConvertButton() {
+    final button = FlowyIconButton(
+      icon: FlowySvg(FlowySvgs.turninto_m),
+      isSelected: isConvertButtonSelected,
+      tooltipText: LocaleKeys.editor_convertTo.tr(),
+      preferBelow: false,
+      hoverColor: hoverColor,
+      width: 36,
+      height: 32,
+      onPressed: getTapCallback(() {
+        setState(() {
+          isConvertButtonSelected = true;
+        });
+        showConvertMenu();
+      }),
+    );
+    if (!editable) return button;
     return AppFlowyPopover(
       offset: Offset(44, 10.0),
       direction: PopoverDirection.bottomWithRightAligned,
@@ -468,20 +491,7 @@ class _LinkHoverMenuState extends State<LinkHoverMenu> {
       onOpen: () => keepEditorFocusNotifier.increase(),
       onClose: () => keepEditorFocusNotifier.decrease(),
       popupBuilder: (context) => buildConvertMenu(),
-      child: FlowyIconButton(
-        icon: FlowySvg(FlowySvgs.turninto_m),
-        isSelected: isConvertButtonSelected,
-        tooltipText: LocaleKeys.editor_convertTo.tr(),
-        preferBelow: false,
-        width: 36,
-        height: 32,
-        onPressed: () {
-          setState(() {
-            isConvertButtonSelected = true;
-          });
-          showConvertMenu();
-        },
-      ),
+      child: button,
     );
   }
 
@@ -515,6 +525,13 @@ class _LinkHoverMenuState extends State<LinkHoverMenu> {
         ),
       ),
     );
+  }
+
+  Color? get hoverColor => editable ? null : Colors.transparent;
+
+  VoidCallback? getTapCallback(VoidCallback callback) {
+    if (editable) return callback;
+    return null;
   }
 
   void showConvertMenu() {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_embed/link_embed_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_embed/link_embed_menu.dart
@@ -45,6 +45,7 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
 
   Node get node => widget.node;
   EditorState get editorState => widget.editorState;
+  bool get editable => editorState.editable;
 
   String get url => node.attributes[LinkPreviewBlockKeys.url] ?? '';
 
@@ -103,6 +104,17 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
 
   Widget buildConvertButton() {
     final theme = AppFlowyTheme.of(context), iconScheme = theme.iconColorScheme;
+    final button = FlowyIconButton(
+      icon: FlowySvg(
+        FlowySvgs.turninto_m,
+        color: iconScheme.tertiary,
+      ),
+      radius: BorderRadius.all(Radius.circular(theme.borderRadius.m)),
+      tooltipText: LocaleKeys.editor_convertTo.tr(),
+      preferBelow: false,
+      onPressed: getTapCallback(showTurnIntoMenu),
+    );
+    if (!editable) return button;
     return AppFlowyPopover(
       offset: Offset(0, 6),
       direction: PopoverDirection.bottomWithRightAligned,
@@ -118,16 +130,7 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
         checkToHideMenu();
       },
       popupBuilder: (context) => buildConvertMenu(),
-      child: FlowyIconButton(
-        icon: FlowySvg(
-          FlowySvgs.turninto_m,
-          color: iconScheme.tertiary,
-        ),
-        radius: BorderRadius.all(Radius.circular(theme.borderRadius.m)),
-        tooltipText: LocaleKeys.editor_convertTo.tr(),
-        preferBelow: false,
-        onPressed: showTurnIntoMenu,
-      ),
+      child: button,
     );
   }
 
@@ -171,6 +174,18 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
 
   Widget buildMoreOptionButton() {
     final theme = AppFlowyTheme.of(context), iconScheme = theme.iconColorScheme;
+    final button = FlowyIconButton(
+      key: moreOptionButtonKey,
+      icon: FlowySvg(
+        FlowySvgs.toolbar_more_m,
+        color: iconScheme.tertiary,
+      ),
+      radius: BorderRadius.all(Radius.circular(theme.borderRadius.m)),
+      tooltipText: LocaleKeys.document_toolbar_moreOptions.tr(),
+      preferBelow: false,
+      onPressed: getTapCallback(showMoreOptionMenu),
+    );
+    if (!editable) return button;
     return AppFlowyPopover(
       offset: Offset(0, 6),
       direction: PopoverDirection.bottomWithRightAligned,
@@ -186,17 +201,7 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
         checkToHideMenu();
       },
       popupBuilder: (context) => buildMoreOptionMenu(),
-      child: FlowyIconButton(
-        key: moreOptionButtonKey,
-        icon: FlowySvg(
-          FlowySvgs.toolbar_more_m,
-          color: iconScheme.tertiary,
-        ),
-        radius: BorderRadius.all(Radius.circular(theme.borderRadius.m)),
-        tooltipText: LocaleKeys.document_toolbar_moreOptions.tr(),
-        preferBelow: false,
-        onPressed: showMoreOptionMenu,
-      ),
+      child: button,
     );
   }
 
@@ -305,6 +310,11 @@ class _LinkEmbedMenuState extends State<LinkEmbedMenu> {
         break;
     }
     closeMoreOptionMenu();
+  }
+
+  VoidCallback? getTapCallback(VoidCallback callback) {
+    if (editable) return callback;
+    return null;
   }
 }
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/link_preview/link_preview_menu.dart
@@ -74,6 +74,8 @@ class _CustomLinkPreviewMenuState extends State<CustomLinkPreviewMenu> {
   }
 
   Widget buildMenu() {
+    final editorState = context.read<EditorState>(),
+        editable = editorState.editable;
     return MouseRegion(
       child: Padding(
         padding: const EdgeInsets.all(8.0),
@@ -83,15 +85,18 @@ class _CustomLinkPreviewMenuState extends State<CustomLinkPreviewMenu> {
           children:
               List.generate(LinkPreviewMenuCommand.values.length, (index) {
             final command = LinkPreviewMenuCommand.values[index];
+            final isCopyCommand = command == LinkPreviewMenuCommand.copyLink;
+            final enableButton = editable || (!editable && isCopyCommand);
             return SizedBox(
               height: 36,
               child: FlowyButton(
+                hoverColor: enableButton ? null : Colors.transparent,
                 text: FlowyText(
                   command.title,
                   fontWeight: FontWeight.w400,
                   figmaLineHeight: 20,
                 ),
-                onTap: () => onTap(command),
+                onTap: enableButton ? () => onTap(command) : null,
               ),
             );
           }),

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_block.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_block.dart
@@ -56,6 +56,8 @@ class _MentionLinkBlockState extends State<MentionLinkBlock> {
 
   EditorState get editorState => widget.editorState;
 
+  bool get editable => editorState.editable;
+
   Node get node => widget.node;
 
   int get index => widget.index;
@@ -119,6 +121,7 @@ class _MentionLinkBlockState extends State<MentionLinkBlock> {
       popupBuilder: (context) => readyForPreview
           ? MentionLinkPreview(
               linkInfo: linkInfo,
+              editable: editable,
               showAtBottom: showAtBottom,
               triggerSize: getSizeFromKey(),
               onEnter: (e) {
@@ -135,6 +138,7 @@ class _MentionLinkBlockState extends State<MentionLinkBlock> {
             )
           : MentionLinkErrorPreview(
               url: url,
+              editable: editable,
               triggerSize: getSizeFromKey(),
               onEnter: (e) {
                 isPreviewHovering = true;

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_error_preview.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_error_preview.dart
@@ -22,6 +22,7 @@ class MentionLinkErrorPreview extends StatefulWidget {
     required this.onConvertTo,
     required this.onOpenLink,
     required this.triggerSize,
+    required this.editable,
   });
 
   final String url;
@@ -32,6 +33,7 @@ class MentionLinkErrorPreview extends StatefulWidget {
   final VoidCallback onOpenLink;
   final ValueChanged<PasteMenuType> onConvertTo;
   final Size triggerSize;
+  final bool editable;
 
   @override
   State<MentionLinkErrorPreview> createState() =>

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_preview.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_link_preview.dart
@@ -24,6 +24,7 @@ class MentionLinkPreview extends StatefulWidget {
     required this.onOpenLink,
     required this.triggerSize,
     required this.showAtBottom,
+    required this.editable,
   });
 
   final LinkInfo linkInfo;
@@ -35,6 +36,7 @@ class MentionLinkPreview extends StatefulWidget {
   final ValueChanged<PasteMenuType> onConvertTo;
   final Size triggerSize;
   final bool showAtBottom;
+  final bool editable;
 
   @override
   State<MentionLinkPreview> createState() => _MentionLinkPreviewState();
@@ -45,6 +47,8 @@ class _MentionLinkPreviewState extends State<MentionLinkPreview> {
   bool isSelected = false;
 
   LinkInfo get linkInfo => widget.linkInfo;
+
+  bool get editable => widget.editable;
 
   @override
   void dispose() {
@@ -197,15 +201,18 @@ class _MentionLinkPreviewState extends State<MentionLinkPreview> {
           children:
               List.generate(MentionLinktMenuCommand.values.length, (index) {
             final command = MentionLinktMenuCommand.values[index];
+            final isCopyCommand = command == MentionLinktMenuCommand.copyLink;
+            final enableButton = editable || (!editable && isCopyCommand);
             return SizedBox(
               height: 36,
               child: FlowyButton(
+                hoverColor: enableButton ? null : Colors.transparent,
                 text: FlowyText(
                   command.title,
                   fontWeight: FontWeight.w400,
                   figmaLineHeight: 20,
                 ),
-                onTap: () => onTap(command),
+                onTap: enableButton ? () => onTap(command) : null,
               ),
             );
           }),

--- a/frontend/resources/translations/en-US.json
+++ b/frontend/resources/translations/en-US.json
@@ -1649,6 +1649,7 @@
         "other": "Hide {count} hidden fields"
       },
       "openAsFullPage": "Open as full page",
+      "viewDatabase": "View the original Database",
       "moreRowActions": "More row actions"
     },
     "sort": {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Centralize read-only handling in link menus by introducing an editable flag, disabling interactive actions and popovers while preserving copy functionality.

Bug Fixes:
- Disable convert, edit, remove, and more-option popovers when the editor is in read-only mode.
- Restrict mention and custom link preview menus to only allow the copy action in read-only mode.

Enhancements:
- Introduce an `editable` flag in link and mention widgets to toggle interactive behavior based on editor state.
- Add a `getTapCallback` utility and transparent hover styling to centrally disable buttons in read-only mode.
- Propagate the `editable` state through link embed, hover, and mention components to unify behavior across menus.