### PR TITLE
fix: prevent location from being accessed continuously on Windows

### DIFF
--- a/frontend/appflowy_flutter/pubspec.lock
+++ b/frontend/appflowy_flutter/pubspec.lock
@@ -1605,27 +1605,28 @@ packages:
   permission_handler:
     dependency: "direct main"
     description:
-      name: permission_handler
-      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "11.3.1"
+      path: permission_handler
+      ref: faef1c9
+      resolved-ref: faef1c97970de29995642bfae61b884591798684
+      url: "https://github.com/LucasXu0/flutter-permission-handler.git"
+    source: git
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.13"
+    version: "13.0.1"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.5"
+    version: "9.4.7"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1638,10 +1639,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.3.0"
   permission_handler_windows:
     dependency: transitive
     description:

--- a/frontend/appflowy_flutter/pubspec.yaml
+++ b/frontend/appflowy_flutter/pubspec.yaml
@@ -109,7 +109,6 @@ dependencies:
   mime: ^2.0.0
   nanoid: ^1.0.0
   numerus: ^2.1.2
-
   # Used to open local files on Mobile
   open_filex: ^4.5.0
   package_info_plus: ^8.0.2
@@ -246,14 +245,13 @@ dependency_overrides:
       url: https://github.com/LucasXu0/unsplash_client.git
       ref: a8411fc
 
-  # auto_updater:
-  #   path: /Users/lucas.xu/Desktop/auto_updater/packages/auto_updater
-
-  # auto_updater_macos:
-  #   path: /Users/lucas.xu/Desktop/auto_updater/packages/auto_updater_macos
-
-  # auto_updater_platform_interface:
-  #   path: /Users/lucas.xu/Desktop/auto_updater/packages/auto_updater_platform_interface
+  # https://github.com/LucasXu0/flutter-permission-handler/commit/faef1c97970de29995642bfae61b884591798684
+  # Prevent the location from being accessed continuously on Windows
+  permission_handler:
+    git:
+      url: https://github.com/LucasXu0/flutter-permission-handler.git
+      path: permission_handler
+      ref: faef1c9
 
 flutter:
   generate: true


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

https://github.com/LucasXu0/flutter-permission-handler/commit/faef1c97970de29995642bfae61b884591798684

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Update dependency overrides to apply a patched flutter_permission_handler commit that prevents continuous location access on Windows and clean up unused auto_updater overrides

Bug Fixes:
- Override the permission_handler plugin to a custom commit that stops continuous Windows location access

Chores:
- Remove commented-out local auto_updater package overrides from pubspec.yaml