### PR TITLE
fix: prevent crash when mobile workspace list is empty

### DIFF
--- a/frontend/appflowy_flutter/lib/user/presentation/screens/workspace_start_screen/mobile_workspace_start_screen.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/workspace_start_screen/mobile_workspace_start_screen.dart
@@ -37,6 +37,7 @@ class _MobileWorkspaceStartScreenState
     final style = Theme.of(context);
     final size = MediaQuery.of(context).size;
     const double spacing = 16.0;
+    final hasWorkspaces = widget.workspaceState.workspaces.isNotEmpty;
     final List<DropdownMenuEntry<WorkspacePB>> workspaceEntries =
         <DropdownMenuEntry<WorkspacePB>>[];
     for (final WorkspacePB workspace in widget.workspaceState.workspaces) {
@@ -48,7 +49,7 @@ class _MobileWorkspaceStartScreenState
       );
     }
 
-// render the workspace dropdown menu if success, otherwise render error page
+    // render the workspace dropdown menu if success, otherwise render error page
     final body = widget.workspaceState.successOrFailure.fold(
       (_) {
         return Padding(
@@ -106,21 +107,18 @@ class _MobileWorkspaceStartScreenState
                 style: ElevatedButton.styleFrom(
                   minimumSize: const Size(double.infinity, 56),
                 ),
-                onPressed: () {
-                  if (selectedWorkspace == null) {
-                    // If user didn't choose any workspace, pop to the initial workspace(first workspace)
-                    _popToWorkspace(
-                      context,
-                      widget.workspaceState.workspaces.first,
-                    );
-                    return;
-                  }
-                  // pop to the selected workspace
-                  _popToWorkspace(
-                    context,
-                    selectedWorkspace!,
-                  );
-                },
+                onPressed:
+                    hasWorkspaces
+                        ? () {
+                          final workspace =
+                              selectedWorkspace ??
+                              widget.workspaceState.workspaces.first;
+
+                          // If user didn't choose any workspace, pop to the
+                          // initial workspace(first workspace).
+                          _popToWorkspace(context, workspace);
+                        }
+                        : null,
                 child: Text(LocaleKeys.signUp_getStartedText.tr()),
               ),
               const VSpace(spacing),

--- a/frontend/appflowy_flutter/test/widget_test/mobile_workspace_start_screen_test.dart
+++ b/frontend/appflowy_flutter/test/widget_test/mobile_workspace_start_screen_test.dart
@@ -1,0 +1,38 @@
+import 'package:appflowy/user/presentation/screens/workspace_start_screen/mobile_workspace_start_screen.dart';
+import 'package:appflowy/workspace/application/workspace/prelude.dart';
+import 'package:appflowy_result/appflowy_result.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_material_app.dart';
+
+void main() {
+  setUpAll(() async {
+    EasyLocalization.logger.enableLevels = [];
+    await EasyLocalization.ensureInitialized();
+  });
+
+  group('MobileWorkspaceStartScreen', () {
+    testWidgets('disables get started when workspaces are empty', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        WidgetTestApp(
+          child: MobileWorkspaceStartScreen(
+            workspaceState: WorkspaceState(
+              isLoading: false,
+              workspaces: const [],
+              successOrFailure: FlowyResult.success(null),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR prevents a crash in `MobileWorkspaceStartScreen` when the workspace list is empty.

## Root Cause

The `Get Started` button accessed:

`widget.workspaceState.workspaces.first`

when `selectedWorkspace == null`.

If the workspace list was empty, this caused:

`Bad state: No element`

## Changes

* Added a guard to check whether workspaces exist
* Disabled the Get Started button when workspace list is empty
* Preserved existing behavior when workspaces are available
* Added widget test coverage for the empty workspace state

## Testing

* Verified normal flow when workspace exists
* Verified button becomes disabled when workspace list is empty
* Verified no `.first` access occurs on empty lists

#### PR Checklist

* [x] My code adheres to AppFlowy's Conventions
* [ ] I've listed at least one issue that this PR fixes in the description above.
* [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
* [ ] All existing tests are passing.

## Summary by Sourcery

Prevent MobileWorkspaceStartScreen from crashing when the workspace list is empty and add coverage for the empty state.

Bug Fixes:
- Disable the Get Started action when there are no workspaces to avoid accessing the first element of an empty list.

Tests:
- Add a widget test ensuring the Get Started button is disabled when the workspace list is empty.