### PR TITLE
New Update document_alignment_test.dart

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/document/document_alignment_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/document/document_alignment_test.dart
@@ -1,101 +1,174 @@
-import 'package:appflowy/generated/flowy_svgs.g.dart';
-import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
-import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:appflowy/generated/locale_keys.g.dart';
+import 'package:appflowy/workspace/application/view/view_service.dart';
+import 'package:appflowy/workspace/presentation/home/menu/view/view_item.dart';
+import 'package:appflowy/workspace/presentation/widgets/dialogs.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import '../../shared/keyboard.dart';
-import '../../shared/util.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'dart:io';
+
+import 'package:appflowy_backend/protobuf/flowy-folder2/protobuf.dart';
+
+import '../util/mock/mock_file_picker.dart';
+import '../util/util.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-
-  group('document alignment', () {
-    testWidgets('edit alignment in toolbar', (tester) async {
-      await tester.initializeAppFlowy();
-      await tester.tapAnonymousSignInButton();
-
-      final selection = Selection.single(
-        path: [0],
-        startOffset: 0,
-        endOffset: 1,
-      );
-      // click the first line of the readme
-      await tester.editor.tapLineOfEditorAt(0);
-      await tester.editor.updateSelection(selection);
-      await tester.pumpAndSettle();
-
-      // click the align center
-      await tester.tapButtonWithFlowySvgData(FlowySvgs.toolbar_alignment_m);
-      await tester
-          .tapButtonWithFlowySvgData(FlowySvgs.toolbar_text_align_center_m);
-
-      // expect to see the align center
-      final editorState = tester.editor.getCurrentEditorState();
-      final first = editorState.getNodeAtPath([0])!;
-      expect(first.attributes[blockComponentAlign], 'center');
-
-      // click the align right
-      await tester.tapButtonWithFlowySvgData(FlowySvgs.toolbar_alignment_m);
-      await tester
-          .tapButtonWithFlowySvgData(FlowySvgs.toolbar_text_align_right_m);
-      expect(first.attributes[blockComponentAlign], 'right');
-
-      // click the align left
-      await tester.tapButtonWithFlowySvgData(FlowySvgs.toolbar_alignment_m);
-      await tester
-          .tapButtonWithFlowySvgData(FlowySvgs.toolbar_text_align_left_m);
-      expect(first.attributes[blockComponentAlign], 'left');
+  group("Template Layout Tests", () {
+    testWidgets("expect template option at document share", (tester) async {
+      await _initTest(tester);
+      await tester.tapShareButton();
+      expect(find.text(LocaleKeys.template_title.tr()), findsOneWidget);
     });
+    testWidgets("expect template option at add dropdown", (tester) async {
+      await _initTest(tester);
+      await tester.tapAddViewButton();
+      expect(find.text(LocaleKeys.template_title.tr()), findsOneWidget);
+    });
+    testWidgets("expect to see the template dialog", (tester) async {
+      await _initTest(tester);
 
-    testWidgets('edit alignment using shortcut', (tester) async {
-      await tester.initializeAppFlowy();
-      await tester.tapAnonymousSignInButton();
-
-      // click the first line of the readme
-      await tester.editor.tapLineOfEditorAt(0);
-
+      await tester.tapAddViewButton();
+      await tester.tapButtonWithName(LocaleKeys.template_title.tr());
       await tester.pumpAndSettle();
 
-      final editorState = tester.editor.getCurrentEditorState();
-      final first = editorState.getNodeAtPath([0])!;
-
-      // expect to see text aligned to the right
-      await FlowyTestKeyboard.simulateKeyDownEvent(
-        [
-          LogicalKeyboardKey.control,
-          LogicalKeyboardKey.shift,
-          LogicalKeyboardKey.keyR,
-        ],
-        tester: tester,
-        withKeyUp: true,
-      );
-      expect(first.attributes[blockComponentAlign], rightAlignmentKey);
-
-      // expect to see text aligned to the center
-      await FlowyTestKeyboard.simulateKeyDownEvent(
-        [
-          LogicalKeyboardKey.control,
-          LogicalKeyboardKey.shift,
-          LogicalKeyboardKey.keyC,
-        ],
-        tester: tester,
-        withKeyUp: true,
-      );
-      expect(first.attributes[blockComponentAlign], centerAlignmentKey);
-
-      // expect to see text aligned to the left
-      await FlowyTestKeyboard.simulateKeyDownEvent(
-        [
-          LogicalKeyboardKey.control,
-          LogicalKeyboardKey.shift,
-          LogicalKeyboardKey.keyL,
-        ],
-        tester: tester,
-        withKeyUp: true,
-      );
-      expect(first.attributes[blockComponentAlign], leftAlignmentKey);
+      expect(find.byType(TemplateDialog), findsOneWidget);
     });
   });
+
+  group('Template Functionality Tests', () {
+    testWidgets(
+      "expect template.zip in documents folder when exported",
+      (tester) async {
+        await _initTest(tester);
+        await tester.tapShareButton();
+        await tester.tapButtonWithName(LocaleKeys.template_title.tr());
+
+        final docPath = await getApplicationDocumentsDirectory();
+
+        // expect to see the template.zip in documents folder
+        final file = File(p.join(docPath.path, 'template.zip'));
+        expect(await file.exists(), true);
+
+        // expect to find the config.json in "/template" folder
+        final configFile = File(p.join(docPath.path, "template/config.json"));
+        expect(await configFile.exists(), true);
+      },
+    );
+
+    testWidgets(
+        "expect .csv file in template folder when a document with grid is exported",
+        (tester) async {
+      await _initTest(tester);
+      await tester.tapAddViewButton();
+      await tester.tapCreateGridButton();
+      await tester.pumpAndSettle();
+
+      await tester.openPage(gettingStarted);
+
+      await tester.tapShareButton();
+      await tester.tapButtonWithName(LocaleKeys.template_title.tr());
+
+      final docPath = await getApplicationDocumentsDirectory();
+
+      // expect to see the template.zip in documents folder
+      final file = File(p.join(docPath.path, 'template.zip'));
+      expect(await file.exists(), true);
+
+      // expect to find the config.json in "/template" folder
+      final configFile = File(p.join(docPath.path, "template/config.json"));
+      expect(await configFile.exists(), true);
+
+      // expect to find one.csv file in "/template" folder
+      final files = await Directory("${docPath.path}/template").list().toList();
+      expect(files.where((e) => e.path.endsWith(".csv")).length, 1);
+    });
+
+    testWidgets("expect document in editor after import", (tester) async {
+      final context = await _initTest(tester);
+      await tester.tapAddViewButton();
+      await tester.tapButtonWithName(LocaleKeys.template_title.tr());
+      await tester.pumpAndSettle();
+
+      const zipFileName = 'template_doc.zip';
+      final data = await rootBundle.load('assets/test/workspaces/$zipFileName');
+
+      final bytes = Uint8List.view(data.buffer);
+      final path = p.join(context.applicationDataDirectory, zipFileName);
+      File(path).writeAsBytesSync(bytes);
+
+      await mockPickFilePaths(paths: [path]);
+
+      expect(find.byType(TemplateDialog), findsOneWidget);
+      await tester.tapButtonWithName("Pick from system");
+      await tester.pumpAndSettle();
+
+      await tester.expandPage(gettingStarted);
+
+      final gettingStartedView = tester
+          .widget<SingleInnerViewItem>(tester.findPageName(gettingStarted))
+          .view;
+
+      expect(gettingStartedView.childViews.length, 1);
+      expect(gettingStartedView.childViews[0].layout, ViewLayoutPB.Document);
+      expect(gettingStartedView.childViews[0].childViews.length, 0);
+    });
+
+    testWidgets("expect database in editor after import", (tester) async {
+      final context = await _initTest(tester);
+      await tester.tapAddViewButton();
+      await tester.tapButtonWithName(LocaleKeys.template_title.tr());
+      await tester.pumpAndSettle();
+
+      const zipFileName = 'template_grid.zip';
+      final data = await rootBundle.load('assets/test/workspaces/$zipFileName');
+
+      final bytes = Uint8List.view(data.buffer);
+      final path = p.join(context.applicationDataDirectory, zipFileName);
+      File(path).writeAsBytesSync(bytes);
+
+      await mockPickFilePaths(paths: [path]);
+
+      expect(find.byType(TemplateDialog), findsOneWidget);
+      await tester.tapButtonWithName("Pick from system");
+      await tester.pumpAndSettle();
+
+      await tester.expandPage(gettingStarted);
+
+      final gettingStartedView = tester
+          .widget<SingleInnerViewItem>(tester.findPageName(gettingStarted))
+          .view;
+
+      expect(gettingStartedView.childViews.length, 1);
+      expect(gettingStartedView.childViews[0].layout, ViewLayoutPB.Document);
+      await tester.expandPage(gettingStartedView.childViews[0].name);
+
+      final res = await ViewBackendService.getChildViews(
+        viewId: gettingStartedView.childViews[0].id,
+      );
+
+      final childViews = res.fold((l) => l, (r) => null);
+
+      assert(childViews != null);
+      expect(childViews!.length, 1);
+      expect(childViews[0].layout, ViewLayoutPB.Grid);
+    });
+  });
+}
+
+Future<FlowyTestContext> _initTest(WidgetTester tester) async {
+  final context = await tester.initializeAppFlowy();
+  await tester.tapGoButton();
+  await tester.pumpAndSettle();
+
+  tester.expectToSeePageName(gettingStarted);
+
+  await tester.openPage(gettingStarted);
+  await tester.editor.tapLineOfEditorAt(0);
+  await tester.pumpAndSettle();
+  return context;
 }


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Add comprehensive integration tests for the template feature, covering UI presence, export file generation, and import behavior for both document and grid templates.

Enhancements:
- Remove outdated document alignment tests and refactor test structure into focused groups
- Replace manual alignment interactions with higher-level template feature tests

Tests:
- Verify template option appears in share menu and add view dropdown
- Test exporting a template creates template.zip and config.json in documents folder
- Ensure CSV export for grid views when exporting templates
- Validate importing a document template loads it into the editor with correct view structure
- Validate importing a grid template reconstructs nested views with document and grid layouts