### PR TITLE
fix: stabilize advanced filter UI and handle nested filter structures

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/application/field/filter_entities.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/application/field/filter_entities.dart
@@ -27,6 +27,19 @@ abstract class DatabaseFilter extends Equatable {
   });
 
   factory DatabaseFilter.fromPB(FilterPB filterPB) {
+    if (filterPB.filterType == FilterType.And ||
+        filterPB.filterType == FilterType.Or) {
+      return GroupFilter(
+        filterId: filterPB.id,
+        filterType: filterPB.filterType,
+        children: filterPB.children.map(DatabaseFilter.fromPB).toList(),
+      );
+    }
+
+    if (!filterPB.hasData()) {
+      return PlaceholderFilter(filterId: filterPB.id);
+    }
+
     final FilterDataPB(:fieldId, :fieldType) = filterPB.data;
     switch (fieldType) {
       case FieldType.RichText:
@@ -88,7 +101,7 @@ abstract class DatabaseFilter extends Equatable {
           end: data.hasEnd() ? data.end.toDateTime() : null,
         );
       default:
-        throw ArgumentError();
+        return PlaceholderFilter(filterId: filterPB.id);
     }
   }
 
@@ -745,4 +758,50 @@ final class TimeFilter extends DatabaseFilter {
 
   @override
   List<Object?> get props => [filterId, fieldId, condition, content];
+}
+
+final class PlaceholderFilter extends DatabaseFilter {
+  const PlaceholderFilter({required super.filterId})
+      : super(fieldId: '', fieldType: FieldType.RichText);
+
+  @override
+  String get conditionName => "";
+
+  @override
+  bool get canAttachContent => false;
+
+  @override
+  String getContentDescription(FieldInfo field) => "";
+
+  @override
+  Uint8List writeToBuffer() => Uint8List(0);
+
+  @override
+  List<Object?> get props => [filterId];
+}
+
+final class GroupFilter extends DatabaseFilter {
+  const GroupFilter({
+    required super.filterId,
+    required this.filterType,
+    required this.children,
+  }) : super(fieldId: '', fieldType: FieldType.RichText);
+
+  final FilterType filterType;
+  final List<DatabaseFilter> children;
+
+  @override
+  String get conditionName => filterType == FilterType.And ? "And" : "Or";
+
+  @override
+  bool get canAttachContent => false;
+
+  @override
+  String getContentDescription(FieldInfo field) => "";
+
+  @override
+  Uint8List writeToBuffer() => Uint8List(0);
+
+  @override
+  List<Object?> get props => [filterId, filterType, children];
 }

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/filter/filter_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/presentation/widgets/filter/filter_menu.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:appflowy/generated/flowy_svgs.g.dart';
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/plugins/database/application/field/field_controller.dart';
@@ -35,21 +36,28 @@ class FilterMenu extends StatelessWidget {
         },
         builder: (context, state) {
           final List<Widget> children = [];
-          children.addAll(
-            state.filters
-                .map(
-                  (filter) => FilterMenuItem(
-                    key: ValueKey(filter.filterId),
-                    filterId: filter.filterId,
-                    fieldType: state.fields
-                        .firstWhere(
-                          (element) => element.id == filter.fieldId,
-                        )
-                        .fieldType,
-                  ),
-                )
-                .toList(),
-          );
+          void addFilters(List<DatabaseFilter> filters) {
+            for (final filter in filters) {
+              if (filter is GroupFilter) {
+                addFilters(filter.children);
+              } else {
+                final field = state.fields.firstWhereOrNull(
+                  (element) => element.id == filter.fieldId,
+                );
+                if (field != null) {
+                  children.add(
+                    FilterMenuItem(
+                      key: ValueKey(filter.filterId),
+                      filterId: filter.filterId,
+                      fieldType: field.fieldType,
+                    ),
+                  );
+                }
+              }
+            }
+          }
+
+          addFilters(state.filters);
 
           if (state.fields.isNotEmpty) {
             children.add(


### PR DESCRIPTION
### Overview
This PR fixes a critical UI issue in the advanced filter where adding or removing criteria caused the interface to temporarily disappear and rebuild itself.

The root cause was a mismatch between the backend’s automatic grouping of filters and the frontend’s assumption of a flat structure.

---

### Changes

- **Recursive Filter Parsing**  
  Updated `DatabaseFilter.fromPB` in `filter_entities.dart` to support nested `AND` and `OR` filter structures. This ensures compatibility with backend-generated groupings.

- **Support for Grouping**  
  Introduced `GroupFilter` and `PlaceholderFilter` entities to safely represent nested and unknown filter types.

- **Flattened UI Rendering**  
  Refactored `FilterMenu` in `filter_menu.dart` to recursively traverse and flatten grouped filters for display, ensuring all criteria remain visible and interactive.

- **Crash Prevention**  
  Added defensive field lookup using `firstWhereOrNull` in `FilterMenu` to prevent crashes during structural transitions.

---

### Why This Is Necessary
In AppFlowy `0.11.x`, the backend automatically wraps filters into `AND` groups when additional criteria are added. Previously, the frontend failed to handle these unexpected structures, leading to parsing errors and UI breakdowns.

This PR ensures the frontend is resilient to such structural changes and maintains a stable user experience.

---

### Verification

- Added multiple criteria → verified backend auto-grouping into `AND` / `OR`
- Removed criteria → verified proper recursive cleanup
- Confirmed all filter conditions remain visible and interactive despite nested backend structure

---

### PR Checklist

- [x] My code adheres to AppFlowy's conventions  
- [x] I've listed at least one issue that this PR fixes  
- [x] I've added tests or this PR contains only semantic/structural improvements  
- [x] All existing tests are passing  

closes #8638

## Summary by Sourcery

Stabilize the advanced filter UI by supporting grouped filters and safely handling unknown or nested filter structures.

Bug Fixes:
- Prevent crashes and disappearing UI when the backend returns grouped (AND/OR) or structurally unexpected filters in the advanced filter menu.

Enhancements:
- Add support for nested AND/OR group filters and placeholder filters in filter parsing to handle backend-generated groupings and unknown filter types.
- Flatten grouped filters when rendering the filter menu so all criteria remain visible and interactive while ignoring filters lacking matching fields.