### PR TITLE
Document Linux zenity requirement for AppImage installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ AppFlowy is the AI workspace where you achieve more without losing control of yo
 ## User Installation
 
 - [Download AppFlowy Desktop (macOS, Windows, and Linux)](https://github.com/AppFlowy-IO/AppFlowy/releases)
+  - On minimal Linux desktop environments, install `zenity` before using the AppImage or `.tar.gz` archive so AppFlowy's folder picker can open correctly. Flatpak typically includes the required portal integration.
 - Other
   channels: [FlatHub](https://flathub.org/apps/io.appflowy.AppFlowy), [Snapcraft](https://snapcraft.io/appflowy), [Sourceforge](https://sourceforge.net/projects/appflowy/)
 - Available on


### PR DESCRIPTION
## Summary

- Add a Linux installation note that minimal desktop environments may need `zenity` for the folder picker when using AppImage or `.tar.gz` packages.
- Mention that Flatpak typically includes the required portal integration.

Fixes #3973.

## Validation

- `git diff --check`

## Summary by Sourcery

Documentation:
- Add a note explaining that minimal Linux desktop environments may need zenity installed for the folder picker to work with AppImage or .tar.gz packages and that Flatpak usually includes the necessary portal integration.