### PR TITLE
chore(mobile): add selected sources count indicator

### DIFF
--- a/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
+++ b/frontend/appflowy_flutter/lib/ai/widgets/prompt_input/select_sources_bottom_sheet.dart
@@ -7,6 +7,7 @@ import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/base/flowy_search_text_field.dart';
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
 import 'package:appflowy/plugins/base/drag_handler.dart';
+import 'package:appflowy/plugins/document/application/document_bloc.dart';
 import 'package:appflowy/workspace/application/sidebar/space/space_bloc.dart';
 import 'package:appflowy/workspace/application/view/view_ext.dart';
 import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
@@ -99,6 +100,26 @@ class _PromptInputMobileSelectSourcesButtonState
                       color: Theme.of(context).iconTheme.color,
                       size: const Size.square(20.0),
                     ),
+                    const HSpace(2.0),
+                    ValueListenableBuilder(
+                      valueListenable: widget.selectedSourcesNotifier,
+                      builder: (context, selectedSourceIds, _) {
+                        final documentId =
+                            context.read<DocumentBloc?>()?.documentId;
+                        final label = documentId != null &&
+                                selectedSourceIds.length == 1 &&
+                                selectedSourceIds[0] == documentId
+                            ? LocaleKeys.chat_currentPage.tr()
+                            : selectedSourceIds.length.toString();
+                        return FlowyText(
+                          label,
+                          fontSize: 14,
+                          figmaLineHeight: 20,
+                          color: Theme.of(context).hintColor,
+                        );
+                      },
+                    ),
+                    const HSpace(2.0),
                     FlowySvg(
                       FlowySvgs.ai_source_drop_down_s,
                       color: Theme.of(context).hintColor,
@@ -199,6 +220,48 @@ class _MobileSelectSourcesSheetBody extends StatelessWidget {
               ),
             ),
           ),
+        ),
+        BlocBuilder<ViewSelectorCubit, ViewSelectorState>(
+          builder: (context, state) {
+            return SliverList(
+              delegate: SliverChildBuilderDelegate(
+                childCount: state.selectedSources.length,
+                (context, index) {
+                  final source = state.selectedSources.elementAt(index);
+                  return ViewSelectorTreeItem(
+                    key: ValueKey(
+                      'selected_select_sources_tree_item_${source.view.id}',
+                    ),
+                    viewSelectorItem: source,
+                    level: 0,
+                    isDescendentOfSpace: source.view.isSpace,
+                    isSelectedSection: true,
+                    onSelected: (item) {
+                      context
+                          .read<ViewSelectorCubit>()
+                          .toggleSelectedStatus(item, true);
+                    },
+                    height: 40.0,
+                  );
+                },
+              ),
+            );
+          },
+        ),
+        BlocBuilder<ViewSelectorCubit, ViewSelectorState>(
+          builder: (context, state) {
+            if (state.selectedSources.isNotEmpty &&
+                state.visibleSources.isNotEmpty) {
+              return SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: AFDivider(),
+                ),
+              );
+            }
+
+            return const SliverToBoxAdapter();
+          },
         ),
         BlocBuilder<ViewSelectorCubit, ViewSelectorState>(
           builder: (context, state) {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Add a selected sources count indicator to the source selection button and render the selected items list with a divider in the selection sheet

Enhancements:
- Show the number of selected sources next to the select sources button
- Display “Current Page” when the only selected source is the current document
- Render selected sources at the top of the bottom sheet before available sources
- Insert a divider between the selected sources list and the available sources list