### PR TITLE
+fix: resolve search box losing focus during find and replace (#8802)

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/find_and_replace/find_and_replace_menu.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/find_and_replace/find_and_replace_menu.dart
@@ -242,6 +242,17 @@ class _FindMenuState extends State<FindMenu> {
   void _searchPattern() {
     widget.searchService.findAndHighlight(textController.text);
     _setState();
+
+    // after update selection, the editor will request focus.
+    // here's a workaround to request the focus back to the text field.
+    Future.delayed(
+      const Duration(milliseconds: 50),
+      () {
+        if (mounted) {
+          widget.focusNode.requestFocus();
+        }
+      },
+    );
   }
 
   void _setState() {


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Bug Fixes:
- Work around the editor refocusing behavior so the search text field regains focus after executing a find-and-highlight action.