### PR TITLE
fix: databse layout issue

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/calendar/presentation/calendar_page.dart
@@ -221,8 +221,9 @@ class _CalendarPageState extends State<CalendarPage> {
     return LayoutBuilder(
       // must specify MonthView width for useAvailableVerticalSpace to work properly
       builder: (context, constraints) {
-        final paddingLeft =
-            context.read<DatabasePluginWidgetBuilderSize>().paddingLeft;
+        final paddingLeft = context
+            .read<DatabasePluginWidgetBuilderSize>()
+            .paddingLeftWithMaxDocumentWidth;
         EdgeInsets padding = UniversalPlatform.isMobile
             ? CalendarSize.contentInsetsMobile
             : CalendarSize.contentInsets +

--- a/frontend/appflowy_flutter/lib/plugins/database/tab_bar/tab_bar_view.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/tab_bar/tab_bar_view.dart
@@ -207,7 +207,7 @@ class _DatabaseTabBarViewState extends State<DatabaseTabBarView> {
                           padding: EdgeInsets.fromLTRB(
                             horizontalPadding + paddingLeft,
                             0,
-                            horizontalPadding,
+                            horizontalPadding + (isCalendar ? paddingLeft : 0),
                             0,
                           ),
                           child: child,
@@ -217,14 +217,20 @@ class _DatabaseTabBarViewState extends State<DatabaseTabBarView> {
                       return child;
                     },
                   ),
-                  pageSettingBarExtensionFromState(context, state),
+                  pageSettingBarExtensionFromState(
+                    context,
+                    state,
+                    horizontalPadding,
+                  ),
                   wrapContent(
                     layout: layout,
                     child: Padding(
-                      padding:
-                          (isCalendar && widget.shrinkWrap || showActionWrapper)
-                              ? EdgeInsets.only(left: 42 - horizontalPadding)
-                              : EdgeInsets.zero,
+                      padding: (widget.shrinkWrap || showActionWrapper)
+                          ? EdgeInsets.only(
+                              left: 42 - horizontalPadding,
+                              right: isCalendar ? paddingLeft : 0,
+                            )
+                          : EdgeInsets.zero,
                       child: Provider(
                         create: (_) => DatabasePluginWidgetBuilderSize(
                           horizontalPadding: horizontalPadding,
@@ -313,6 +319,7 @@ class _DatabaseTabBarViewState extends State<DatabaseTabBarView> {
   Widget pageSettingBarExtensionFromState(
     BuildContext context,
     DatabaseTabBarState state,
+    double horizontalPadding,
   ) {
     if (state.tabBars.length < state.selectedIndex) {
       return const SizedBox.shrink();
@@ -322,8 +329,7 @@ class _DatabaseTabBarViewState extends State<DatabaseTabBarView> {
         state.tabBarControllerByViewId[tabBar.viewId]!.controller;
     return Padding(
       padding: EdgeInsets.symmetric(
-        horizontal:
-            context.read<DatabasePluginWidgetBuilderSize>().horizontalPadding,
+        horizontal: horizontalPadding,
       ),
       child: tabBar.builder.settingBarExtension(
         context,

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/database_view_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/database_view_widget.dart
@@ -61,9 +61,7 @@ class _DatabaseViewWidgetState extends State<DatabaseViewWidget> {
     double? horizontalPadding = 0.0;
     final databasePluginWidgetBuilderSize =
         Provider.of<DatabasePluginWidgetBuilderSize?>(context);
-    if (view.layout == ViewLayoutPB.Grid || view.layout == ViewLayoutPB.Board) {
-      horizontalPadding = 40.0;
-    }
+    horizontalPadding = 40.0;
     if (databasePluginWidgetBuilderSize != null) {
       horizontalPadding = databasePluginWidgetBuilderSize.horizontalPadding;
     }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/database/database_view_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/database/database_view_block_component.dart
@@ -23,6 +23,7 @@ class DatabaseBlockKeys {
 const overflowTypes = {
   DatabaseBlockKeys.gridType,
   DatabaseBlockKeys.boardType,
+  DatabaseBlockKeys.calendarType,
 };
 
 class DatabaseViewBlockComponentBuilder extends BlockComponentBuilder {


### PR DESCRIPTION
To fix #6770 

database reference | inline databse
---|---
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/99798de5-4d68-4ac3-a8cb-8ade326bbe12" /> | <img width="1189" alt="image" src="https://github.com/user-attachments/assets/dcd952a1-08bc-47ae-8bcf-1f37b77c063c" />

To fix #6940
<img width="542" alt="image" src="https://github.com/user-attachments/assets/da0a0a8a-2c97-4751-9118-ed73e9d91099" />



### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Fix database layout issues by refining padding logic across tab bar, calendar page, and inline database views, and register calendar type for overflow handling.

Bug Fixes:
- Adjust TabBar view padding to correctly apply horizontal offsets for calendar and inline database layouts
- Use corrected paddingLeftWithMaxDocumentWidth in CalendarPage for accurate content alignment
- Ensure inline database views consistently apply horizontal padding from provider

Enhancements:
- Simplify horizontalPadding default logic in DatabaseViewWidget to always initialize before provider override

Chores:
- Add calendarType to DatabaseBlockKeys overflowTypes for proper handling