### PR TITLE
.1502411993651747:e8a094f9f73d7110187a30dee1197896_69dd0b270d50753e257d922b.69dd19950d50753e257d9230.69dd19957deec78a495cacd0:Trae CN.T(2026/4/14 00:28:05)

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/card_cell_skeleton/url_card_cell.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/widgets/cell/card_cell_skeleton/url_card_cell.dart
@@ -4,7 +4,10 @@ import 'package:appflowy/plugins/database/application/database_controller.dart';
 import 'package:appflowy/plugins/database/application/cell/bloc/url_cell_bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/services.dart';
+import 'package:universal_platform/universal_platform.dart';
 
+import '../editable_cell_skeleton/url.dart';
 import 'card_cell.dart';
 
 class URLCardCellStyle extends CardCellStyle {
@@ -32,6 +35,34 @@ class URLCardCell extends CardCell<URLCardCellStyle> {
 }
 
 class _URLCellState extends State<URLCardCell> {
+  bool isLinkClickable = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (UniversalPlatform.isDesktop) {
+      HardwareKeyboard.instance.addHandler(_handleGlobalKeyEvent);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (UniversalPlatform.isDesktop) {
+      HardwareKeyboard.instance.removeHandler(_handleGlobalKeyEvent);
+    }
+    super.dispose();
+  }
+
+  bool _handleGlobalKeyEvent(KeyEvent event) {
+    final keyboard = HardwareKeyboard.instance;
+    final canOpenLink = event is KeyDownEvent &&
+        (keyboard.isControlPressed || keyboard.isMetaPressed);
+    if (canOpenLink != isLinkClickable) {
+      setState(() => isLinkClickable = canOpenLink);
+    }
+    return false;
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -49,12 +80,28 @@ class _URLCellState extends State<URLCardCell> {
           if (state.content.isEmpty) {
             return const SizedBox.shrink();
           }
-          return Container(
-            alignment: AlignmentDirectional.centerStart,
-            padding: widget.style.padding,
-            child: Text(
-              state.content,
-              style: widget.style.textStyle,
+          return GestureDetector(
+            onTap: () {
+              if (UniversalPlatform.isDesktop) {
+                if (isLinkClickable) {
+                  openUrlCellLink(state.content);
+                }
+              } else {
+                openUrlCellLink(state.content);
+              }
+            },
+            child: MouseRegion(
+              cursor: isLinkClickable || UniversalPlatform.isMobile
+                  ? SystemMouseCursors.click
+                  : SystemMouseCursors.basic,
+              child: Container(
+                alignment: AlignmentDirectional.centerStart,
+                padding: widget.style.padding,
+                child: Text(
+                  state.content,
+                  style: widget.style.textStyle,
+                ),
+              ),
             ),
           );
         },


### PR DESCRIPTION
在桌面端支持通过Ctrl/Cmd+点击打开URL链接，移动端直接点击即可打开。添加了键盘事件监听和鼠标指针状态变化，提升用户体验。

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Enable URL card cells to be opened via modifier-click on desktop and direct tap on mobile, with visual feedback for clickability.

New Features:
- Allow opening URL card cell links on desktop via Ctrl/Cmd+click and on mobile via a simple tap.
- Update URL card cells to reflect link clickability through mouse cursor changes based on platform and keyboard state.