### PR TITLE
Fix date query handler to use 1-based month/day and add regression test

### DIFF
--- a/frontend/rust-lib/flowy-date/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-date/src/event_handler.rs
@@ -25,12 +25,24 @@ pub(crate) async fn query_date_handler(
       let year_match = year_regex().find(&query).unwrap();
       let formatted = year_match
         .and_then(|capture| capture.as_str().parse::<i32>().ok())
-        .and_then(|year| NaiveDate::from_ymd_opt(year, naive_date.month0(), naive_date.day0()))
+        .and_then(|year| NaiveDate::from_ymd_opt(year, naive_date.month(), naive_date.day()))
         .map(|date| date.to_string())
         .unwrap_or_else(|| naive_date.to_string());
 
       data_result_ok(DateResultPB { date: formatted })
     },
     None => Err(FlowyError::internal().with_context("Failed to parse date from")),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[tokio::test]
+  async fn parses_year_from_query() {
+    let data = AFPluginData(DateQueryPB { query: "June 5 2024".into() });
+    let result = query_date_handler(data).await.expect("handler should succeed");
+    assert_eq!(result.date, "2024-06-05");
   }
 }


### PR DESCRIPTION
Description

This PR addresses a bug in the date query handler where NaiveDate::from_ymd_opt was constructed with month0()/day0(), leading to invalid or missing dates when substituting a parsed year.

Changes

- Replaced month0()/day0() with 1-based month() and day() to correctly construct dates.
- Added an async regression test (parses_year_from_query) to ensure queries like "June 5 2024" correctly format to "2024-06-05".

Notes

- Preserves fallback behavior: if the constructed date is invalid (e.g., leap year rollover), the handler falls back to the original parsed date string.
- No API changes; only internal correctness and test coverage improvements.