### PR TITLE
set autoFocus true for font dropdown search input

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/font/customize_font_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/font/customize_font_toolbar_item.dart
@@ -121,7 +121,7 @@ class _FontFamilyDropDownState extends State<FontFamilyDropDown> {
               child: FlowyTextField(
                 key: ThemeFontFamilySetting.textFieldKey,
                 hintText: LocaleKeys.settings_appearance_fontFamily_search.tr(),
-                autoFocus: false,
+                autoFocus: true,
                 debounceDuration: const Duration(milliseconds: 300),
                 onChanged: (value) {
                   setState(() {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview
this PR fix the font name input field is not focused issue #8290
fixes https://github.com/AppFlowy-IO/AppFlowy/issues/8290
<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106

-->

Before:
---

https://github.com/user-attachments/assets/91cfdcc7-87c6-489f-acf3-e7cc9ab357a0

After:

https://github.com/user-attachments/assets/87b22332-e870-42c1-abcf-d416adce14ee

What this PR does:

This PR fixes the font family dropdown in AppFlowy so that the font name input field is auto-focused by default when the dropdown opens.

Before this fix, typing immediately after opening the font menu would accidentally replace the selected text in the document instead of entering the font name in the search field.
This PR changes the autoFocus property of the font family search input in the dropdown from false to true.
<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Focus the font family search input on dropdown open to avoid typed characters replacing document content