### PR TITLE
feat: add guillemet auto-formatting (<< and >>) to the document editor

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/format_arrow_character.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/base/format_arrow_character.dart
@@ -10,6 +10,10 @@ const _dashGreater = '→';
 const _hyphen = '-';
 const _emDash = '—'; // This is an em dash — not a single dash - !!
 
+const _leftAngle = '<';
+const _leftGuillemet = '«';
+const _rightGuillemet = '»';
+
 /// format '=' + '>' into an ⇒
 ///
 /// - support
@@ -61,6 +65,46 @@ final CharacterShortcutEvent customFormatDoubleHyphenEmDash =
     editorState: editorState,
     character: _hyphen,
     replacement: _emDash,
+  ),
+);
+
+/// format two left angle brackets into a left guillemet
+///
+/// '<<' into '«'
+///
+/// - support
+///   - desktop
+///   - mobile
+///   - web
+///
+final CharacterShortcutEvent customFormatDoubleAngleLeftGuillemet =
+    CharacterShortcutEvent(
+  key: 'format double left angle bracket into a left guillemet',
+  character: _leftAngle,
+  handler: (editorState) async => _handleDoubleCharacterReplacement(
+    editorState: editorState,
+    character: _leftAngle,
+    replacement: _leftGuillemet,
+  ),
+);
+
+/// format two right angle brackets into a right guillemet
+///
+/// '>>' into '»'
+///
+/// - support
+///   - desktop
+///   - mobile
+///   - web
+///
+final CharacterShortcutEvent customFormatDoubleAngleRightGuillemet =
+    CharacterShortcutEvent(
+  key: 'format double right angle bracket into a right guillemet',
+  character: _greater,
+  handler: (editorState) async => _handleDoubleCharacterReplacement(
+    editorState: editorState,
+    character: _greater,
+    replacement: _rightGuillemet,
   ),
 );
 

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/shortcuts/character_shortcuts.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/shortcuts/character_shortcuts.dart
@@ -46,6 +46,8 @@ List<CharacterShortcutEvent> buildCharacterShortcutEvents(
     customFormatGreaterEqual,
     customFormatDashGreater,
     customFormatDoubleHyphenEmDash,
+    customFormatDoubleAngleLeftGuillemet,
+    customFormatDoubleAngleRightGuillemet,
 
     customFormatNumberToNumberedList,
     customFormatSignToHeading,

--- a/frontend/appflowy_flutter/test/unit_test/document/shortcuts/format_shortcut_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/shortcuts/format_shortcut_test.dart
@@ -99,5 +99,65 @@ void main() {
 
       editorState.dispose();
     });
+
+    test('turn << into «', () async {
+      final document = Document.blank()
+        ..insert([
+          0,
+        ], [
+          paragraphNode(text: '<'),
+        ]);
+
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(path: [0], offset: 1),
+      );
+
+      final result =
+          await customFormatDoubleAngleLeftGuillemet.execute(editorState);
+      expect(result, true);
+
+      expect(editorState.document.root.children.length, 1);
+      final node = editorState.document.root.children[0];
+      expect(node.delta!.toPlainText(), '«');
+
+      // use undo to revert the change
+      undoCommand.execute(editorState);
+      expect(editorState.document.root.children.length, 1);
+      final nodeAfterUndo = editorState.document.root.children[0];
+      expect(nodeAfterUndo.delta!.toPlainText(), '<<');
+
+      editorState.dispose();
+    });
+
+    test('turn >> into »', () async {
+      final document = Document.blank()
+        ..insert([
+          0,
+        ], [
+          paragraphNode(text: '>'),
+        ]);
+
+      final editorState = EditorState(document: document);
+      editorState.selection = Selection.collapsed(
+        Position(path: [0], offset: 1),
+      );
+
+      final result =
+          await customFormatDoubleAngleRightGuillemet.execute(editorState);
+      expect(result, true);
+
+      expect(editorState.document.root.children.length, 1);
+      final node = editorState.document.root.children[0];
+      expect(node.delta!.toPlainText(), '»');
+
+      // use undo to revert the change
+      undoCommand.execute(editorState);
+      expect(editorState.document.root.children.length, 1);
+      final nodeAfterUndo = editorState.document.root.children[0];
+      expect(nodeAfterUndo.delta!.toPlainText(), '>>');
+
+      editorState.dispose();
+    });
   });
 }


### PR DESCRIPTION
### Feature Preview

This adds two unambiguous auto-typography conversions to the document editor, building on the existing `--` → `—`, `->` → `→` and `=>` → `⇒` shortcuts:

- `<<` → `«`
- `>>` → `»`

Both reuse the existing `_handleDoubleCharacterReplacement` helper (so the conversion is undoable) and are registered in `buildCharacterShortcutEvents`. The `>>` handler keys off a preceding `>`, so it does not conflict with the existing `=>` / `->` shortcuts (which look for `=` / `-`) or the `>` + space block-quote toggle.

This is a small first step toward #3322. The other requests in that issue (three-character conversions such as `(c)` → `©`, the ambiguous quote conversions, and an on/off "Advanced settings" toggle) are intentionally left out of this PR and can be handled separately.

Partially addresses #3322

---

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing. <!-- Added unit tests for both conversions; I was not able to run the Flutter test suite locally, so this is left for CI. -->

## Summary by Sourcery

Add new auto-typography shortcuts in the document editor to convert double angle brackets into guillemets and wire them into the existing character shortcut system.

New Features:
- Convert `<<` into the left guillemet character `«` via a character shortcut event in the document editor.
- Convert `>>` into the right guillemet character `»` via a character shortcut event in the document editor.

Tests:
- Add unit tests verifying that `<<` and `>>` are converted to `«` and `»` respectively and that the operations are undoable.