### PR TITLE
chore: adjust padding for include time

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/date/date_time_format.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/date/date_time_format.dart
@@ -261,8 +261,9 @@ class IncludeTimeButton extends StatelessWidget {
                 FlowySvgs.clock_alarm_s,
                 color: Theme.of(context).iconTheme.color,
               ),
-              const HSpace(6),
+              const HSpace(4),
             ],
+            const HSpace(2),
             FlowyText(LocaleKeys.grid_field_includeTime.tr()),
             const Spacer(),
             Toggle(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Adjust the horizontal padding around the "Include Time" toggle to refine UI spacing.

Enhancements:
- Reduce space between clock icon and text from 6px to 4px.
- Add 2px horizontal space after icon row before the label.