### PR TITLE
[FR] add an @ all members for notifications

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_page.dart
@@ -9,6 +9,7 @@ import 'package:appflowy/plugins/document/presentation/editor_plugins/i18n/edito
 import 'package:appflowy/plugins/document/presentation/editor_plugins/plugins.dart';
 import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy/plugins/inline_actions/handlers/child_page.dart';
+import 'package:appflowy/plugins/inline_actions/handlers/all_members_notification.dart';
 import 'package:appflowy/plugins/inline_actions/handlers/date_reference.dart';
 import 'package:appflowy/plugins/inline_actions/handlers/inline_page_reference.dart';
 import 'package:appflowy/plugins/inline_actions/handlers/reminder_reference.dart';
@@ -83,6 +84,7 @@ class _AppFlowyEditorPageState extends State<AppFlowyEditorPage>
       if (FeatureFlag.inlineSubPageMention.isOn)
         InlineChildPageService(currentViewId: documentBloc.documentId),
       InlinePageReferenceService(currentViewId: documentBloc.documentId),
+      AllMembersNotificationService(context),
       DateReferenceService(context),
       ReminderReferenceService(context),
     ],

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/delta/text_delta_extension.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/delta/text_delta_extension.dart
@@ -32,6 +32,10 @@ extension TextDeltaExtension on Delta {
           if (mentionPageId != null) {
             text += await getMentionPageName(mentionPageId);
             continue;
+          } else if (mentionType == MentionType.allMembers.name) {
+            final label = mention?[MentionBlockKeys.label] ?? 'all';
+            text += '@$label';
+            continue;
           } else if (mentionType == MentionType.externalLink.name) {
             final url = mention?[MentionBlockKeys.url] ?? '';
             final info = await LinkInfoCache.get(url);

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_all_members_block.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_all_members_block.dart
@@ -1,0 +1,44 @@
+import 'package:appflowy/generated/flowy_svgs.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_block.dart';
+import 'package:flowy_infra_ui/flowy_infra_ui.dart';
+import 'package:flutter/material.dart';
+
+class MentionAllMembersBlock extends StatelessWidget {
+  const MentionAllMembersBlock({
+    super.key,
+    required this.mention,
+    this.textStyle,
+  });
+
+  final Map<String, dynamic> mention;
+  final TextStyle? textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = mention[MentionBlockKeys.label] as String? ?? 'all';
+    final effectiveStyle = textStyle?.copyWith(
+      leadingDistribution: TextLeadingDistribution.even,
+    );
+
+    final iconSize = (textStyle?.fontSize ?? 14.0) / 14.0 * 16.0;
+
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        Text(
+          '@$label',
+          style: effectiveStyle,
+          strutStyle: effectiveStyle != null
+              ? StrutStyle.fromTextStyle(effectiveStyle)
+              : null,
+        ),
+        const HSpace(4),
+        FlowySvg(
+          FlowySvgs.settings_members_m,
+          size: Size.square(iconSize),
+          color: effectiveStyle?.color,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_block.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/mention/mention_block.dart
@@ -1,4 +1,5 @@
 import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_date_block.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_all_members_block.dart';
 import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_page_block.dart';
 import 'package:appflowy/workspace/presentation/widgets/date_picker/widgets/reminder_selector.dart';
 import 'package:appflowy_editor/appflowy_editor.dart';
@@ -12,13 +13,15 @@ enum MentionType {
   page,
   date,
   externalLink,
-  childPage;
+  childPage,
+  allMembers;
 
   static MentionType fromString(String value) => switch (value) {
         'page' => page,
         'date' => date,
         'externalLink' => externalLink,
         'childPage' => childPage,
+        'allMembers' => allMembers,
         // Backwards compatibility
         'reminder' => date,
         _ => throw UnimplementedError(),
@@ -58,6 +61,10 @@ class MentionBlockKeys {
   static const includeTime = 'include_time';
   static const reminderId = 'reminder_id'; // ReminderID
   static const reminderOption = 'reminder_option';
+  static const workspaceId = 'workspace_id';
+  static const memberCount = 'member_count';
+  static const memberEmails = 'member_emails';
+  static const label = 'label';
 
   static const mentionChar = '\$';
 
@@ -89,6 +96,22 @@ class MentionBlockKeys {
         if (reminderId != null) MentionBlockKeys.reminderId: reminderId,
         if (reminderOption != null)
           MentionBlockKeys.reminderOption: reminderOption,
+      },
+    };
+  }
+
+  static Map<String, dynamic> buildMentionAllMembersAttributes({
+    required String workspaceId,
+    required List<String> memberEmails,
+    String label = 'all',
+  }) {
+    return {
+      MentionBlockKeys.mention: {
+        MentionBlockKeys.type: MentionType.allMembers.name,
+        MentionBlockKeys.workspaceId: workspaceId,
+        MentionBlockKeys.memberCount: memberEmails.length,
+        MentionBlockKeys.memberEmails: memberEmails,
+        MentionBlockKeys.label: label,
       },
     };
   }
@@ -172,6 +195,11 @@ class MentionBlock extends StatelessWidget {
           editorState: editorState,
           node: node,
           index: index,
+        );
+      case MentionType.allMembers:
+        return MentionAllMembersBlock(
+          mention: mention,
+          textStyle: textStyle,
         );
     }
   }

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_style.dart
@@ -399,8 +399,9 @@ class EditorStyleCustomizer {
         child: MentionBlock(
           key: ValueKey(
             switch (type) {
-              MentionType.page => mention[MentionBlockKeys.pageId],
-              MentionType.date => mention[MentionBlockKeys.date],
+              'page' => mention[MentionBlockKeys.pageId],
+              'date' => mention[MentionBlockKeys.date],
+              'allMembers' => mention[MentionBlockKeys.label],
               _ => MentionBlockKeys.mention,
             },
           ),

--- a/frontend/appflowy_flutter/lib/plugins/inline_actions/handlers/all_members_notification.dart
+++ b/frontend/appflowy_flutter/lib/plugins/inline_actions/handlers/all_members_notification.dart
@@ -1,0 +1,138 @@
+import 'package:appflowy/generated/flowy_svgs.g.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/mention/mention_block.dart';
+import 'package:appflowy/plugins/inline_actions/inline_actions_result.dart';
+import 'package:appflowy/plugins/inline_actions/service_handler.dart';
+import 'package:appflowy/user/application/user_service.dart';
+import 'package:appflowy/workspace/application/user/user_workspace_bloc.dart';
+import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class AllMembersNotificationService extends InlineActionsDelegate {
+  AllMembersNotificationService(this.context);
+
+  final BuildContext context;
+
+  static const _keywords = ['all', 'everyone', 'members', 'notify'];
+
+  List<WorkspaceMemberPB>? _members;
+  String? _workspaceId;
+
+  @override
+  Future<InlineActionsResult> search([
+    String? search,
+  ]) async {
+    final workspace =
+        context.read<UserWorkspaceBloc?>()?.state.currentWorkspace;
+    if (workspace == null ||
+        workspace.workspaceType == WorkspaceTypePB.LocalW) {
+      return InlineActionsResult(title: 'Notifications', results: const []);
+    }
+
+    if (_workspaceId != workspace.workspaceId || _members == null) {
+      _workspaceId = workspace.workspaceId;
+      _members = await _fetchWorkspaceMembers(workspace.workspaceId);
+    }
+
+    final members = _members ?? const <WorkspaceMemberPB>[];
+    if (members.isEmpty) {
+      return InlineActionsResult(title: 'Notifications', results: const []);
+    }
+
+    if (!_matchesSearch(search)) {
+      return InlineActionsResult(title: 'Notifications', results: const []);
+    }
+
+    return InlineActionsResult(
+      title: 'Notifications',
+      startsWithKeywords: _keywords,
+      results: [
+        InlineActionsMenuItem(
+          label: '@all',
+          keywords: _keywords,
+          iconBuilder: (_) => const FlowySvg(
+            FlowySvgs.settings_members_m,
+            size: Size.square(16),
+          ),
+          onSelected: (context, editorState, menuService, replace) =>
+              _insertMention(
+            editorState,
+            workspace.workspaceId,
+            members,
+            replace.$1,
+            replace.$2,
+          ),
+        ),
+      ],
+    );
+  }
+
+  bool _matchesSearch(String? search) {
+    if (search == null || search.isEmpty) {
+      return true;
+    }
+
+    final normalized = search.toLowerCase();
+    return _keywords.any((keyword) => keyword.contains(normalized));
+  }
+
+  Future<List<WorkspaceMemberPB>> _fetchWorkspaceMembers(
+    String workspaceId,
+  ) async {
+    final userProfile = context.read<UserWorkspaceBloc?>()?.state.userProfile;
+    if (userProfile == null) {
+      return const [];
+    }
+
+    final result = await UserBackendService(
+      userId: userProfile.id,
+    ).getWorkspaceMembers(workspaceId);
+
+    return result.fold(
+      (success) => success.items,
+      (_) => const [],
+    );
+  }
+
+  Future<void> _insertMention(
+    EditorState editorState,
+    String workspaceId,
+    List<WorkspaceMemberPB> members,
+    int start,
+    int end,
+  ) async {
+    final selection = editorState.selection;
+    if (selection == null || !selection.isCollapsed) {
+      return;
+    }
+
+    final node = editorState.getNodeAtPath(selection.end.path);
+    final delta = node?.delta;
+    if (node == null || delta == null) {
+      return;
+    }
+
+    final memberEmails = members
+        .map((member) => member.email)
+        .where((email) => email.isNotEmpty)
+        .toList();
+    if (memberEmails.isEmpty) {
+      return;
+    }
+
+    final transaction = editorState.transaction
+      ..replaceText(
+        node,
+        start,
+        end,
+        MentionBlockKeys.mentionChar,
+        attributes: MentionBlockKeys.buildMentionAllMembersAttributes(
+          workspaceId: workspaceId,
+          memberEmails: memberEmails,
+        ),
+      );
+
+    await editorState.apply(transaction);
+  }
+}


### PR DESCRIPTION
### Feature Preview

This PR adds support for an `@everyone` / “all members” mention option in the mention flow, allowing users to notify all workspace members more easily.

Fixes #8652

<img width="1283" height="872" alt="Captura de ecrã 2026-04-11, às 21 16 37" src="https://github.com/user-attachments/assets/81637704-f4db-4207-b0a9-e77775350864" />

---

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Add support for an "@all" / all-members mention in the editor mention and inline actions flow.

New Features:
- Introduce an all-members mention type that lets users notify all workspace members via the mention flow.
- Add an inline action that surfaces an '@all' notification option when typing relevant keywords in the editor.

Enhancements:
- Render all-members mentions with a dedicated visual block and ensure they serialize to readable '@label' text in document exports.