### PR TITLE
feat: add OIDC/SSO enterprise login support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ frontend/*.deb
 **/Cargo.toml.bak
 
 **/.cargo/**
+
+# ignore custom build scripts
+build_dockers.sh

--- a/frontend/appflowy_flutter/lib/user/application/auth/af_cloud_auth_service.dart
+++ b/frontend/appflowy_flutter/lib/user/application/auth/af_cloud_auth_service.dart
@@ -139,6 +139,8 @@ extension ProviderTypePBExtension on ProviderTypePB {
         return ProviderTypePB.Discord;
       case 'apple':
         return ProviderTypePB.Apple;
+      case 'sso':
+        return ProviderTypePB.Oidc;
       default:
         throw UnimplementedError();
     }

--- a/frontend/appflowy_flutter/lib/user/application/auth/af_cloud_auth_service.dart
+++ b/frontend/appflowy_flutter/lib/user/application/auth/af_cloud_auth_service.dart
@@ -139,6 +139,11 @@ extension ProviderTypePBExtension on ProviderTypePB {
         return ProviderTypePB.Discord;
       case 'apple':
         return ProviderTypePB.Apple;
+      // The UI SSO button emits 'sso' as the provider string. We map it to
+      // ProviderTypePB.Oidc because GoTrue's /sso endpoint handles both SAML
+      // and OIDC via domain-based routing. The backend AuthProvider enum uses
+      // the canonical name 'oidc', so this client-side mapping bridges the
+      // UI label to the correct backend variant.
       case 'sso':
         return ProviderTypePB.Oidc;
       default:

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
@@ -57,7 +57,7 @@ enum ThirdPartySignInButtonType {
       case ThirdPartySignInButtonType.discord:
         return LocaleKeys.signIn_signInWithDiscord.tr();
       case ThirdPartySignInButtonType.sso:
-        return 'Enterprise Login (SSO)';
+        return LocaleKeys.signIn_signInWithSSO.tr();
       case ThirdPartySignInButtonType.anonymous:
         return 'Anonymous session';
     }

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
@@ -9,6 +9,7 @@ enum ThirdPartySignInButtonType {
   google,
   github,
   discord,
+  sso,
   anonymous;
 
   String get provider {
@@ -21,6 +22,8 @@ enum ThirdPartySignInButtonType {
         return 'github';
       case ThirdPartySignInButtonType.discord:
         return 'discord';
+      case ThirdPartySignInButtonType.sso:
+        return 'sso';
       case ThirdPartySignInButtonType.anonymous:
         throw UnsupportedError('Anonymous session does not have a provider');
     }
@@ -36,6 +39,8 @@ enum ThirdPartySignInButtonType {
         return FlowySvgs.m_github_icon_xl;
       case ThirdPartySignInButtonType.discord:
         return FlowySvgs.m_discord_icon_xl;
+      case ThirdPartySignInButtonType.sso:
+        return FlowySvgs.shield_check_s;
       case ThirdPartySignInButtonType.anonymous:
         return FlowySvgs.m_discord_icon_xl;
     }
@@ -51,6 +56,8 @@ enum ThirdPartySignInButtonType {
         return LocaleKeys.signIn_signInWithGithub.tr();
       case ThirdPartySignInButtonType.discord:
         return LocaleKeys.signIn_signInWithDiscord.tr();
+      case ThirdPartySignInButtonType.sso:
+        return 'Enterprise Login (SSO)';
       case ThirdPartySignInButtonType.anonymous:
         return 'Anonymous session';
     }
@@ -65,6 +72,7 @@ enum ThirdPartySignInButtonType {
       case ThirdPartySignInButtonType.google:
       case ThirdPartySignInButtonType.github:
       case ThirdPartySignInButtonType.discord:
+      case ThirdPartySignInButtonType.sso:
       case ThirdPartySignInButtonType.anonymous:
         return isDarkMode ? Colors.black : Colors.grey.shade100;
     }
@@ -78,6 +86,7 @@ enum ThirdPartySignInButtonType {
       case ThirdPartySignInButtonType.google:
       case ThirdPartySignInButtonType.github:
       case ThirdPartySignInButtonType.discord:
+      case ThirdPartySignInButtonType.sso:
       case ThirdPartySignInButtonType.anonymous:
         return isDarkMode ? Colors.white : Colors.black;
     }

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_buttons.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_buttons.dart
@@ -19,19 +19,26 @@ class ThirdPartySignInButtons extends StatelessWidget {
   const ThirdPartySignInButtons({
     super.key,
     this.expanded = false,
+    this.showSSO = false,
   });
 
   final bool expanded;
+
+  /// Whether to show the Enterprise Login (SSO) button.
+  /// Set to true only in deployments that have OIDC/SAML configured.
+  final bool showSSO;
 
   @override
   Widget build(BuildContext context) {
     if (UniversalPlatform.isDesktopOrWeb) {
       return _DesktopThirdPartySignIn(
+        showSSO: showSSO,
         onSignIn: (type) => _signIn(context, type.provider),
       );
     } else {
       return _MobileThirdPartySignIn(
         isExpanded: expanded,
+        showSSO: showSSO,
         onSignIn: (type) => _signIn(context, type.provider),
       );
     }
@@ -47,9 +54,11 @@ class ThirdPartySignInButtons extends StatelessWidget {
 class _DesktopThirdPartySignIn extends StatefulWidget {
   const _DesktopThirdPartySignIn({
     required this.onSignIn,
+    this.showSSO = false,
   });
 
   final _SignInCallback onSignIn;
+  final bool showSSO;
 
   @override
   State<_DesktopThirdPartySignIn> createState() =>
@@ -74,11 +83,13 @@ class _DesktopThirdPartySignInState extends State<_DesktopThirdPartySignIn> {
           type: ThirdPartySignInButtonType.apple,
           onTap: () => widget.onSignIn(ThirdPartySignInButtonType.apple),
         ),
-        VSpace(theme.spacing.l),
-        DesktopThirdPartySignInButton(
-          type: ThirdPartySignInButtonType.sso,
-          onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
-        ),
+        if (widget.showSSO) ...[
+          VSpace(theme.spacing.l),
+          DesktopThirdPartySignInButton(
+            type: ThirdPartySignInButtonType.sso,
+            onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
+          ),
+        ],
         ...isExpanded ? _buildExpandedButtons() : _buildCollapsedButtons(),
       ],
     );
@@ -127,10 +138,12 @@ class _MobileThirdPartySignIn extends StatefulWidget {
   const _MobileThirdPartySignIn({
     required this.isExpanded,
     required this.onSignIn,
+    this.showSSO = false,
   });
 
   final bool isExpanded;
   final _SignInCallback onSignIn;
+  final bool showSSO;
 
   @override
   State<_MobileThirdPartySignIn> createState() =>
@@ -166,11 +179,13 @@ class _MobileThirdPartySignInState extends State<_MobileThirdPartySignIn> {
           type: ThirdPartySignInButtonType.google,
           onTap: () => widget.onSignIn(ThirdPartySignInButtonType.google),
         ),
-        const VSpace(padding),
-        MobileThirdPartySignInButton(
-          type: ThirdPartySignInButtonType.sso,
-          onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
-        ),
+        if (widget.showSSO) ...[
+          const VSpace(padding),
+          MobileThirdPartySignInButton(
+            type: ThirdPartySignInButtonType.sso,
+            onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
+          ),
+        ],
         ...isExpanded ? _buildExpandedButtons() : _buildCollapsedButtons(),
       ],
     );

--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_buttons.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_buttons.dart
@@ -74,6 +74,11 @@ class _DesktopThirdPartySignInState extends State<_DesktopThirdPartySignIn> {
           type: ThirdPartySignInButtonType.apple,
           onTap: () => widget.onSignIn(ThirdPartySignInButtonType.apple),
         ),
+        VSpace(theme.spacing.l),
+        DesktopThirdPartySignInButton(
+          type: ThirdPartySignInButtonType.sso,
+          onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
+        ),
         ...isExpanded ? _buildExpandedButtons() : _buildCollapsedButtons(),
       ],
     );
@@ -160,6 +165,11 @@ class _MobileThirdPartySignInState extends State<_MobileThirdPartySignIn> {
           key: signInWithGoogleButtonKey,
           type: ThirdPartySignInButtonType.google,
           onTap: () => widget.onSignIn(ThirdPartySignInButtonType.google),
+        ),
+        const VSpace(padding),
+        MobileThirdPartySignInButton(
+          type: ThirdPartySignInButtonType.sso,
+          onTap: () => widget.onSignIn(ThirdPartySignInButtonType.sso),
         ),
         ...isExpanded ? _buildExpandedButtons() : _buildCollapsedButtons(),
       ],

--- a/frontend/resources/translations/en-US.json
+++ b/frontend/resources/translations/en-US.json
@@ -54,6 +54,7 @@
     "signInWithGoogle": "Continue with Google",
     "signInWithGithub": "Continue with GitHub",
     "signInWithDiscord": "Continue with Discord",
+    "signInWithSSO": "Enterprise Login (SSO)",
     "signInWithApple": "Continue with Apple",
     "continueAnotherWay": "Continue another way",
     "signUpWithGoogle": "Sign up with Google",

--- a/frontend/resources/translations/it-IT.json
+++ b/frontend/resources/translations/it-IT.json
@@ -54,6 +54,7 @@
     "signInWithGoogle": "Continua con Google",
     "signInWithGithub": "Continua con Github",
     "signInWithDiscord": "Continua con Discord",
+    "signInWithSSO": "Accesso Aziendale (SSO)",
     "signInWithApple": "Continua con Apple",
     "continueAnotherWay": "Continua in un altro modo",
     "signUpWithGoogle": "Registrati con Google",

--- a/frontend/rust-lib/Cargo.toml
+++ b/frontend/rust-lib/Cargo.toml
@@ -157,3 +157,9 @@ collab-user = { version = "0.2", git = "https://github.com/AppFlowy-IO/AppFlowy-
 collab-importer = { version = "0.1", git = "https://github.com/AppFlowy-IO/AppFlowy-Collab", rev = "4dfccef" }
 
 langchain-rust = { version = "4.6.0", git = "https://github.com/appflowy/langchain-rust", branch = "af" }
+
+[patch."https://github.com/AppFlowy-IO/AppFlowy-Cloud"]
+client-api = { path = "../../../AppFlowy-Cloud/libs/client-api" }
+client-api-entity = { path = "../../../AppFlowy-Cloud/libs/client-api-entity" }
+workspace-template = { path = "../../../AppFlowy-Cloud/libs/workspace-template" }
+gotrue-entity = { path = "../../../AppFlowy-Cloud/libs/gotrue-entity" }

--- a/frontend/rust-lib/flowy-user/src/entities/auth.rs
+++ b/frontend/rust-lib/flowy-user/src/entities/auth.rs
@@ -192,6 +192,8 @@ pub enum ProviderTypePB {
   Email = 18,
   Phone = 19,
   Zoom = 20,
+  Saml = 21,
+  Oidc = 22,
 }
 
 impl ProviderTypePB {
@@ -218,6 +220,8 @@ impl ProviderTypePB {
       ProviderTypePB::Email => "email",
       ProviderTypePB::Phone => "phone",
       ProviderTypePB::Zoom => "zoom",
+      ProviderTypePB::Saml => "saml",
+      ProviderTypePB::Oidc => "oidc",
     }
   }
 }


### PR DESCRIPTION
- Modified frontend/rust-lib/Cargo.toml to include patch for AppFlowy-Cloud.
- Added Saml and Oidc variants to ProviderTypePB enum in frontend/rust-lib/flowy-user/src/entities/auth.rs.
- Mapped 'sso' to ProviderTypePB.Oidc in af_cloud_auth_service.dart.
- Added 'sso' variant to ThirdPartySignInButtonType enum and updated UI components.
- Integrated SSO login button into the sign-in screens.
- Ignored build_dockers.sh in .gitignore.

<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Add support for enterprise SSO/OIDC login across frontend and Rust user auth, including wiring the new provider type through the sign-in UI and auth service.

New Features:
- Expose a new SSO/enterprise login option in desktop and mobile sign-in screens.
- Introduce an SSO provider type in the Flutter auth layer mapped to an OIDC provider in the Rust user auth entities.

Enhancements:
- Patch Rust client dependencies to local AppFlowy-Cloud paths for client API and related entities.

Chores:
- Ignore the build_dockers.sh script in version control.