### PR TITLE
fix: persist custom themes across updates & auto-reload on file changes

### DIFF
--- a/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/app_widget.dart
@@ -25,6 +25,8 @@ import 'package:appflowy_backend/protobuf/flowy-folder/view.pb.dart';
 import 'package:appflowy_backend/protobuf/flowy-user/protobuf.dart';
 import 'package:appflowy_ui/appflowy_ui.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra/plugins/service/location_service.dart';
+import 'package:flowy_infra/plugins/service/plugin_service.dart';
 import 'package:flowy_infra/theme.dart';
 import 'package:flowy_infra_ui/flowy_infra_ui.dart';
 import 'package:flutter/gestures.dart';
@@ -32,6 +34,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:toastification/toastification.dart';
 import 'package:universal_platform/universal_platform.dart';
@@ -53,6 +57,8 @@ class InitAppWidgetTask extends LaunchTask {
     await NotificationService.initialize();
 
     await loadIconGroups();
+
+    await _initPluginLocation();
 
     final widget = context.getIt<EntryPoint>().create(context.config);
     final appearanceSetting =
@@ -318,4 +324,24 @@ Future<AppTheme> appTheme(String themeName) async {
       return AppTheme.fallback;
     }
   }
+}
+
+/// Configures [FlowyPluginService] to store plugins in a stable directory
+/// under the platform app-support path (e.g. Application Support on macOS,
+/// AppData\Roaming on Windows, ~/.local/share on Linux). The legacy
+/// Documents directory is kept as a read-only fallback for themes imported
+/// with older versions.
+Future<void> _initPluginLocation() async {
+  final appSupport = await getApplicationSupportDirectory();
+  final pluginsDir = Directory(p.join(appSupport.path, 'plugins'));
+  if (!pluginsDir.existsSync()) {
+    pluginsDir.createSync(recursive: true);
+  }
+
+  FlowyPluginService.instance.setLocation(
+    PluginLocationService(
+      fallback: Future.value(pluginsDir),
+      additionalLocations: [getApplicationDocumentsDirectory()],
+    ),
+  );
 }

--- a/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/settings/appearance/appearance_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:appflowy/core/config/kv.dart';
 import 'package:appflowy/core/config/kv_keys.dart';
@@ -15,6 +16,7 @@ import 'package:appflowy_backend/protobuf/flowy-user/user_setting.pb.dart';
 import 'package:appflowy_editor/appflowy_editor.dart'
     show AppFlowyEditorLocalizations;
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flowy_infra/plugins/service/plugin_service.dart';
 import 'package:flowy_infra/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -69,10 +71,15 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
           ),
         ) {
     readTextScaleFactor();
+    _startWatchingTheme(appTheme);
   }
 
   final AppearanceSettingsPB _appearanceSettings;
   final DateTimeSettingsPB _dateTimeSettings;
