### PR TITLE
Hide raw cloud config errors in settings

### DIFF
--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
@@ -45,10 +45,7 @@ class AppFlowyCloudViewSetting extends StatelessWidget {
             snapshot.connectionState == ConnectionState.done) {
           return snapshot.data!.fold(
             (setting) => _renderContent(context, setting),
-            (err) => FlowyErrorPage.message(
-              LocaleKeys.error_syncError.tr(),
-              howToFix: LocaleKeys.error_syncErrorHint.tr(),
-            ),
+            (err) => _cloudConfigErrorPage(err),
           );
         }
 
@@ -116,10 +113,7 @@ class CustomAppFlowyCloudView extends StatelessWidget {
             snapshot.connectionState == ConnectionState.done) {
           return snapshot.data!.fold(
             (setting) => _renderContent(setting),
-            (err) => FlowyErrorPage.message(
-              LocaleKeys.error_syncError.tr(),
-              howToFix: LocaleKeys.error_syncErrorHint.tr(),
-            ),
+            (err) => _cloudConfigErrorPage(err),
           );
         } else {
           return const Center(
@@ -165,6 +159,31 @@ class CustomAppFlowyCloudView extends StatelessWidget {
       ),
     );
   }
+}
+
+FlowyErrorPage _cloudConfigErrorPage(FlowyError err) {
+  Log.error('Failed to load cloud config: ${err.msg}');
+
+  final isNetworkError = _looksLikeNetworkError(err);
+  return FlowyErrorPage.message(
+    isNetworkError
+        ? LocaleKeys.newSettings_syncState_noNetworkConnected.tr()
+        : LocaleKeys.error_syncError.tr(),
+    howToFix: isNetworkError
+        ? LocaleKeys.error_loadingViewError.tr()
+        : LocaleKeys.error_syncErrorHint.tr(),
+  );
+}
+
+bool _looksLikeNetworkError(FlowyError err) {
+  final message = err.msg.toLowerCase();
+  return message.contains('network') ||
+      message.contains('socket') ||
+      message.contains('connection') ||
+      message.contains('timeout') ||
+      message.contains('timed out') ||
+      message.contains('unavailable') ||
+      message.contains('dns');
 }
 
 class AppFlowyCloudURLs extends StatelessWidget {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/widgets/setting_appflowy_cloud.dart
@@ -45,7 +45,10 @@ class AppFlowyCloudViewSetting extends StatelessWidget {
             snapshot.connectionState == ConnectionState.done) {
           return snapshot.data!.fold(
             (setting) => _renderContent(context, setting),
-            (err) => FlowyErrorPage.message(err.toString(), howToFix: ""),
+            (err) => FlowyErrorPage.message(
+              LocaleKeys.error_syncError.tr(),
+              howToFix: LocaleKeys.error_syncErrorHint.tr(),
+            ),
           );
         }
 
@@ -113,7 +116,10 @@ class CustomAppFlowyCloudView extends StatelessWidget {
             snapshot.connectionState == ConnectionState.done) {
           return snapshot.data!.fold(
             (setting) => _renderContent(setting),
-            (err) => FlowyErrorPage.message(err.toString(), howToFix: ""),
+            (err) => FlowyErrorPage.message(
+              LocaleKeys.error_syncError.tr(),
+              howToFix: LocaleKeys.error_syncErrorHint.tr(),
+            ),
           );
         } else {
           return const Center(


### PR DESCRIPTION
## Summary
- replace raw cloud-config error strings in settings with user-friendly sync error copy
- keep the failure path non-technical when cloud config cannot be loaded

## Why
When settings loads while offline or cloud config fetch fails, the UI should not surface raw backend/internal error text directly to the user.

Related to #8668.

## Validation
- git diff --check

## Notes
- I could not run Dart/Flutter validation locally because this machine does not have `dart` or `flutter` installed.

## Summary by Sourcery

Replace raw cloud configuration error messages in settings with localized, user-friendly sync error copy.

Bug Fixes:
- Prevent internal cloud configuration error strings from being shown directly to users in settings by using generic sync error messaging.

Enhancements:
- Use localized sync error title and hint text on cloud settings error pages instead of raw exception strings.