### PR TITLE
merge of rel prop

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/relation.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/field/type_option_editor/relation.dart
@@ -27,7 +27,7 @@ class RelationTypeOptionEditorFactory implements TypeOptionEditorFactory {
     final typeOption = _parseTypeOptionData(field.typeOptionData);
 
     return BlocProvider(
-      create: (_) => RelationDatabaseListCubit(),
+      create: (_) => RelationDatabaseListCubit()..fetchDatabases(),
       child: Builder(
         builder: (context) {
           return Column(
@@ -93,6 +93,51 @@ class RelationTypeOptionEditorFactory implements TypeOptionEditorFactory {
                   );
                 },
               ),
+              BlocBuilder<RelationDatabaseListCubit, RelationDatabaseListState>(
+                builder: (context, state) {
+                  final currentDatabaseMeta =
+                      state.databaseMetas.firstWhereOrNull(
+                    (meta) => meta.viewId == viewId,
+                  );
+                  final isSelfRelation = currentDatabaseMeta != null &&
+                      currentDatabaseMeta.databaseId == typeOption.databaseId;
+
+                  if (!isSelfRelation) {
+                    return const SizedBox.shrink();
+                  }
+
+                  return Column(
+                    children: [
+                      VSpace(GridSize.typeOptionSeparatorHeight),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 14),
+                        height: GridSize.popoverItemHeight,
+                        child: Row(
+                          children: [
+                            const FlowyText.regular(
+                              "Separate columns",
+                              fontSize: 12,
+                            ),
+                            const Spacer(),
+                            FlowySwitch(
+                              value: !typeOption.bidirectional,
+                              onChanged: (value) {
+                                final newTypeOption = _updateTypeOption(
+                                  typeOption: typeOption,
+                                  bidirectional: !value,
+                                );
+                                onTypeOptionUpdated(
+                                  newTypeOption.writeToBuffer(),
+                                );
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
             ],
           );
         },
@@ -106,11 +151,17 @@ class RelationTypeOptionEditorFactory implements TypeOptionEditorFactory {
 
   RelationTypeOptionPB _updateTypeOption({
     required RelationTypeOptionPB typeOption,
-    required String databaseId,
+    String? databaseId,
+    bool? bidirectional,
   }) {
     typeOption.freeze();
     return typeOption.rebuild((typeOption) {
-      typeOption.databaseId = databaseId;
+      if (databaseId != null) {
+        typeOption.databaseId = databaseId;
+      }
+      if (bidirectional != null) {
+        typeOption.bidirectional = bidirectional;
+      }
     });
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/relation_entities.rs
+++ b/frontend/rust-lib/flowy-database2/src/entities/type_option_entities/relation_entities.rs
@@ -45,12 +45,16 @@ pub struct RelationCellChangesetPB {
 pub struct RelationTypeOptionPB {
   #[pb(index = 1)]
   pub database_id: String,
+
+  #[pb(index = 2)]
+  pub bidirectional: bool,
 }
 
 impl From<RelationTypeOption> for RelationTypeOptionPB {
   fn from(value: RelationTypeOption) -> Self {
     RelationTypeOptionPB {
       database_id: value.database_id,
+      bidirectional: false,
     }
   }
 }

--- a/frontend/rust-lib/flowy-database2/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database2/src/event_handler.rs
@@ -1212,15 +1212,63 @@ pub(crate) async fn update_relation_cell_handler(
   //   .validate_row_ids_exist(&params)
   //   .await?;
 
+  let mut is_bidirectional = false;
+  if let Some(field) = database_editor.get_field(&cell_id.field_id).await {
+    if let Some(type_option_data) =
+      field.get_any_type_option(collab_database::fields::FieldType::Relation)
+    {
+      let bytes =
+        crate::services::field::type_option_to_pb(type_option_data, &FieldType::Relation);
+      if let Ok(pb) = RelationTypeOptionPB::try_from(bytes.as_ref()) {
+        if pb.bidirectional && pb.database_id == database_editor.get_database_id().await {
+          is_bidirectional = true;
+        }
+      }
+    }
+  }
+
   // update the cell in the database
   database_editor
     .update_cell_with_changeset(
       &view_id,
       &cell_id.row_id,
       &cell_id.field_id,
-      BoxAny::new(params),
+      BoxAny::new(params.clone()),
     )
     .await?;
+
+  if is_bidirectional {
+    for row_id in params.inserted_row_ids {
+      let reverse_params = RelationCellChangeset {
+        inserted_row_ids: vec![cell_id.row_id.clone()],
+        removed_row_ids: vec![],
+      };
+      let _ = database_editor
+        .update_cell_with_changeset(
+          &view_id,
+          &row_id.to_string(),
+          &cell_id.field_id,
+          BoxAny::new(reverse_params),
+        )
+        .await;
+    }
+
+    for row_id in params.removed_row_ids {
+      let reverse_params = RelationCellChangeset {
+        inserted_row_ids: vec![],
+        removed_row_ids: vec![cell_id.row_id.clone()],
+      };
+      let _ = database_editor
+        .update_cell_with_changeset(
+          &view_id,
+          &row_id.to_string(),
+          &cell_id.field_id,
+          BoxAny::new(reverse_params),
+        )
+        .await;
+    }
+  }
+
   Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implements support for **merged relational columns** in self-referencing databases by introducing a bidirectional relation mode. This allows two-way relations to be represented within a single column with automatic symmetric synchronization.

closes #8647 

---

## Motivation

Currently, self-referential relations require separate columns to maintain bidirectional links, which adds redundancy and complexity.

This PR introduces a **bidirectional mode** that:
- Eliminates duplicate relation columns
- Ensures automatic two-way synchronization
- Improves UX for self-referencing databases

---

## Changes

### 1. Rust Backend (`flowy-database2`)

#### A. Protobuf Updates
- Added `bidirectional: bool` to `RelationTypeOptionPB`
- Updated `From` implementations to support the new field

#### B. Symmetric Sync Logic
Updated `update_relation_cell_handler` to:
- Decode `RelationTypeOptionPB` from type option data
- If `bidirectional == true` and relation is self-referencing:
  - Linking Row A → Row B automatically links Row B → Row A
  - Unlinking Row A → Row B automatically unlinks Row B → Row A

---

### 2. Flutter Frontend (`appflowy_flutter`)

#### A. UI Toggle
- Added **"Separate columns"** toggle (enabled by default)
- Visible only for self-referencing relations
- Turning OFF sets `bidirectional = true` (merged mode)

#### B. Protobuf Regeneration
Regenerated Dart protobuf classes to include the new field:

```bash
./scripts/generate_proto.sh

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.