### PR TITLE
feat: support expanding/collapsing toggle list in read-only mode

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
@@ -187,6 +187,17 @@ class _ToggleListBlockComponentWidgetState
   int? get level => node.attributes[ToggleListBlockKeys.level] as int?;
 
   @override
+  void didUpdateWidget(ToggleListBlockComponentWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldCollapsed =
+        oldWidget.node.attributes[ToggleListBlockKeys.collapsed] as bool? ??
+            false;
+    if (oldCollapsed != collapsed) {
+      _readOnlyCollapsed = null;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return _effectiveCollapsed
         ? buildComponent(context)

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toggle/toggle_block_component.dart
@@ -180,11 +180,15 @@ class _ToggleListBlockComponentWidgetState
 
   bool get collapsed => node.attributes[ToggleListBlockKeys.collapsed] ?? false;
 
+  bool? _readOnlyCollapsed;
+
+  bool get _effectiveCollapsed => _readOnlyCollapsed ?? collapsed;
+
   int? get level => node.attributes[ToggleListBlockKeys.level] as int?;
 
   @override
   Widget build(BuildContext context) {
-    return collapsed
+    return _effectiveCollapsed
         ? buildComponent(context)
         : buildComponentWithChildren(context);
   }
@@ -241,7 +245,7 @@ class _ToggleListBlockComponentWidgetState
       child: Container(
         key: blockComponentKey,
         color: withBackgroundColor ||
-                (backgroundColor != Colors.transparent && collapsed)
+                (backgroundColor != Colors.transparent && _effectiveCollapsed)
             ? backgroundColor
             : null,
         child: child,
@@ -295,7 +299,7 @@ class _ToggleListBlockComponentWidgetState
   Widget _buildPlaceholder() {
     // if the toggle block is collapsed or it contains children, don't show the
     // placeholder.
-    if (collapsed || node.children.isNotEmpty) {
+    if (_effectiveCollapsed || node.children.isNotEmpty) {
       return const SizedBox.shrink();
     }
 
@@ -375,8 +379,8 @@ class _ToggleListBlockComponentWidgetState
     }
 
     final turns = switch (textDirection) {
-      TextDirection.ltr => collapsed ? 0.0 : 0.25,
-      TextDirection.rtl => collapsed ? -0.5 : -0.75,
+      TextDirection.ltr => _effectiveCollapsed ? 0.0 : 0.25,
+      TextDirection.rtl => _effectiveCollapsed ? -0.5 : -0.75,
     };
 
     return Container(
@@ -402,6 +406,12 @@ class _ToggleListBlockComponentWidgetState
   }
 
   Future<void> onCollapsed() async {
+    if (!editorState.editable) {
+      setState(() {
+        _readOnlyCollapsed = !_effectiveCollapsed;
+      });
+      return;
+    }
     final transaction = editorState.transaction
       ..updateNode(node, {
         ToggleListBlockKeys.collapsed: !collapsed,


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Support toggling the collapsed state of toggle list blocks while in read-only mode without persisting changes to the document.

New Features:
- Allow users to expand and collapse toggle list blocks when the editor is not editable.

Enhancements:
- Introduce an internal read-only collapsed state used for rendering and visuals, while preserving the stored collapsed attribute for editable sessions.