### PR TITLE
fix: swap officialVersion labels between en-US and zh-TW translations

### DIFF
--- a/frontend/resources/translations/en-US.json
+++ b/frontend/resources/translations/en-US.json
@@ -635,7 +635,7 @@
         "logoutLabel": "Log out"
       },
       "isUpToDate": "@:appName is up to date!",
-      "officialVersion": "Version {version} (官方構建)"
+      "officialVersion": "Version {version} (Official build)"
     },
     "workspacePage": {
       "menuLabel": "Workspace",

--- a/frontend/resources/translations/zh-TW.json
+++ b/frontend/resources/translations/zh-TW.json
@@ -635,7 +635,7 @@
         "logoutLabel": "登出"
       },
       "isUpToDate": "@:appName 已更新!",
-      "officialVersion": "版本 {version} (Official build)"
+      "officialVersion": "版本 {version} (官方構建)"
     },
     "workspacePage": {
       "menuLabel": "工作區",


### PR DESCRIPTION
## What

The `officialVersion` translation strings in `en-US.json` and `zh-TW.json` are swapped:

| File | Before (incorrect) | After (correct) |
|------|-------------------|-----------------|
| `en-US.json` | `Version {version} (官方構建)` | `Version {version} (Official build)` |
| `zh-TW.json` | `版本 {version} (Official build)` | `版本 {version} (官方構建)` |

English-locale users see a Chinese string in the About dialog, and Traditional Chinese users see an English string — the labels were placed in the wrong locale files.

## How to reproduce

Build AppFlowy with an English locale and open **Settings → About AppFlowy**. The version line shows `Version x.y.z (官方構建)` instead of `Version x.y.z (Official build)`.

## Summary by Sourcery

Bug Fixes:
- Fix swapped `officialVersion` translation strings between en-US and zh-TW so each locale displays the correct language label.