+
+  StreamSubscription<FileSystemEvent>? _themeWatcher;
+  Timer? _themeReloadDebounce;
+  int _watchGeneration = 0;
 
   Future<void> setTextScaleFactor(double textScaleFactor) async {
     // only saved in local storage, this value is not synced across devices
@@ -102,6 +109,7 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
     unawaited(_saveAppearanceSettings());
     try {
       final theme = await AppTheme.fromName(themeName);
+      _startWatchingTheme(theme);
       emit(state.copyWith(appTheme: theme));
     } catch (e) {
       Log.error("Error setting theme: $e");
@@ -302,6 +310,58 @@ class AppearanceSettingsCubit extends Cubit<AppearanceSettingsState> {
       (l) => null,
       (error) => Log.error(error),
     );
+  }
+
+  /// Watches the on-disk source of [theme] and reloads it on changes.
+  void _startWatchingTheme(AppTheme theme) {
+    _stopWatchingTheme();
+    if (theme.builtIn) return;
+    final generation = ++_watchGeneration;
+    _watchThemeByName(theme.themeName, generation);
+  }
+
+  Future<void> _watchThemeByName(String themeName, int generation) async {
+    final plugin =
+        await FlowyPluginService.instance.lookup(name: themeName);
+    if (generation != _watchGeneration) return;
+    if (plugin == null || !plugin.source.existsSync()) return;
+
+    _themeWatcher = plugin.source.watch(recursive: true).listen(
+      (_) {
+        _themeReloadDebounce?.cancel();
+        _themeReloadDebounce = Timer(
+          const Duration(milliseconds: 500),
+          _reloadCurrentTheme,
+        );
+      },
+      onError: (_) {},
+    );
+  }
+
+  Future<void> _reloadCurrentTheme() async {
+    final currentName = state.appTheme.themeName;
+    if (state.appTheme.builtIn) return;
+    try {
+      final theme = await AppTheme.fromName(currentName);
+      if (!isClosed) {
+        emit(state.copyWith(appTheme: theme));
+      }
+    } catch (e) {
+      Log.error('Error reloading theme "$currentName": $e');
+    }
+  }
+
+  void _stopWatchingTheme() {
+    _themeReloadDebounce?.cancel();
+    _themeReloadDebounce = null;
+    _themeWatcher?.cancel();
+    _themeWatcher = null;
+  }
+
+  @override
+  Future<void> close() {
+    _stopWatchingTheme();
+    return super.close();
   }
 }
 

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/plugins/service/location_service.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/plugins/service/location_service.dart
@@ -3,11 +3,21 @@ import 'dart:io';
 class PluginLocationService {
   const PluginLocationService({
     required Future<Directory> fallback,
-  }) : _fallback = fallback;
+    List<Future<Directory>>? additionalLocations,
+  })  : _fallback = fallback,
+        _additionalLocations = additionalLocations ?? const [];
 
   final Future<Directory> _fallback;
+  final List<Future<Directory>> _additionalLocations;
 
   Future<Directory> get fallback async => _fallback;
 
   Future<Directory> get location async => fallback;
+
+  /// Returns the primary and all additional scan locations.
+  Future<List<Directory>> get allLocations async {
+    final primary = await fallback;
+    final extras = await Future.wait(_additionalLocations);
+    return [primary, ...extras];
+  }
 }

