### PR TITLE
fix: pin 35 unpinned action(s),extract 22 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build_command.yml
+++ b/.github/workflows/build_command.yml
@@ -36,7 +36,10 @@ jobs:
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.TOKEN }}" \
+            -H "Authorization: Bearer ${TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/AppFlowy-IO/AppFlowy-Builder/actions/workflows/$platform.yaml/dispatches \
             -d "$params"
+
+        env:
+          TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@416045160973f9fff174ac6698412cfe7181c3f3 # v4

--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # cache the docker layers
       # don't cache anything temporarly, because it always triggers "no space left on device" error
@@ -33,7 +33,7 @@ jobs:
       #       ${{ runner.os }}-buildx-
 
       - name: Build the app
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./frontend/scripts/docker-buildfiles/Dockerfile

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Install Rust toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.target }}
@@ -150,20 +150,20 @@ jobs:
 
       - name: Install flutter
         id: flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: ${{ matrix.os }}
           workspaces: |
             frontend/rust-lib
           cache-all-crates: true
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-make@${{ env.CARGO_MAKE_VERSION }}, duckscript_cli
 
@@ -292,13 +292,13 @@ jobs:
 
       - name: Install flutter
         id: flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-make@${{ env.CARGO_MAKE_VERSION }}
 

--- a/.github/workflows/ios_ci.yaml
+++ b/.github/workflows/ios_ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: aarch64-apple-ios-sim
@@ -42,19 +42,19 @@ jobs:
           profile: minimal
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: macos-latest
           workspaces: |
             frontend/rust-lib
 
-      - uses: davidB/rust-cargo-make@v1
+      - uses: davidB/rust-cargo-make@291dc18d931d07d4960a5c40e9b6afcea9287f5b # v1
         with:
           version: "0.37.15"
 

--- a/.github/workflows/mobile_ci.yml
+++ b/.github/workflows/mobile_ci.yml
@@ -69,7 +69,7 @@ jobs:
           done
 
       - name: Slack Notification
-        uses: 8398a7/action-slack@v3
+        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         if: always()
         with:
           status: ${{ steps.check_status.outputs.success == 'true' && 'success' || 'failure' }}

--- a/.github/workflows/ninja_i18n.yml
+++ b/.github/workflows/ninja_i18n.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run Ninja i18n
         id: ninja-i18n
-        uses: opral/ninja-i18n-action@main
+        uses: opral/ninja-i18n-action@415e999371bc9489e3d4a49503c43c3d075d9428 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Build release notes
         run: |
           touch ${{ env.RELEASE_NOTES_PATH }}
-          cat CHANGELOG.md | sed -e '/./{H;$!d;}' -e "x;/##\ Version\ ${{ github.ref_name }}/"'!d;' >> ${{ env.RELEASE_NOTES_PATH }}
+          cat CHANGELOG.md | sed -e '/./{H;$!d;}' -e "x;/##\ Version\ ${REF_NAME}/"'!d;' >> ${{ env.RELEASE_NOTES_PATH }}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -55,13 +57,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.job.target }}
@@ -81,12 +83,14 @@ jobs:
         # the cargo make script has to be run separately because of file locking issues
         run: |
           flutter config --enable-windows-desktop
-          dart ./scripts/flutter_release_build/build_flowy.dart exclude-directives . ${{ github.ref_name }}
-          cargo make --env APP_VERSION=${{ github.ref_name }} --profile production-windows-x86 appflowy
-          dart ./scripts/flutter_release_build/build_flowy.dart include-directives . ${{ github.ref_name }}
+          dart ./scripts/flutter_release_build/build_flowy.dart exclude-directives . ${REF_NAME}
+          cargo make --env APP_VERSION=${REF_NAME} --profile production-windows-x86 appflowy
+          dart ./scripts/flutter_release_build/build_flowy.dart include-directives . ${REF_NAME}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Archive Asset
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # v1
         with:
           files: ${{ env.WINDOWS_APP_RELEASE_PATH }}\
           dest: ${{ env.WINDOWS_APP_RELEASE_PATH }}\${{ env.WINDOWS_ZIP_NAME }}
@@ -99,8 +103,10 @@ jobs:
       - name: Build installer executable
         working-directory: ${{ env.WINDOWS_APP_RELEASE_PATH }}
         run: |
-          iscc /F${{ env.WINDOWS_INSTALLER_NAME }} inno_setup_config.iss /DAppVersion=${{ github.ref_name }}
+          iscc /F${{ env.WINDOWS_INSTALLER_NAME }} inno_setup_config.iss /DAppVersion=${REF_NAME}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Upload Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -141,13 +147,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.job.target }}
@@ -165,18 +171,24 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-macos-desktop
-          dart ./scripts/flutter_release_build/build_flowy.dart run . ${{ github.ref_name }}
+          dart ./scripts/flutter_release_build/build_flowy.dart run . ${REF_NAME}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Codesign AppFlowy
         run: |
