### PR TITLE
fix: regression in handling on non-standard URLs on Windows

### DIFF
--- a/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
+++ b/frontend/appflowy_flutter/lib/core/helpers/url_launcher.dart
@@ -43,11 +43,11 @@ Future<bool> afLaunchUri(
   }
 
   // on Linux or Android, add http scheme to the url if it is not present
-  final isNotCustomUrlOnWidows =
+  final isNotCustomUrlOnWindows =
       UniversalPlatform.isWindows && !isCustomUrL(url);
   if ((UniversalPlatform.isLinux ||
           UniversalPlatform.isAndroid ||
-          isNotCustomUrlOnWidows) &&
+          isNotCustomUrlOnWindows) &&
       !isURL(url, {'require_protocol': true})) {
     uri = Uri.parse('https://$url');
   }


### PR DESCRIPTION
To fix #8050 

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Refine URL handling to prevent unintentional protocol prepending for custom editor URLs on Windows while preserving scheme addition for standard links on Linux and Android.

Bug Fixes:
- Skip adding default protocol to custom URLs on Windows to restore correct link launching behavior.

Enhancements:
- Refine URL launcher logic by introducing a Windows-specific custom URL check with isCustomUrL.