### PR TITLE
fix: improve settings button hover consistency and shortcut layout

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_shortcuts_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_shortcuts_view.dart
@@ -185,23 +185,29 @@ class _ResetButton extends StatelessWidget {
       behavior: HitTestBehavior.translucent,
       onTap: onReset,
       child: FlowyHover(
-        child: Padding(
+        builder: (context, isHovering) => Padding(
           padding: const EdgeInsets.symmetric(
             vertical: 4.0,
             horizontal: 6,
           ),
+
           child: Row(
             children: [
-              const FlowySvg(
+               FlowySvg(
                 FlowySvgs.restore_s,
-                size: Size.square(20),
+                size: const Size.square(20),
+                color: isHovering
+                    ? Theme.of(context).colorScheme.primary
+                    : null,
               ),
               const HSpace(6),
               SizedBox(
                 height: 16,
                 child: FlowyText.regular(
                   LocaleKeys.settings_shortcutsPage_actions_resetDefault.tr(),
-                  color: AFThemeExtension.of(context).strongText,
+                  color: isHovering
+                      ? Theme.of(context).colorScheme.primary
+                      : AFThemeExtension.of(context).strongText,
                 ),
               ),
             ],
@@ -356,8 +362,9 @@ class _ShortcutSettingTileState extends State<ShortcutSettingTile> {
         resetHoverOnRebuild: false,
         builder: (context, isHovering) => Padding(
           padding: const EdgeInsets.symmetric(vertical: 4),
-          child: Row(
-            children: [
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
               const HSpace(8),
               Expanded(
                 child: Padding(
@@ -371,11 +378,9 @@ class _ShortcutSettingTileState extends State<ShortcutSettingTile> {
                   ),
                 ),
               ),
-              Expanded(
-                child: isEditing
-                    ? _renderKeybindEditor()
+              isEditing
+                    ? Expanded(child: _renderKeybindEditor())
                     : _renderKeybindings(isHovering),
-              ),
             ],
           ),
         ),


### PR DESCRIPTION
…8222)

- Fixed reset button hover effect to match other settings buttons
- Changed shortcut tile layout from 50/50 to space-between alignment
- Improved visual consistency across settings UI

Fixes #8222

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Improve the settings shortcuts UI for better hover feedback and shortcut layout.

Enhancements:
- Update the reset shortcuts button to visually highlight icon and label on hover for consistency with other settings buttons.
- Adjust the shortcut settings tile layout to space shortcuts and editors more evenly within the row.