### PR TITLE
chore: update Makefile.toml [only for testing]

### DIFF
--- a/frontend/Makefile.toml
+++ b/frontend/Makefile.toml
@@ -190,6 +190,9 @@ FLUTTER_OUTPUT_DIR = "Debug"
 RUST_COMPILE_TARGET = "aarch64-apple-ios"
 BUILD_ARCHS = "arm64"
 CRATE_TYPE = "staticlib"
+IPHONEOS_DEPLOYMENT_TARGET = "10.0"
+CFLAGS = "-miphoneos-version-min=10.0"
+LDFLAGS = "-miphoneos-version-min=10.0"
 
 [env.production-ios-arm64]
 BUILD_FLAG = "release"
@@ -198,6 +201,9 @@ FLUTTER_OUTPUT_DIR = "Release"
 RUST_COMPILE_TARGET = "aarch64-apple-ios"
 BUILD_ARCHS = "arm64"
 CRATE_TYPE = "staticlib"
+IPHONEOS_DEPLOYMENT_TARGET = "10.0"
+CFLAGS = "-miphoneos-version-min=10.0"
+LDFLAGS = "-miphoneos-version-min=10.0"
 
 [env.development-android]
 BUILD_FLAG = "debug"


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Set the minimum iOS deployment target in the Makefile.toml and apply corresponding compiler and linker flags for both debug and release iOS build environments.

Chores:
- Add IPHONEOS_DEPLOYMENT_TARGET to 10.0 in iOS build configurations
- Include CFLAGS and LDFLAGS to enforce the iOS 10.0 minimum version