### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -5,7 +5,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,7 +33,7 @@ jobs:
       #       ${{ runner.os }}-buildx-
 
       - name: Build the app
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./frontend/scripts/docker-buildfiles/Dockerfile

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -57,7 +57,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Flutter build
         uses: ./.github/actions/flutter_build
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Flutter build
         uses: ./.github/actions/flutter_build
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Flutter build
         uses: ./.github/actions/flutter_build
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         id: rust_toolchain
@@ -190,7 +190,7 @@ jobs:
           fi
         shell: bash
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ github.run_id }}-${{ matrix.os }}
 
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout appflowy cloud code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: AppFlowy-IO/AppFlowy-Cloud
           path: AppFlowy-Cloud
@@ -288,7 +288,7 @@ jobs:
           fi
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install flutter
         id: flutter
@@ -316,7 +316,7 @@ jobs:
           flutter config --enable-linux-desktop
         shell: bash
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ github.run_id }}-${{ matrix.os }}
 
@@ -353,7 +353,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Flutter Integration Test ${{ matrix.test_number }}
         uses: ./.github/actions/flutter_integration_test

--- a/.github/workflows/ios_ci.yaml
+++ b/.github/workflows/ios_ci.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ninja_i18n.yml
+++ b/.github/workflows/ninja_i18n.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Ninja i18n
         id: ninja-i18n

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build release notes
         run: |
@@ -52,7 +52,7 @@ jobs:
           - { target: x86_64-pc-windows-msvc, os: windows-2019 }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install flutter
         uses: subosito/flutter-action@v2
@@ -138,7 +138,7 @@ jobs:
           - { target: x86_64-apple-darwin, os: macos-13, extra-build-args: "" }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install flutter
         uses: subosito/flutter-action@v2
@@ -245,7 +245,7 @@ jobs:
           }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install flutter
         uses: subosito/flutter-action@v2
@@ -351,7 +351,7 @@ jobs:
           }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install flutter
         uses: subosito/flutter-action@v2
@@ -465,7 +465,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -477,7 +477,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./frontend/scripts/docker-buildfiles/Dockerfile

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -39,7 +39,7 @@ jobs:
           sudo docker image prune --all --force
 
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -56,7 +56,7 @@ jobs:
             frontend/rust-lib
 
       - name: Checkout appflowy cloud code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: AppFlowy-IO/AppFlowy-Cloud
           path: AppFlowy-Cloud

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         id: rust_toolchain


### PR DESCRIPTION
---

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR addresses in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

---

### Description

This PR updates outdated GitHub Action versions in the project's workflow files. The changes include:

- Updating `docker/build-push-action` from `v5` to `v6` in `.github/workflows/release.yml`
- Updating `actions/checkout` from `v4` to `v6` in multiple workflow files: `.github/workflows/rust_ci.yaml`, `.github/workflows/ios_ci.yaml`, `.github/workflows/commit_lint.yml`, `.github/workflows/flutter_ci.yaml`, `.github/workflows/docker_ci.yml`, `.github/workflows/ninja_i18n.yml`, `.github/workflows/release.yml`, `.github/workflows/rust_coverage.yml`

---

#### Tests

These changes will be tested in the CI pipeline of the pull request.

## Summary by Sourcery

Update GitHub Actions workflows to use newer action versions for source checkout, artifact handling, and Docker builds.

Build:
- Bump docker/build-push-action from v5 to v6 in release and Docker CI workflows.

CI:
- Upgrade actions/checkout from v4 to v6 across Flutter, Rust, iOS, commit lint, i18n, coverage, and release workflows.
- Update actions/download-artifact from v4 to v7 in Flutter CI workflows.