--- a/frontend/appflowy_flutter/packages/flowy_infra/lib/plugins/service/plugin_service.dart
+++ b/frontend/appflowy_flutter/packages/flowy_infra/lib/plugins/service/plugin_service.dart
@@ -14,7 +14,7 @@ class FlowyPluginService {
   static final FlowyPluginService _instance = FlowyPluginService._();
   static FlowyPluginService get instance => _instance;
 
-  PluginLocationService _locationService = PluginLocationService(
+  late PluginLocationService _locationService = PluginLocationService(
     fallback: getApplicationDocumentsDirectory(),
   );
 
@@ -22,9 +22,22 @@ class FlowyPluginService {
       _locationService = locationService;
 
   Future<Iterable<Directory>> get _targets async {
-    final location = await _locationService.location;
-    final targets = location.listSync().where(FlowyDynamicPlugin.isPlugin);
-    return targets.map<Directory>((entity) => entity as Directory).toList();
+    final locations = await _locationService.allLocations;
+    final seen = <String>{};
+    final targets = <Directory>[];
+    for (final location in locations) {
+      if (!location.existsSync()) continue;
+      for (final entity in location.listSync()) {
+        if (FlowyDynamicPlugin.isPlugin(entity)) {
+          final dir = entity as Directory;
+          final name = p.basename(dir.path);
+          if (seen.add(name)) {
+            targets.add(dir);
+          }
+        }
+      }
+    }
+    return targets;
   }
 
   /// Searches the [PluginLocationService.location] for plugins and compiles them.

--- a/frontend/appflowy_flutter/test/unit_test/theme/plugin_location_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/theme/plugin_location_test.dart
@@ -1,0 +1,182 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flowy_infra/colorscheme/default_colorscheme.dart';
+import 'package:flowy_infra/plugins/service/location_service.dart';
+import 'package:flowy_infra/plugins/service/plugin_service.dart';
+import 'package:flowy_infra/theme.dart';
+import 'package:path/path.dart' as p;
+
+/// Creates a minimal `.flowy_plugin` directory with stub theme files.
+Directory _createFakePlugin(Directory parent, String name) {
+  final pluginDir =
+      Directory(p.join(parent.path, '$name.flowy_plugin'))..createSync();
+
+  final colorScheme = const DefaultColorScheme.light().toJson();
+  final encoded = jsonEncode(colorScheme);
+
+  File(p.join(pluginDir.path, '$name.light.json'))
+    ..createSync()
+    ..writeAsStringSync(encoded);
+  File(p.join(pluginDir.path, '$name.dark.json'))
+    ..createSync()
+    ..writeAsStringSync(encoded);
+
+  return pluginDir;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('appflowy_plugin_test_');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  group('PluginLocationService', () {
+    test('location returns the primary directory', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final service = PluginLocationService(fallback: Future.value(primary));
+
+      expect((await service.location).path, equals(primary.path));
+    });
+
+    test('allLocations returns primary + additional directories', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final extra1 = Directory(p.join(tmp.path, 'extra1'))..createSync();
+      final extra2 = Directory(p.join(tmp.path, 'extra2'))..createSync();
+
+      final service = PluginLocationService(
+        fallback: Future.value(primary),
+        additionalLocations: [Future.value(extra1), Future.value(extra2)],
+      );
+
+      final all = await service.allLocations;
+      expect(all, hasLength(3));
+      expect(all.map((d) => d.path), containsAll([primary.path, extra1.path, extra2.path]));
+    });
+
+    test('allLocations returns only primary when no additionalLocations', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final service = PluginLocationService(fallback: Future.value(primary));
+
+      final all = await service.allLocations;
+      expect(all, hasLength(1));
+      expect(all.first.path, equals(primary.path));
+    });
+  });
+
+  group('FlowyPluginService — multi-location plugin discovery', () {
+    test('finds plugins in the primary directory', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      _createFakePlugin(primary, 'myTheme');
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(fallback: Future.value(primary)),
+      );
+
+      final found = await service.plugins;
+      expect(found.map((p) => p.name), contains('myTheme'));
+    });
+
+    test('finds plugins in the secondary (legacy) directory', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final legacy = Directory(p.join(tmp.path, 'legacy'))..createSync();
+      _createFakePlugin(legacy, 'legacyTheme');
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(
+          fallback: Future.value(primary),
+          additionalLocations: [Future.value(legacy)],
+        ),
+      );
+
+      final found = await service.plugins;
+      expect(found.map((p) => p.name), contains('legacyTheme'));
+    });
+
+    test('deduplicates plugins with the same name across directories', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final legacy = Directory(p.join(tmp.path, 'legacy'))..createSync();
+
+      _createFakePlugin(primary, 'sharedTheme');
+      _createFakePlugin(legacy, 'sharedTheme');
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(
+          fallback: Future.value(primary),
+          additionalLocations: [Future.value(legacy)],
+        ),
+      );
+
+      final found = await service.plugins;
+      final names = found.map((p) => p.name).toList();
+      expect(names.where((n) => n == 'sharedTheme'), hasLength(1));
+    });
+
+    test('primary location takes precedence over legacy for deduplication', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final legacy = Directory(p.join(tmp.path, 'legacy'))..createSync();
+
+      _createFakePlugin(primary, 'shared');
+      _createFakePlugin(legacy, 'shared');
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(
+          fallback: Future.value(primary),
+          additionalLocations: [Future.value(legacy)],
+        ),
+      );
+
+      final found = await service.plugins;
+      final plugin = found.firstWhere((p) => p.name == 'shared');
+      expect(plugin.source.path, startsWith(primary.path));
+    });
+
+    test('skips non-existent additional locations gracefully', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      _createFakePlugin(primary, 'myTheme');
+      final nonExistent = Directory(p.join(tmp.path, 'does_not_exist'));
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(
+          fallback: Future.value(primary),
+          additionalLocations: [Future.value(nonExistent)],
+        ),
+      );
+
+      final found = await service.plugins;
+      expect(found.map((p) => p.name), contains('myTheme'));
+    });
+
+    test('AppTheme.fromName resolves a plugin theme from the legacy directory',
+        () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final legacy = Directory(p.join(tmp.path, 'legacy'))..createSync();
+      _createFakePlugin(legacy, 'retroTheme');
+
+      final service = FlowyPluginService.instance;
+      service.setLocation(
+        PluginLocationService(
+          fallback: Future.value(primary),
+          additionalLocations: [Future.value(legacy)],
+        ),
+      );
+
+      final theme = await AppTheme.fromName('retroTheme', pluginService: service);
+      expect(theme.themeName, equals('retroTheme'));
+      expect(theme.builtIn, isFalse);
+    });
+  });
+}

