### PR TITLE
fix: outline doesn't show when @dates are used in the headline

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/columns/simple_column_block_width_resizer.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/columns/simple_column_block_width_resizer.dart
@@ -3,6 +3,7 @@ import 'package:appflowy/plugins/document/presentation/editor_plugins/actions/dr
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:universal_platform/universal_platform.dart';
 
 class SimpleColumnBlockWidthResizer extends StatefulWidget {
   const SimpleColumnBlockWidthResizer({
@@ -55,6 +56,10 @@ class _SimpleColumnBlockWidthResizerState
         child: ValueListenableBuilder<bool>(
           valueListenable: isHovering,
           builder: (context, isHovering, child) {
+            if (UniversalPlatform.isMobile) {
+              return const SizedBox.shrink();
+            }
+
             final hide = isDraggingAppFlowyEditorBlock.value || !isHovering;
             return MouseRegion(
               cursor: SystemMouseCursors.resizeLeftRight,

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -287,9 +287,6 @@ class OutlineItemWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final editorState = context.read<EditorState>();
-    final textStyle = editorState.editorStyle.textStyleConfiguration;
-    final style = textStyle.href.combine(textStyle.text);
     return FlowyButton(
       onTap: () => scrollToBlock(context),
       text: Row(
@@ -297,12 +294,7 @@ class OutlineItemWidget extends StatelessWidget {
         children: [
           HSpace(node.leftIndent),
           Flexible(
-            child: Text(
-              node.outlineItemText,
-              textDirection: textDirection,
-              style: style,
-              overflow: TextOverflow.ellipsis,
-            ),
+            child: buildOutlineItemWidget(context),
           ),
         ],
       ),
@@ -318,6 +310,60 @@ class OutlineItemWidget extends StatelessWidget {
     );
     editorState.selection = Selection.collapsed(
       Position(path: node.path, offset: node.delta?.length ?? 0),
+    );
+  }
+
+  Widget buildOutlineItemWidget(BuildContext context) {
+    final editorState = context.read<EditorState>();
+    final textStyle = editorState.editorStyle.textStyleConfiguration;
+    final style = textStyle.href.combine(textStyle.text);
+
+    final textInserted = node.delta?.whereType<TextInsert>();
+    if (textInserted == null) {
+      return const SizedBox.shrink();
+    }
+
+    final children = <InlineSpan>[];
+
+    var i = 0;
+    for (final e in textInserted) {
+      final mentionAttribute = e.attributes?[MentionBlockKeys.mention];
+      final mention =
+          mentionAttribute is Map<String, dynamic> ? mentionAttribute : null;
+      final text = e.text;
+      if (mention != null) {
+        final type = mention[MentionBlockKeys.type];
+        children.add(
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: MentionBlock(
+              key: ValueKey(type),
+              node: node,
+              index: i,
+              mention: mention,
+              textStyle: style,
+            ),
+          ),
+        );
+      } else {
+        children.add(
+          TextSpan(
+            text: text,
+            style: style,
+          ),
+        );
+      }
+
+      i += text.length;
+    }
+
+    return IgnorePointer(
+      child: Text.rich(
+        TextSpan(
+          children: children,
+          style: style,
+        ),
+      ),
     );
   }
 }
@@ -338,9 +384,5 @@ extension on Node {
     }
 
     return 0.0;
-  }
-
-  String get outlineItemText {
-    return delta?.toPlainText() ?? '';
   }
 }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/outline/outline_block_component.dart
@@ -345,7 +345,7 @@ class OutlineItemWidget extends StatelessWidget {
             ),
           ),
         );
-      } else {
+    } else {
         children.add(
           TextSpan(
             text: text,

--- a/frontend/appflowy_flutter/lib/startup/tasks/appflowy_cloud_task.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/appflowy_cloud_task.dart
@@ -9,6 +9,7 @@ import 'package:appflowy/startup/tasks/deeplink/deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/expire_login_deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/invitation_deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/login_deeplink_handler.dart';
+import 'package:appflowy/startup/tasks/deeplink/open_app_deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/payment_deeplink_handler.dart';
 import 'package:appflowy/user/application/auth/auth_error.dart';
 import 'package:appflowy/user/application/user_auth_listener.dart';
@@ -28,7 +29,8 @@ class AppFlowyCloudDeepLink {
       ..register(LoginDeepLinkHandler())
       ..register(PaymentDeepLinkHandler())
       ..register(InvitationDeepLinkHandler())
-      ..register(ExpireLoginDeepLinkHandler());
+      ..register(ExpireLoginDeepLinkHandler())
+      ..register(OpenAppDeepLinkHandler());
 
     _deepLinkSubscription = _AppLinkWrapper.instance.listen(
       (Uri? uri) async {

--- a/frontend/appflowy_flutter/lib/startup/tasks/deeplink/open_app_deeplink_handler.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/deeplink/open_app_deeplink_handler.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+
+import 'package:appflowy/startup/tasks/deeplink/deeplink_handler.dart';
+import 'package:appflowy_backend/protobuf/flowy-error/errors.pb.dart';
+import 'package:appflowy_result/appflowy_result.dart';
+
+class OpenAppDeepLinkHandler extends DeepLinkHandler<void> {
+  @override
+  bool canHandle(Uri uri) {
+    return uri.toString() == 'appflowy-flutter://';
+  }
+
+  @override
+  Future<FlowyResult<void, FlowyError>> handle({
+    required Uri uri,
+    required DeepLinkStateHandler onStateChange,
+  }) async {
+    return FlowyResult.success(null);
+  }
+}

--- a/frontend/appflowy_flutter/test/unit_test/deeplink/deeplink_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/deeplink/deeplink_test.dart
@@ -1,6 +1,7 @@
 import 'package:appflowy/startup/tasks/deeplink/deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/invitation_deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/login_deeplink_handler.dart';
+import 'package:appflowy/startup/tasks/deeplink/open_app_deeplink_handler.dart';
 import 'package:appflowy/startup/tasks/deeplink/payment_deeplink_handler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,7 +10,8 @@ void main() {
     final deepLinkHandlerRegistry = DeepLinkHandlerRegistry.instance
       ..register(LoginDeepLinkHandler())
       ..register(PaymentDeepLinkHandler())
-      ..register(InvitationDeepLinkHandler());
+      ..register(InvitationDeepLinkHandler())
+      ..register(OpenAppDeepLinkHandler());
 
     test('invitation deep link handler', () {
       final uri = Uri.parse(
@@ -52,6 +54,11 @@ void main() {
           expect(error, isNotNull);
         },
       );
+    });
+
+    test('open app deep link handler', () {
+      final uri = Uri.parse('appflowy-flutter://');
+      expect(OpenAppDeepLinkHandler().canHandle(uri), true);
     });
   });
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

closes https://github.com/AppFlowy-IO/AppFlowy/issues/8027

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Fix outline rendering to correctly display inline mentions (such as dates) in headings by refactoring the outline component to build rich text spans.

Bug Fixes:
- Ensure outline items render when @mentions or date mentions are included in headings.

Enhancements:
- Refactor OutlineItemWidget to construct Text.rich with InlineSpans and WidgetSpans for mentions instead of using a plain Text widget.

Chores:
- Remove deprecated outlineItemText extension property.