### PR TITLE
fixed issue #8450 [Bug] Close sidebar button is not visible by default

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/header/sidebar_top_menu.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/menu/sidebar/header/sidebar_top_menu.dart
@@ -89,7 +89,7 @@ class SidebarTopMenu extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: isSidebarOnHover,
       builder: (_, value, ___) => Opacity(
-        opacity: value ? 1 : 0,
+        opacity: value ? 1 : 0.7,
         child: Padding(
           padding: const EdgeInsets.only(top: 12.0, right: 6.0),
           child: FlowyTooltip(


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Make the sidebar close button visible by default by rendering it with partial opacity instead of fully hiding it when not hovered.