--- a/frontend/appflowy_flutter/test/unit_test/theme/theme_hot_reload_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/theme/theme_hot_reload_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flowy_infra/colorscheme/default_colorscheme.dart';
+import 'package:flowy_infra/plugins/service/models/flowy_dynamic_plugin.dart';
+import 'package:path/path.dart' as p;
+
+/// Creates a minimal `.flowy_plugin` directory with stub theme files.
+Directory _createFakePlugin(Directory parent, String name) {
+  final pluginDir =
+      Directory(p.join(parent.path, '$name.flowy_plugin'))..createSync();
+
+  final colorScheme = const DefaultColorScheme.light().toJson();
+  final encoded = jsonEncode(colorScheme);
+
+  File(p.join(pluginDir.path, '$name.light.json'))
+    ..createSync()
+    ..writeAsStringSync(encoded);
+  File(p.join(pluginDir.path, '$name.dark.json'))
+    ..createSync()
+    ..writeAsStringSync(encoded);
+
+  return pluginDir;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('appflowy_hotreload_test_');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  group('Theme hot-reload — file changes detected on disk', () {
+    test(
+        'FlowyDynamicPlugin.decode re-reads files so updated JSON is picked up',
+        () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final pluginDir = _createFakePlugin(primary, 'hotTheme');
+
+      final original = await FlowyDynamicPlugin.decode(src: pluginDir);
+      expect(original.theme, isNotNull);
+      final originalLight = original.theme!.lightTheme;
+
+      final lightFile = File(p.join(pluginDir.path, 'hotTheme.light.json'));
+      final json =
+          jsonDecode(lightFile.readAsStringSync()) as Map<String, dynamic>;
+      json['primary'] = '0xFFFF0000';
+      lightFile.writeAsStringSync(jsonEncode(json));
+
+      final reloaded = await FlowyDynamicPlugin.decode(src: pluginDir);
+      expect(reloaded.theme, isNotNull);
+      expect(
+        reloaded.theme!.lightTheme.primary,
+        isNot(equals(originalLight.primary)),
+      );
+    });
+
+    test('Directory.watch emits events when theme JSON files change', () async {
+      final primary = Directory(p.join(tmp.path, 'primary'))..createSync();
+      final pluginDir = _createFakePlugin(primary, 'watchTheme');
+
+      final events = <FileSystemEvent>[];
+      final subscription = pluginDir.watch(recursive: true).listen(events.add);
+
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      final lightFile =
+          File(p.join(pluginDir.path, 'watchTheme.light.json'));
+      lightFile.writeAsStringSync('{}');
+
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await subscription.cancel();
+
+      expect(events, isNotEmpty, reason: 'File watcher should have fired');
+    });
+  });
+}


### PR DESCRIPTION
### Feature Preview
Custom themes now survive app updates and automatically reload when their JSON files are modified on disk — no re-import needed. This enables seamless integration with external theming tools (e.g. matugen, wallpaper scripts).

Theme persistence: Plugins are stored under the platform's app-support directory (Application Support on macOS, AppData\Roaming on Windows, ~/.local/share on Linux) instead of Documents. The legacy Documents folder is kept as a read-only fallback.

Hot-reload: The app watches the active theme's source directory for file-system changes and re-applies the theme automatically with a 500ms debounce.

fixes [https://github.com/AppFlowy-IO/AppFlowy/issues/8663](https://github.com/AppFlowy-IO/AppFlowy/issues/8663)
fixes [https://github.com/AppFlowy-IO/AppFlowy/issues/5873](https://github.com/AppFlowy-IO/AppFlowy/issues/5873)

#### PR Checklist

- [X] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [X] I've listed at least one issue that this PR fixes in the description above.
- [X] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [X] All existing tests are passing.