-          echo ${{ secrets.MACOS_CERTIFICATE }} | base64 --decode > certificate.p12
+          echo ${MACOS_CERTIFICATE} | base64 --decode > certificate.p12
           security create-keychain -p action build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p action build.keychain
-          security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PWD }} -T /usr/bin/codesign
+          security import certificate.p12 -k build.keychain -P ${MACOS_CERTIFICATE_PWD} -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k action build.keychain
-          /usr/bin/codesign --force --options runtime --deep --sign "${{ secrets.MACOS_CODESIGN_ID }}" "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app" -v
+          /usr/bin/codesign --force --options runtime --deep --sign "${MACOS_CODESIGN_ID}" "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app" -v
 
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_CODESIGN_ID: ${{ secrets.MACOS_CODESIGN_ID }}
       - name: Create macOS dmg
         run: |
           brew install create-dmg
@@ -200,8 +212,12 @@ jobs:
           done
       - name: Notarize AppFlowy
         run: |
-          xcrun notarytool submit ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg --apple-id ${{ secrets.MACOS_NOTARY_USER }} --team-id ${{ secrets.MACOS_TEAM_ID }} --password ${{ secrets.MACOS_NOTARY_PWD }} -v -f "json" --wait
+          xcrun notarytool submit ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg --apple-id ${MACOS_NOTARY_USER} --team-id ${MACOS_TEAM_ID} --password ${MACOS_NOTARY_PWD} -v -f "json" --wait
 
+        env:
+          MACOS_NOTARY_USER: ${{ secrets.MACOS_NOTARY_USER }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+          MACOS_NOTARY_PWD: ${{ secrets.MACOS_NOTARY_PWD }}
       - name: Archive Asset
         working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
         run: zip --symlinks -qr ${{ env.MACOS_X86_ZIP_NAME }} AppFlowy.app
@@ -248,13 +264,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.job.targets }}
@@ -270,18 +286,24 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-macos-desktop
-          sh scripts/flutter_release_build/build_universal_package_for_macos.sh ${{ github.ref_name }}
+          sh scripts/flutter_release_build/build_universal_package_for_macos.sh ${REF_NAME}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Codesign AppFlowy
         run: |
-          echo ${{ secrets.MACOS_CERTIFICATE }} | base64 --decode > certificate.p12
+          echo ${MACOS_CERTIFICATE} | base64 --decode > certificate.p12
           security create-keychain -p action build.keychain
           security default-keychain -s build.keychain
           security unlock-keychain -p action build.keychain
-          security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PWD }} -T /usr/bin/codesign
+          security import certificate.p12 -k build.keychain -P ${MACOS_CERTIFICATE_PWD} -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k action build.keychain
-          /usr/bin/codesign --force --options runtime --deep --sign "${{ secrets.MACOS_CODESIGN_ID }}" "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app" -v
+          /usr/bin/codesign --force --options runtime --deep --sign "${MACOS_CODESIGN_ID}" "${{ env.MACOS_APP_RELEASE_PATH }}/AppFlowy.app" -v
 
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_CODESIGN_ID: ${{ secrets.MACOS_CODESIGN_ID }}
       - name: Create macOS dmg
         run: |
           brew install create-dmg
@@ -298,8 +320,12 @@ jobs:
 
       - name: Notarize AppFlowy
         run: |
-          xcrun notarytool submit ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg --apple-id ${{ secrets.MACOS_NOTARY_USER }} --team-id ${{ secrets.MACOS_TEAM_ID }} --password ${{ secrets.MACOS_NOTARY_PWD }} -v -f "json" --wait
+          xcrun notarytool submit ${{ env.MACOS_APP_RELEASE_PATH }}/${{ env.MACOS_DMG_NAME }}.dmg --apple-id ${MACOS_NOTARY_USER} --team-id ${MACOS_TEAM_ID} --password ${MACOS_NOTARY_PWD} -v -f "json" --wait
 
+        env:
+          MACOS_NOTARY_USER: ${{ secrets.MACOS_NOTARY_USER }}
+          MACOS_TEAM_ID: ${{ secrets.MACOS_TEAM_ID }}
+          MACOS_NOTARY_PWD: ${{ secrets.MACOS_NOTARY_PWD }}
       - name: Archive Asset
         working-directory: ${{ env.MACOS_APP_RELEASE_PATH }}
         run: zip --symlinks -qr ${{ env.MACOS_AARCH64_ZIP_NAME }} AppFlowy.app
@@ -354,13 +380,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.job.target }}
@@ -392,8 +418,10 @@ jobs:
         working-directory: frontend
         run: |
           flutter config --enable-linux-desktop
