### PR TITLE
chore: remove extra space in createdAt translation of zh-CN

### DIFF
--- a/frontend/resources/translations/zh-CN.json
+++ b/frontend/resources/translations/zh-CN.json
@@ -149,7 +149,7 @@
     "moreOptions": "更多选项",
     "wordCount": "字数:{}",
     "charCount": "字符数:{}",
-    "createdAt": "创建于 :{}",
+    "createdAt": "创建于:{}",
     "deleteView": "删除",
     "duplicateView": "复制",
     "wordCountLabel": "词总数:",


### PR DESCRIPTION
### Feature Preview

Correction of the Chinese translation.

<img width="185" alt="image" src="https://github.com/user-attachments/assets/7888976a-caed-4e36-a7c0-45a1911ba5a1" />

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Documentation:
- Remove the unintended extra space in the zh-CN translation of the createdAt field