### PR TITLE
Fix for #8200: add PLN (Polish Złoty) number format support

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/type_option/number_format_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/type_option/number_format_bloc.dart
@@ -95,6 +95,8 @@ extension NumberFormatExtension on NumberFormatPB {
         return "Percent";
       case NumberFormatPB.PhilippinePeso:
         return "Philippine peso";
+      case NumberFormatPB.PLN:
+        return "Polish złoty";
       case NumberFormatPB.Pound:
         return "Pound";
       case NumberFormatPB.Rand:
@@ -174,6 +176,8 @@ extension NumberFormatExtension on NumberFormatPB {
         return "%";
       case NumberFormatPB.PhilippinePeso:
         return "₱";
+      case NumberFormatPB.PLN:
+        return "zł";
       case NumberFormatPB.Pound:
         return "£";
       case NumberFormatPB.Rand:

--- a/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/number_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/number_entities.rs
@@ -78,6 +78,7 @@ pub enum NumberFormatPB {
   ArgentinePeso = 34,
   UruguayanPeso = 35,
   Percent = 36,
+  PLN = 37,
 }
 
 impl From<NumberFormat> for NumberFormatPB {
@@ -119,6 +120,7 @@ impl From<NumberFormat> for NumberFormatPB {
       NumberFormat::ArgentinePeso => NumberFormatPB::ArgentinePeso,
       NumberFormat::UruguayanPeso => NumberFormatPB::UruguayanPeso,
       NumberFormat::Percent => NumberFormatPB::Percent,
+      NumberFormat::PLN => NumberFormatPB::PLN,
     }
   }
 }
@@ -162,6 +164,7 @@ impl From<NumberFormatPB> for NumberFormat {
       NumberFormatPB::ArgentinePeso => NumberFormat::ArgentinePeso,
       NumberFormatPB::UruguayanPeso => NumberFormat::UruguayanPeso,
       NumberFormatPB::Percent => NumberFormat::Percent,
+      NumberFormatPB::PLN => NumberFormat::PLN,
     }
   }
 }


### PR DESCRIPTION
This PR adds support for PLN (Polish Złoty) as a number format option in the database fields. 

- Add PLN = 37 to NumberFormatPB enum in Rust
- Add conversion mappings between NumberFormat::PLN and NumberFormatPB::PLN
- Add "Polish złoty" title and "zł" symbol in Flutter UI

**Note:** This requires corresponding NumberFormat::PLN to be added in the collab-database dependency (AppFlowy-Collab repository).

Changes needed in collab-database:

`In the NumberFormat enum (likely in a file similar to fields/number_type_option.rs), add: PLN = 37,
`

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

This addresses the following issue:  https://github.com/AppFlowy-IO/AppFlowy/issues/8200

However, a change to `collab-database` is required for it to be a fix.

Also, this may need to be adjusted for https://github.com/AppFlowy-IO/AppFlowy-Web

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing - they will be once it's added to `collab-database`

## Summary by Sourcery

Add support for the Polish złoty (PLN) number format by extending the Rust NumberFormatPB enum with conversion mappings and updating the Flutter UI with the corresponding label and symbol.

New Features:
- Introduce PLN variant to NumberFormatPB enum and mapping in Rust
- Display "Polish złoty" title and "zł" symbol for PLN in the Flutter UI