### PR TITLE
fix: Add missing autofillHints param to AFTextField to fix build error

### DIFF
--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/textfield/textfield.dart
@@ -34,6 +34,7 @@ class AFTextField extends StatefulWidget {
     this.focusNode,
     this.readOnly = false,
     this.maxLength,
+    this.autofillHints,
   });
 
   /// The hint text to display when the text field is empty.
@@ -86,6 +87,9 @@ class AFTextField extends StatefulWidget {
 
   /// The maximum length of the text field.
   final int? maxLength;
+
+  /// The autofill hints for the text field.
+  final Iterable<String>? autofillHints;
 
   @override
   State<AFTextField> createState() => _AFTextFieldState();
@@ -188,6 +192,7 @@ class _AFTextFieldState extends AFTextFieldState {
       autofocus: widget.autoFocus ?? false,
       maxLength: widget.maxLength,
       maxLengthEnforcement: MaxLengthEnforcement.truncateAfterCompositionEnds,
+      autofillHints: widget.autofillHints,
       decoration: InputDecoration(
         hintText: widget.hintText,
         hintStyle: theme.textStyle.body.standard(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

## Description

Fixes build error caused by missing `autofillHints` parameter in `AFTextField` widget definition. The parameter was being used in password fields but wasn't defined in the widget, causing compilation errors.

## Changes

- Added `autofillHints` parameter to `AFTextField` constructor
- Added field declaration: `final Iterable<String>? autofillHints;`
- Passed `autofillHints` to the internal `TextField` widget

## Results

<img width="1063" height="532" alt="image" src="https://github.com/user-attachments/assets/8312d333-b3e5-46ac-8884-78bb34e38c9a" />

## Fixes

fixes #8425

---

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Fix compilation error by defining and wiring through the autofillHints parameter used by AFTextField consumers.