### PR TITLE
fix: spacebar not working when editing text fields in grid view

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/grid/grid_text_cell_key_event_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/grid/grid_text_cell_key_event_test.dart
@@ -1,0 +1,83 @@
+import 'package:appflowy_backend/protobuf/flowy-database2/protobuf.dart';
+import 'package:appflowy_backend/protobuf/flowy-folder/view.pbenum.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../shared/database_test_op.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('grid text cell key event test:', () {
+    testWidgets('spacebar inserts a space character when editing a text cell',
+        (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Grid);
+
+      // Tap the first RichText (Name) cell in row 0 to start editing
+      await tester.tapCellInGrid(rowIndex: 0, fieldType: FieldType.RichText);
+      await tester.pumpAndSettle();
+
+      // Type "hello", press space, then type "world"
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyH);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyE);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyO);
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyW);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyO);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyR);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyD);
+      await tester.pumpAndSettle();
+
+      // Escape saves and dismisses focus
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      // Verify the space character was preserved in the cell content
+      tester.assertCellContent(
+        rowIndex: 0,
+        fieldType: FieldType.RichText,
+        content: 'hello world',
+      );
+    });
+
+    testWidgets(
+        'spacebar with modifier keys does not swallow the key event',
+        (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      await tester.createNewPageWithNameUnderParent(layout: ViewLayoutPB.Grid);
+
+      // Tap the first text cell to start editing
+      await tester.tapCellInGrid(rowIndex: 0, fieldType: FieldType.RichText);
+      await tester.pumpAndSettle();
+
+      // Type some text so the cell is non-empty
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyB);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.pumpAndSettle();
+
+      // Shift+Space should not crash or be swallowed by the key handler
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pumpAndSettle();
+
+      // Escape to commit
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      // Cell should still exist and be accessible (no crash)
+      final cell = tester.cellFinder(0, FieldType.RichText);
+      expect(cell, findsOneWidget);
+    });
+  });
+}

--- a/frontend/appflowy_flutter/integration_test/desktop_runner_9.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop_runner_9.dart
@@ -3,6 +3,8 @@ import 'package:integration_test/integration_test.dart';
 import 'desktop/chat/chat_page_test.dart' as chat_page_test;
 import 'desktop/database/database_icon_test.dart' as database_icon_test;
 import 'desktop/first_test/first_test.dart' as first_test;
+import 'desktop/grid/grid_text_cell_key_event_test.dart'
+    as grid_text_cell_key_event_test;
 import 'desktop/uncategorized/code_block_language_selector_test.dart'
     as code_language_selector;
 import 'desktop/uncategorized/tabs_test.dart' as tabs_test;
@@ -19,4 +21,5 @@ Future<void> runIntegration9OnDesktop() async {
   code_language_selector.main();
   database_icon_test.main();
   chat_page_test.main();
+  grid_text_cell_key_event_test.main();
 }

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/text.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/text.dart
@@ -66,6 +66,13 @@ class _TextCellState extends GridEditableTextCell<EditableTextCell> {
     super.initState();
     _textEditingController =
         TextEditingController(text: cellBloc.state.content);
+    focusNode.onKeyEvent = (node, event) {
+      if (event is KeyDownEvent &&
+          event.logicalKey == LogicalKeyboardKey.space) {
+        return KeyEventResult.skipRemainingHandlers;
+      }
+      return KeyEventResult.ignored;
+    };
   }
 
   @override

--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/text.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/editable_cell_skeleton/text.dart
@@ -68,7 +68,11 @@ class _TextCellState extends GridEditableTextCell<EditableTextCell> {
         TextEditingController(text: cellBloc.state.content);
     focusNode.onKeyEvent = (node, event) {
       if (event is KeyDownEvent &&
-          event.logicalKey == LogicalKeyboardKey.space) {
+          event.logicalKey == LogicalKeyboardKey.space &&
+          !HardwareKeyboard.instance.isShiftPressed &&
+          !HardwareKeyboard.instance.isControlPressed &&
+          !HardwareKeyboard.instance.isAltPressed &&
+          !HardwareKeyboard.instance.isMetaPressed) {
         return KeyEventResult.skipRemainingHandlers;
       }
       return KeyEventResult.ignored;


### PR DESCRIPTION
## Description

Fixes the spacebar key not working when editing text fields in database grid view on Windows.

**Root cause:** When a key event is dispatched, Flutter's ancestor `Shortcuts` widget maps the bare space key to `ActivateIntent`. When that intent is handled, the engine receives `handled: true` and suppresses the `WM_CHAR` message — so the character never reaches the text input system.

**Fix:** Set `onKeyEvent` on the text cell's `focusNode` to return `KeyEventResult.skipRemainingHandlers` for the space key. This stops ancestor Shortcuts from seeing the event without marking it as "handled", so the platform still generates `WM_CHAR` and the space is inserted normally.

Closes #8572

## Checklist

- [x] Code follows AppFlowy's conventions
- [x] At least one related issue is referenced
- [ ] Tests included (UI key event test)
- [x] Existing tests pass

## Summary by Sourcery

Bug Fixes:
- Prevent the grid text editor from swallowing spacebar presses by skipping remaining key handlers for the space key.