-          dart ./scripts/flutter_release_build/build_flowy.dart run . ${{ github.ref_name }}
+          dart ./scripts/flutter_release_build/build_flowy.dart run . ${REF_NAME}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Archive Asset
         working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}
         run: tar -czf ${{ env.LINUX_ZIP_NAME }} *
@@ -401,8 +429,10 @@ jobs:
       - name: Build Linux package (.deb)
         working-directory: frontend
         run: |
-          sh scripts/linux_distribution/deb/build_deb.sh appflowy_flutter/product/${{ github.ref_name }}/linux/Release ${{ github.ref_name }} ${{ env.LINUX_PACKAGE_DEB_NAME }}
+          sh scripts/linux_distribution/deb/build_deb.sh appflowy_flutter/product/${REF_NAME}/linux/Release ${REF_NAME} ${{ env.LINUX_PACKAGE_DEB_NAME }}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Build Linux package (.rpm)
         working-directory: ${{ env.LINUX_APP_RELEASE_PATH }}
         run: |
@@ -413,10 +443,12 @@ jobs:
         working-directory: frontend
         continue-on-error: true
         run: |
-          sh scripts/linux_distribution/appimage/build_appimage.sh ${{ github.ref_name }}
+          sh scripts/linux_distribution/appimage/build_appimage.sh ${REF_NAME}
           cd ..
           cp -r frontend/${{ env.LINUX_PACKAGE_TMP_APPIMAGE_NAME }} ${{ env.LINUX_APP_RELEASE_PATH }}/${{ env.LINUX_PACKAGE_APPIMAGE_NAME }}
 
+        env:
+          REF_NAME: ${{ github.ref_name }}
       - name: Upload Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -468,16 +500,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./frontend/scripts/docker-buildfiles/Dockerfile
@@ -495,7 +527,7 @@ jobs:
       - build-for-linux
     if: failure()
     steps:
-      - uses: 8398a7/action-slack@v3
+      - uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
         with:
           status: ${{ job.status }}
           text: |
@@ -517,5 +549,7 @@ jobs:
     steps:
       - name: Notify Discord
         run: |
-          curl -H "Content-Type: application/json" -d '{"username": "release@appflowy", "content": "🎉 AppFlowy ${{ github.ref_name }} is available. https://github.com/AppFlowy-IO/AppFlowy/releases/tag/'${{ github.ref_name }}'"}' "https://discord.com/api/webhooks/${{ secrets.DISCORD }}"
+          curl -H "Content-Type: application/json" -d '{"username": "release@appflowy", "content": "🎉 AppFlowy ${{ github.ref_name }} is available. https://github.com/AppFlowy-IO/AppFlowy/releases/tag/'${{ github.ref_name }}'"}' "https://discord.com/api/webhooks/${DISCORD}"
+        env:
+          DISCORD: ${{ secrets.DISCORD }}
         shell: bash

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set timezone for action
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
           timezoneLinux: "US/Pacific"
 
@@ -42,13 +42,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
           components: rustfmt, clippy
           profile: minimal
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: ${{ runner.os }}
           cache-on-failure: true

--- a/.github/workflows/rust_coverage.yml
+++ b/.github/workflows/rust_coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Rust toolchain
         id: rust_toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.job.target }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install flutter
         id: flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -43,7 +43,7 @@ jobs:
           cargo install --force --locked cargo-make
           cargo install --force --locked duckscript_cli
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           prefix-key: ${{ matrix.job.os }}
 

--- a/.github/workflows/translation_notify.yml
+++ b/.github/workflows/translation_notify.yml
@@ -9,7 +9,7 @@ jobs:
   Discord-Notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: Ilshidur/action-discord@master
+      - uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # master
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/build_command.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/commit_lint.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/docker_ci.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/flutter_ci.yaml` | Pinned 6 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/ios_ci.yaml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/mobile_ci.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/ninja_i18n.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release.yml` | Pinned 13 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/release.yml` | Extracted 21 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/rust_ci.yaml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/rust_coverage.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/translation_notify.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-002 | critical | `.github/workflows/release.yml` | Expression Injection via Branch Name or Untrusted Input |
| RGS-014 | high | `.github/workflows/mobile_ci.yml` | Expression Injection via workflow_dispatch Input |
| RGS-012 | high | `.github/workflows/mobile_ci.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/mobile_ci.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/release.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | `.github/workflows/release.yml` | Secret Exfiltration via Outbound HTTP Request |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.

## Summary by Sourcery

Harden GitHub Actions workflows by pinning third-party actions to specific commit SHAs and isolating GitHub context and secrets usage via environment variables to reduce injection and supply-chain risk.

CI:
- Pin multiple GitHub Actions across release, Flutter, iOS, Rust, Docker, commit lint, Slack, and translation workflows to immutable commit SHAs instead of floating tags.
- Refactor release, build, and notification workflows to pass GitHub context values and secrets through env variables before use in shell commands and HTTP requests, mitigating expression and secret injection risks.