### PR TITLE
Support LaTeX paste

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_html.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/copy_and_paste/paste_from_html.dart
@@ -21,18 +21,50 @@ extension PasteFromHtml on EditorState {
     return true;
   }
 
-  // Convert the html to document nodes.
-  // For the google docs table, it will be fallback to the markdown parser.
+  /// Convert HTML to document nodes using the appropriate parser.
+  ///
+  /// This method implements a decision tree to choose between two parsing approaches:
+  /// 1. HTML-to-markdown-to-nodes: Better for structured content (lists, math, tables)
+  /// 2. HTML-to-nodes directly: Faster for simple formatted text
+  ///
+  /// **Decision Flow:**
+  /// ```
+  /// ┌─ Detect content type (Google Docs, Apple Notes, lists, math)
+  /// │
+  /// ├─ If (Google Docs OR lists OR math) AND NOT Apple Notes:
+  /// │  └─> Use html2md → customMarkdownToDocument
+  /// │      (Preserves LaTeX equations, list structure, nested formatting)
+  /// │
+  /// └─ Else:
+  ///    ├─> Try htmlToDocument first (faster for simple content)
+  ///    ├─> Clean up empty nodes
+  ///    ├─> Convert legacy tables to simple tables
+  ///    └─> If result is empty OR contains tables:
+  ///        └─> Fallback to html2md → customMarkdownToDocument
+  /// ```
+  ///
+  /// **Why two paths?**
+  /// - Markdown path: Handles LaTeX preprocessing (see markdown_to_document.dart)
+  ///   which fixes line breaks in piecewise functions and converts spacing
+  /// - Direct HTML path: Simpler and faster for plain formatted text
+  /// - Apple Notes exception: Known to work better with direct HTML parsing
+  ///
+  /// For Google Docs tables, it will fallback to the markdown parser.
   List<Node> convertHtmlToNodes(String html) {
-    // Check for special cases that need specific handling
+    // ========== Step 1: Detect content source and type ==========
     const googleDocsFlag = 'docs-internal-guid-';
     final isPasteFromGoogleDocs = html.contains(googleDocsFlag);
     final isPasteFromAppleNotes = appleNotesRegex.hasMatch(html);
 
-    // Detect if HTML contains list structures or LaTeX-like content
+    // Detect if HTML contains list structures
+    // Lists need markdown parser to preserve nesting and ordering
     final containsListStructures = html.contains('<ul>') ||
                                    html.contains('<ol>') ||
                                    html.contains('<li>');
+
+    // Detect LaTeX/math content patterns
+    // Math equations need markdown parser for LaTeX preprocessing
+    // (fixes line breaks, spacing, etc. - see markdown_latex_utils.dart)
     final containsMathContent = html.contains(r'\(') ||
                                html.contains(r'\[') ||
         html.contains(r'$$') ||
@@ -42,24 +74,35 @@ extension PasteFromHtml on EditorState {
 
     List<Node> nodes = [];
 
-    // Prefer html2md converter for content with lists or math to preserve structure
-    // This is especially important for ChatGPT, Notion, and other rich content sources
+    // ========== Step 2: Choose parsing strategy ==========
+    // Use markdown converter when:
+    // - Content is from Google Docs (better structure preservation)
+    // - Content has lists (preserves nesting and ordering)
+    // - Content has math (enables LaTeX preprocessing)
+    // UNLESS it's from Apple Notes (which works better with direct HTML parsing)
     final shouldUseMarkdownConverter = isPasteFromGoogleDocs ||
                                        containsListStructures ||
                                        containsMathContent;
 
     if (shouldUseMarkdownConverter && !isPasteFromAppleNotes) {
-      // Use markdown parser for better structure preservation
+      // ========== Path A: HTML → Markdown → Document ==========
+      // Convert HTML to markdown, then parse to document nodes
+      // This path enables:
+      // - LaTeX preprocessing (line breaks, spacing fixes)
+      // - Better list structure preservation
+      // - Proper handling of nested formatting
       final markdown = html2md.convert(html);
       nodes = customMarkdownToDocument(markdown, tableWidth: 200)
           .root
           .children
           .toList();
     } else {
-      // Try htmlToDocument first for simple content
+      // ========== Path B: HTML → Document (with fallback) ==========
+      // Try direct HTML to document conversion first (faster for simple content)
       nodes = htmlToDocument(html).root.children.toList();
 
-      // 1. remove the front and back empty line
+      // Post-process: Remove leading/trailing empty nodes
+      // (HTML parser sometimes creates empty paragraphs from formatting tags)
       while (nodes.isNotEmpty && nodes.first.delta?.isEmpty == true) {
         nodes.removeAt(0);
       }
@@ -67,7 +110,8 @@ extension PasteFromHtml on EditorState {
         nodes.removeLast();
       }
 
-      // 2. replace the legacy table nodes with the new simple table nodes
+      // Post-process: Convert legacy table format to new simple table format
+      // (Ensures compatibility with newer table implementation)
       for (int i = 0; i < nodes.length; i++) {
         final node = nodes[i];
         if (node.type == TableBlockKeys.type) {
@@ -75,13 +119,14 @@ extension PasteFromHtml on EditorState {
         }
       }
 
-      // 3. Check if result is empty or contains tables, fallback to markdown
+      // Fallback check: If HTML parsing failed or produced tables,
+      // use markdown parser instead (better table handling)
       final containsTable = nodes.any(
         (node) =>
             [TableBlockKeys.type, SimpleTableBlockKeys.type].contains(node.type),
       );
       if (nodes.isEmpty || containsTable) {
-        // fallback to the markdown parser
+        // Fallback to markdown parser for better structure handling
         final markdown = html2md.convert(html);
         nodes = customMarkdownToDocument(markdown, tableWidth: 200)
             .root

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/markdown_latex_utils.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/markdown_latex_utils.dart
@@ -1,0 +1,345 @@
+/// Shared utilities for LaTeX equation processing.
+///
+/// This file contains common LaTeX parsing and fixing logic used across
+/// different markdown processors to ensure consistent behavior when
+/// handling pasted mathematical equations.
+
+// Regular expression patterns used for LaTeX detection and parsing
+// Extracted as constants for better performance and readability
+
+/// Matches LaTeX blocks in square brackets with newlines: [<content>]
+final RegExp latexBlockRegex = RegExp(
+  r'^\[\s*\n((?:.*\n)*?.*?)\s*\]',
+  multiLine: true,
+);
+
+/// Matches display math blocks: $$<content>$$
+final RegExp dollarDisplayRegex = RegExp(r'^\s*\$\$(.+?)\$\$\s*$', dotAll: true);
+
+/// Matches inline math: $<content>$
+final RegExp dollarInlineRegex = RegExp(r'^\s*\$(.+?)\$\s*$', dotAll: true);
+
+/// Matches bracket blocks: [<content>]
+final RegExp bracketDisplayRegex = RegExp(r'^\s*\[(.+?)\]\s*$', dotAll: true);
+
+/// Matches escaped bracket blocks: \\[<content>\\]
+final RegExp escapedBracketRegex = RegExp(r'^\s*\\\[(.+?)\\\]\s*$', dotAll: true);
+
+/// Matches paren blocks: \\(<content>\\)
+final RegExp parenDisplayRegex = RegExp(r'^\s*\\\((.+?)\\\)\s*$', dotAll: true);
+
+/// Detects invalid `\-` command (backslash followed by minus)
+final RegExp invalidBackslashMinusRegex = RegExp(r'(?<!\\)\\-');
+
+/// Detects single backslash followed by whitespace and alphanumeric
+final RegExp singleBackslashSpaceRegex = RegExp(r'\\\s+([a-zA-Z0-9-])');
+
+/// Detects potential row breaks: closing brace/word/digit followed by space and letter/dash
+final RegExp potentialRowBreakRegex = RegExp(r'([}\w\d])\s+([a-zA-Z-])');
+
+/// Checks if a string contains LaTeX syntax.
+///
+/// Returns true if the content includes common LaTeX commands, environments,
+/// or mathematical notation patterns.
+bool containsLaTeX(String content) {
+  return content.contains(r'\int') ||
+      content.contains(r'\sum') ||
+      content.contains(r'\frac') ||
+      content.contains(r'\lim') ||
+      content.contains(r'\text') ||
+      content.contains(r'\begin') ||
+      content.contains(r'\iint') ||
+      content.contains(r'\iiint') ||
+      content.contains(RegExp(r'\\[a-zA-Z]+')) ||
+      content.contains(RegExp(r'[_^]\{')) ||
+      content.contains(RegExp(r'[a-zA-Z0-9]\s*[+\-*/=]\s*[a-zA-Z0-9]')) ||
+      content.contains(RegExp(r'\^[0-9]'));
+}
+
+/// Checks if a string looks like LaTeX (alternative implementation).
+///
+/// This is a lighter-weight check used by the markdown parser.
+bool looksLikeLaTeX(String content) {
+  return content.contains(r'\') ||
+      content.contains(RegExp(r'[_^]\{')) ||
+      content.contains('\\begin') ||
+      content.contains('\\int') ||
+      content.contains('\\sum') ||
+      content.contains('\\frac') ||
+      content.contains('\\lim') ||
+      content.contains('\\text') ||
+      content.contains(RegExp(r'[a-zA-Z0-9]\s*[+\-*/=]\s*[a-zA-Z0-9]')) ||
+      content.contains(RegExp(r'\^[0-9]'));
+}
+
+/// Fixes LaTeX spacing by converting comma-space patterns to thin spaces.
+///
+/// In proper LaTeX integral notation, differential variables should be
+/// preceded by a thin space (`\,`) rather than a comma. This function
+/// converts patterns like `, dx` to `\, dx` for common differential variables.
+///
+/// Example: `\int x^2, dx` → `\int x^2\, dx`
+String fixLatexSpacing(String latex) {
+  String result = latex;
+  result = result.replaceAll(', dx', r'\, dx');
+  result = result.replaceAll(', dy', r'\, dy');
+  result = result.replaceAll(', dz', r'\, dz');
+  result = result.replaceAll(', dt', r'\, dt');
+  result = result.replaceAll(', dV', r'\, dV');
+  result = result.replaceAll(', dA', r'\, dA');
+  result = result.replaceAll(', ds', r'\, ds');
+  result = result.replaceAll(', du', r'\, du');
+  result = result.replaceAll(', dv', r'\, dv');
+  result = result.replaceAll(', dw', r'\, dw');
+  return result;
+}
+
+/// Fixes LaTeX line breaks for multi-line environments when newlines are intact.
+///
+/// This function processes LaTeX content line-by-line, converting single
+/// backslashes at the end of lines to double backslashes (`\\`) which are
+/// required for row separators in environments like `cases`, `aligned`, and `array`.
+///
+/// This version is used when the original newlines are preserved (e.g., in
+/// preprocessing of `[...]` blocks before markdown parsing).
+///
+/// Example:
+/// ```
+/// \begin{cases}
+/// x^2 & \text{if } x \geq 0 \
+/// -x & \text{if } x < 0
+/// \end{cases}
+/// ```
+/// becomes:
+/// ```
+/// \begin{cases}
+/// x^2 & \text{if } x \geq 0 \\
+/// -x & \text{if } x < 0
+/// \end{cases}
+/// ```
+String fixLatexLineBreaksWithNewlines(String latex) {
+  if (!latex.contains(r'\begin{cases}') &&
+      !latex.contains(r'\begin{aligned}') &&
+      !latex.contains(r'\begin{array}')) {
+    return latex;
+  }
+
+  final lines = latex.split('\n');
+  final result = <String>[];
+  bool inEnvironment = false;
+
+  for (int i = 0; i < lines.length; i++) {
+    final line = lines[i];
+
+    // Track when we enter multi-line environments
+    if (line.contains(r'\begin{cases}') ||
+        line.contains(r'\begin{aligned}') ||
+        line.contains(r'\begin{array}')) {
+      inEnvironment = true;
+      result.add(line);
+      continue;
+    }
+
+    // Track when we exit multi-line environments
+    if (line.contains(r'\end{cases}') ||
+        line.contains(r'\end{aligned}') ||
+        line.contains(r'\end{array}')) {
+      inEnvironment = false;
+      result.add(line);
+      continue;
+    }
+
+    // Only process lines inside multi-line environments
+    if (!inEnvironment) {
+      result.add(line);
+      continue;
+    }
+
+    final trimmed = line.trimRight();
+
+    // Empty lines don't need processing
+    if (trimmed.isEmpty) {
+      result.add(line);
+      continue;
+    }
+
+    // Already has double backslash - leave it alone
+    if (trimmed.endsWith(r'\\')) {
+      result.add(line);
+      continue;
+    }
+
+    // Convert single backslash at end of line to double backslash
+    // This handles the common case of pasted LaTeX from ChatGPT which
+    // uses single backslashes for line breaks
+    if (trimmed.isNotEmpty && trimmed[trimmed.length - 1] == '\\') {
+      if (trimmed.length < 2 || trimmed[trimmed.length - 2] != '\\') {
+        final withoutSlash = trimmed.substring(0, trimmed.length - 1);
+        final trailingSpaces = line.substring(trimmed.length);
+        result.add('$withoutSlash\\\\$trailingSpaces');
+        continue;
+      }
+    }
+
+    // Check if this is the last line before the environment ends
+    // If so, don't add a row separator
+    if (i + 1 < lines.length) {
+      final nextLine = lines[i + 1].trim();
+      if (nextLine.startsWith(r'\end{cases}') ||
+          nextLine.startsWith(r'\end{aligned}') ||
+          nextLine.startsWith(r'\end{array}')) {
+        result.add(line);
+        continue;
+      }
+    }
+
+    // Add double backslash at end of line for row separator
+    result.add('$trimmed \\\\');
+  }
+
+  return result.join('\n');
+}
+
+/// Fixes LaTeX line breaks for multi-line environments when newlines are collapsed.
+///
+/// This function handles LaTeX content where newlines have been collapsed into
+/// spaces by markdown processing. It intelligently detects where row breaks
+/// should occur and adds `\\` separators while avoiding breaking valid LaTeX
+/// constructs like `\text{...}` blocks.
+///
+/// This version is used after markdown has processed the content and collapsed
+/// the newlines (e.g., in the markdown_math_equation_parser).
+///
+/// Key behaviors:
+/// - Fixes invalid `\-` sequences (should be `\\ -`)
+/// - Detects transitions between equation rows
+/// - Preserves `\text{...}` blocks without adding breaks mid-condition
+/// - Adds `\\` only at actual row boundaries
+///
+/// Example (collapsed):
+/// ```
+/// f(x) = \begin{cases} x^2 & \text{if } x \geq 0 -x & \text{if } x < 0 \end{cases}
+/// ```
+/// becomes:
+/// ```
+/// f(x) = \begin{cases} x^2 & \text{if } x \geq 0 \\ -x & \text{if } x < 0 \end{cases}
+/// ```
+String fixLatexLineBreaksCollapsed(String latex) {
+  if (!latex.contains(r'\begin{cases}') &&
+      !latex.contains(r'\begin{aligned}') &&
+      !latex.contains(r'\begin{array}')) {
+    return latex;
+  }
+
+  String result = latex;
+
+  // Fix invalid `\-` command that can occur when markdown collapses
+  // a backslash-newline-minus pattern into `\-`
+  // Example: "\ \n -x" becomes "\-x" which is invalid LaTeX
+  // We convert it to "\\ -x" (proper row break followed by negative number)
+  result = result.replaceAll(invalidBackslashMinusRegex, r'\\ -');
+
+  // Replace single backslash followed by spaces and a letter/digit with double backslash
+  // This handles cases where markdown collapsed "\ \n x" into "\ x"
+  // Example: "\ x" should become "\\ x"
+  result = result.replaceAllMapped(
+    singleBackslashSpaceRegex,
+    (match) {
+      final char = match.group(1)!;
+      final beforeIndex = match.start;
+      // Avoid replacing if already preceded by a backslash (would make \\\)
+      if (beforeIndex >= 1 && result[beforeIndex - 1] == '\\') {
+        return match.group(0)!;
+      }
+      return '\\\\ $char';
+    },
+  );
+
+  // Detect and add `\\` before potential new rows
+  // This is the most complex part: we need to determine when a space
+  // between elements actually represents a new row in the original LaTeX
+  //
+  // Key insight: In piecewise functions like:
+  //   x^2 & \text{if } x >= 0
+  //   -x & \text{if } x < 0
+  // When collapsed, this becomes:
+  //   x^2 & \text{if } x >= 0 -x & \text{if } x < 0
+  //                           ^--- this space represents a new row
+  //
+  // We detect this by looking for patterns like "} -" or "0 -" where
+  // the space is likely a collapsed newline, BUT we must avoid breaking
+  // inside \text{...} blocks.
+  result = result.replaceAllMapped(
+    potentialRowBreakRegex,
+    (match) {
+      final before = match.group(1)!;
+      final after = match.group(2)!;
+      final index = match.start;
+
+      // Don't add \\ if already preceded by \\
+      if (index >= 2) {
+        final twoCharsBefore = result.substring(index - 2, index);
+        if (twoCharsBefore == r'\\') {
+          return match.group(0)!;
+        }
+      }
+
+      final beforeContext = result.substring(0, match.start);
+
+      // Don't add \\ right after environment begin
+      if (beforeContext.endsWith(r'\begin{cases}') ||
+          beforeContext.endsWith(r'\begin{aligned}') ||
+          beforeContext.endsWith(r'\begin{array}')) {
+        return match.group(0)!;
+      }
+
+      // Don't add \\ if we're inside an unclosed \text{...} block
+      final openTextCount = beforeContext.split(r'\text{').length - 1;
+      final closeBraceCount = beforeContext.split('}').length - 1;
+      if (openTextCount > closeBraceCount) {
+        return match.group(0)!;
+      }
+
+      // CRITICAL: Skip if the closing brace is from \text{...}
+      // This prevents breaking conditions like "& \text{if } x >= 0"
+      // into "& \text{if } \\ x >= 0" which would be wrong
+      if (before == '}') {
+        final textPattern = beforeContext.lastIndexOf(r'\text{');
+        if (textPattern >= 0) {
+          final afterText = beforeContext.substring(textPattern);
+          final openCount = afterText.split('{').length - 1;
+          final closeCount = afterText.split('}').length - 1;
+          // If braces just balanced, this } closes a \text{}, skip it
+          if (openCount == closeCount + 1) {
+            return match.group(0)!;
+          }
+        }
+      }
+
+      // Don't add \\ if we're right after a backslash command
+      final lastBackslash = beforeContext.lastIndexOf('\\');
+      if (lastBackslash >= 0) {
+        final sinceLast = beforeContext.substring(lastBackslash + 1);
+        if (sinceLast.isNotEmpty &&
+            !sinceLast.contains(' ') &&
+            !sinceLast.contains('&')) {
+          return match.group(0)!;
+        }
+      }
+
+      // If we found an ampersand (&) but no row separator since then,
+      // this is likely a new row
+      final lastAmpersand = beforeContext.lastIndexOf('&');
+      if (lastAmpersand >= 0) {
+        final sinceAmpersand = beforeContext.substring(lastAmpersand + 1);
+        if (!sinceAmpersand.contains(r'\\')) {
+          return '$before \\\\ $after';
+        }
+      }
+
+      return match.group(0)!;
+    },
+  );
+
+  return result;
+}

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/markdown_math_equation_parser.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/parsers/markdown_math_equation_parser.dart
@@ -1,9 +1,14 @@
+import 'package:appflowy/plugins/document/presentation/editor_plugins/parsers/markdown_latex_utils.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
 import 'package:markdown/markdown.dart' as md;
 
 /// Markdown parser that detects LaTeX/math blocks and converts them to
 /// AppFlowy `mathEquationNode`.
+///
+/// This parser runs after markdown has processed the content, meaning
+/// newlines in the original LaTeX may have been collapsed into spaces.
+/// The shared utility functions handle fixing line breaks in this scenario.
 class MarkdownMathEquationParser extends CustomMarkdownParser {
   const MarkdownMathEquationParser();
 
@@ -26,175 +31,47 @@ class MarkdownMathEquationParser extends CustomMarkdownParser {
     final String textContent = element.textContent;
 
     // $$ ... $$
-    final RegExp dollarDisplayRegex =
-        RegExp(r'^\s*\$\$(.+?)\$\$\s*$', dotAll: true);
     Match? match = dollarDisplayRegex.firstMatch(textContent);
 
     if (match != null) {
       String formula = match.group(1)?.trim() ?? '';
-      formula = _fixLatexLineBreaks(formula);
-      formula = _fixLatexSpacing(formula);
+      formula = fixLatexLineBreaksCollapsed(formula);
+      formula = fixLatexSpacing(formula);
       return <Node>[mathEquationNode(formula: formula)];
     }
 
     // \[ ... \]
-    final RegExp bracketDisplayRegex =
-        RegExp(r'^\s*\\\[(.+?)\\\]\s*$', dotAll: true);
-    match = bracketDisplayRegex.firstMatch(textContent);
+    match = escapedBracketRegex.firstMatch(textContent);
 
     if (match != null) {
       String formula = match.group(1)?.trim() ?? '';
-      formula = _fixLatexLineBreaks(formula);
-      formula = _fixLatexSpacing(formula);
+      formula = fixLatexLineBreaksCollapsed(formula);
+      formula = fixLatexSpacing(formula);
       return <Node>[mathEquationNode(formula: formula)];
     }
 
     // [ ... ]  (custom bracket that may contain LaTeX)
-    final RegExp plainBracketRegex = RegExp(r'^\s*\[(.+?)\]\s*$', dotAll: true);
-    match = plainBracketRegex.firstMatch(textContent);
+    match = bracketDisplayRegex.firstMatch(textContent);
 
     if (match != null) {
       String content = match.group(1)?.trim() ?? '';
-      if (_looksLikeLaTeX(content)) {
-        content = _fixLatexLineBreaks(content);
-        content = _fixLatexSpacing(content);
+      if (looksLikeLaTeX(content)) {
+        content = fixLatexLineBreaksCollapsed(content);
+        content = fixLatexSpacing(content);
         return <Node>[mathEquationNode(formula: content)];
       }
     }
 
     // \( ... \)
-    final RegExp parenInlineRegex =
-        RegExp(r'^\s*\\\((.+?)\\\)\s*$', dotAll: true);
-    match = parenInlineRegex.firstMatch(textContent);
+    match = parenDisplayRegex.firstMatch(textContent);
 
     if (match != null) {
       String formula = match.group(1)?.trim() ?? '';
-      formula = _fixLatexLineBreaks(formula);
-      formula = _fixLatexSpacing(formula);
+      formula = fixLatexLineBreaksCollapsed(formula);
+      formula = fixLatexSpacing(formula);
       return <Node>[mathEquationNode(formula: formula)];
     }
 
     return <Node>[];
-  }
-
-  /// Heuristic check whether a string looks like LaTeX.
-  bool _looksLikeLaTeX(String content) =>
-      content.contains('\\') ||
-      content.contains(RegExp(r'[_^]\{')) ||
-      content.contains(r'\begin') ||
-      content.contains(r'\int') ||
-      content.contains(r'\sum') ||
-      content.contains(r'\frac') ||
-      content.contains(r'\lim') ||
-      content.contains(r'\text') ||
-      content.contains(RegExp(r'[a-zA-Z0-9]\s*[+\-*/=]\s*[a-zA-Z0-9]')) ||
-      content.contains(RegExp(r'\^[0-9]'));
-
-  /// Ensure common spacing in LaTeX (e.g. `\, dx`).
-  String _fixLatexSpacing(String latex) {
-    String result = latex;
-    result = result.replaceAll(', dx', r'\, dx');
-    result = result.replaceAll(', dy', r'\, dy');
-    result = result.replaceAll(', dz', r'\, dz');
-    result = result.replaceAll(', dt', r'\, dt');
-    result = result.replaceAll(', dV', r'\, dV');
-    result = result.replaceAll(', dA', r'\, dA');
-    result = result.replaceAll(', ds', r'\, ds');
-    result = result.replaceAll(', du', r'\, du');
-    result = result.replaceAll(', dv', r'\, dv');
-    result = result.replaceAll(', dw', r'\, dw');
-    return result;
-  }
-
-  /// Fix line breaks inside LaTeX environments so rows end with `\\\\` where needed.
-  String _fixLatexLineBreaks(String latex) {
-    final bool hasEnvironment = latex.contains(r'\begin{cases}') ||
-        latex.contains(r'\begin{aligned}') ||
-        latex.contains(r'\begin{array}');
-
-    if (!hasEnvironment) {
-      return latex;
-    }
-
-    // Avoid sequences like " \-" being treated poorly.
-    String result = latex.replaceAll(RegExp(r'(?<!\\)\\-'), r'\\ -');
-
-    // Replace single backslash followed by spaces and a letter/digit with a double
-    // backslash + space + char, but keep existing escaped sequences intact.
-    result = result.replaceAllMapped(
-      RegExp(r'\\\s+([a-zA-Z0-9-])'),
-      (Match m) {
-        final String char = m.group(1)!;
-        final int beforeIndex = m.start;
-
-        if (beforeIndex >= 1 && result[beforeIndex - 1] == '\\') {
-          return m.group(0)!;
-        }
-        return '\\\\ $char';
-      },
-    );
-
-    // Add explicit row line-breaks inside array/aligned/cases when appropriate.
-    result = result.replaceAllMapped(
-      RegExp(r'([}\w\d])\s+([a-zA-Z-])'),
-      (Match m) {
-        final String before = m.group(1)!;
-        final String after = m.group(2)!;
-        final int index = m.start;
-
-        if (index >= 2) {
-          final String twoCharsBefore = result.substring(index - 2, index);
-          if (twoCharsBefore == r'\\') {
-            return m.group(0)!;
-          }
-        }
-
-        final String beforeContext = result.substring(0, m.start);
-
-        if (beforeContext.endsWith(r'\begin{cases}') ||
-            beforeContext.endsWith(r'\begin{aligned}') ||
-            beforeContext.endsWith(r'\begin{array}')) {
-          return m.group(0)!;
-        }
-
-        final int openTextCount = beforeContext.split(r'\text{').length - 1;
-        final int closeBraceCount = beforeContext.split('}').length - 1;
-        if (openTextCount > closeBraceCount) {
-          return m.group(0)!;
-        }
-
-        if (before == '}') {
-          final int textPattern = beforeContext.lastIndexOf(r'\text{');
-          if (textPattern >= 0) {
-            final String afterText = beforeContext.substring(textPattern);
-            final int openCount = afterText.split('{').length - 1;
-            final int closeCount = afterText.split('}').length - 1;
-            if (openCount == closeCount + 1) {
-              return m.group(0)!;
-            }
-          }
-        }
-
-        final int lastBackslash = beforeContext.lastIndexOf('\\');
-        if (lastBackslash >= 0) {
-          final String sinceLast = beforeContext.substring(lastBackslash + 1);
-          if (sinceLast.isNotEmpty && !sinceLast.contains(' ') && !sinceLast.contains('&')) {
-            return m.group(0)!;
-          }
-        }
-
-        final int lastAmpersand = beforeContext.lastIndexOf('&');
-        if (lastAmpersand >= 0) {
-          final String sinceAmpersand = beforeContext.substring(lastAmpersand + 1);
-          if (!sinceAmpersand.contains(r'\\')) {
-            return '$before \\\\ $after';
-          }
-        }
-
-        return m.group(0)!;
-      },
-    );
-
-    return result;
   }
 }

--- a/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
+++ b/frontend/appflowy_flutter/lib/shared/markdown_to_document.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:appflowy/plugins/document/presentation/editor_plugins/parsers/markdown_latex_utils.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/parsers/markdown_math_equation_parser.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/parsers/sub_page_node_parser.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
@@ -29,130 +30,22 @@ Document customMarkdownToDocument(
 }
 
 /// Find custom bracketed LaTeX blocks and convert them to `$$ ... $$`.
+///
+/// This preprocessor runs before markdown parsing to handle LaTeX content
+/// in square brackets that contains actual newlines (not yet collapsed by markdown).
 String _preprocessLatexBlocks(String markdown) {
-  final RegExp latexBlockRegex = RegExp(
-    r'^\[\s*\n((?:.*\n)*?.*?)\s*\]$',
-    multiLine: true,
-  );
-
   return markdown.replaceAllMapped(latexBlockRegex, (Match match) {
     String content = match.group(1) ?? '';
     content = content.replaceAll(RegExp(r'^\s+|\s+$'), '');
 
-    if (_containsLaTeX(content)) {
-      content = _fixLatexLineBreaks(content);
-      content = _fixLatexSpacing(content);
+    if (containsLaTeX(content)) {
+      content = fixLatexLineBreaksWithNewlines(content);
+      content = fixLatexSpacing(content);
       return '\$\$\n$content\n\$\$';
     }
     return match.group(0) ?? '';
   });
 }
-
-/// Ensure common spacing in LaTeX (e.g. `\, dx`).
-String _fixLatexSpacing(String latex) {
-  String result = latex;
-  result = result.replaceAll(', dx', r'\, dx');
-  result = result.replaceAll(', dy', r'\, dy');
-  result = result.replaceAll(', dz', r'\, dz');
-  result = result.replaceAll(', dt', r'\, dt');
-  result = result.replaceAll(', dV', r'\, dV');
-  result = result.replaceAll(', dA', r'\, dA');
-  result = result.replaceAll(', ds', r'\, ds');
-  result = result.replaceAll(', du', r'\, du');
-  result = result.replaceAll(', dv', r'\, dv');
-  result = result.replaceAll(', dw', r'\, dw');
-  return result;
-}
-
-/// Fix line breaks inside LaTeX environments so rows end with `\\\\` where needed.
-String _fixLatexLineBreaks(String latex) {
-  final bool hasEnvironment = latex.contains(r'\begin{cases}') ||
-      latex.contains(r'\begin{aligned}') ||
-      latex.contains(r'\begin{array}');
-
-  if (!hasEnvironment) {
-    return latex;
-  }
-
-  final List<String> lines = latex.split('\n');
-  final List<String> result = <String>[];
-  bool inEnvironment = false;
-
-  for (int i = 0; i < lines.length; i++) {
-    final String line = lines[i];
-
-    if (line.contains(r'\begin{cases}') ||
-        line.contains(r'\begin{aligned}') ||
-        line.contains(r'\begin{array}')) {
-      inEnvironment = true;
-      result.add(line);
-      continue;
-    }
-
-    if (line.contains(r'\end{cases}') ||
-        line.contains(r'\end{aligned}') ||
-        line.contains(r'\end{array}')) {
-      inEnvironment = false;
-      result.add(line);
-      continue;
-    }
-
-    if (!inEnvironment) {
-      result.add(line);
-      continue;
-    }
-
-    final String trimmed = line.trimRight();
-
-    if (trimmed.isEmpty) {
-      result.add(line);
-      continue;
-    }
-
-    if (trimmed.endsWith(r'\\')) {
-      result.add(line);
-      continue;
-    }
-
-    // compare single backslash correctly
-    if (trimmed.isNotEmpty && trimmed[trimmed.length - 1] == '\\') {
-      if (trimmed.length < 2 || trimmed[trimmed.length - 2] != '\\') {
-        final String withoutSlash = trimmed.substring(0, trimmed.length - 1);
-        final String trailingSpaces = line.substring(trimmed.length);
-        result.add('$withoutSlash\\\\$trailingSpaces');
-        continue;
-      }
-    }
-
-    if (i + 1 < lines.length) {
-      final String nextLine = lines[i + 1].trim();
-      if (nextLine.startsWith(r'\end{cases}') ||
-          nextLine.startsWith(r'\end{aligned}') ||
-          nextLine.startsWith(r'\end{array}')) {
-        result.add(line);
-        continue;
-      }
-    }
-
-    result.add('$trimmed \\\\');
-  }
-
-  return result.join('\n');
-}
-
-/// Heuristic check whether the content likely contains LaTeX.
-bool _containsLaTeX(String content) => content.contains(r'\int') ||
-    content.contains(r'\sum') ||
-    content.contains(r'\frac') ||
-    content.contains(r'\lim') ||
-    content.contains(r'\text') ||
-    content.contains(r'\begin') ||
-    content.contains(r'\iint') ||
-    content.contains(r'\iiint') ||
-    content.contains(RegExp(r'\\[a-zA-Z]+')) ||
-    content.contains(RegExp(r'[_^]\{')) ||
-    content.contains(RegExp(r'[a-zA-Z0-9]\s*[+\-*/=]\s*[a-zA-Z0-9]')) ||
-    content.contains(RegExp(r'\^[0-9]'));
 
 /// Convert an AppFlowy [Document] to Markdown and optionally create/archive resources.
 Future<String> customDocumentToMarkdown(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


## Feature Preview

This adds LaTeX paste support to AppFlowy, allowing users to paste mathematical equations from ChatGPT and other sources directly into documents with proper rendering.

Fixes #8177

## Summary

This PR implements comprehensive LaTeX equation parsing when pasting mathematical content into AppFlowy documents. Users can now copy LaTeX equations from ChatGPT, Gemini, or any other source and paste them directly into AppFlowy with correct rendering.

**What this PR adds:**
- Automatic detection and parsing of LaTeX equations in pasted content
- Support for piecewise functions with `\begin{cases}` environments
- Support for aligned equations with `\begin{aligned}` environments
- Proper handling of integrals, limits, series, and differential equations


Before: 

https://github.com/user-attachments/assets/dd8f6644-8dc8-4220-95cd-8a08327bad04

After:

https://github.com/user-attachments/assets/bfdce96d-bf96-44b2-927a-e5cfd72c2baa


#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Enable users to paste LaTeX equations directly into the editor by parsing and rendering mathematical content in both markdown and HTML paste flows.

New Features:
- Add LaTeX paste support with a custom MarkdownMathEquationParser and preprocessing to detect and convert math blocks (including custom brackets) into rendered equations, handling cases, aligned, array environments, spacing normalization, and line breaks
- Extend HTML paste workflow to detect mathematical and list content and route such content through markdown conversion for accurate structure and LaTeX rendering

## Summary by Sourcery

Enable direct LaTeX equation pasting in AppFlowy documents by routing pasted HTML through a custom markdown path with LaTeX preprocessing and a new equation parser, while preserving list and table structure and optimizing performance with a fallback to native HTML parsing.

New Features:
- Support automatic detection, parsing, and rendering of LaTeX equations from pasted content, including piecewise (cases), aligned, and array environments
- Add custom MarkdownMathEquationParser and preprocessing utilities to fix LaTeX line breaks and spacing for proper math rendering

Enhancements:
- Introduce a decision tree in the HTML paste workflow to choose between direct HTML parsing and HTML→Markdown→document conversion based on content type (Google Docs, lists, math, Apple Notes)
- Preprocess bracketed LaTeX blocks to normalize math delimiters and ensure consistent handling of multiline equations and differential notation