### PR TITLE
feat:added spacing choose activity options

### DIFF
--- a/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
+++ b/frontend/appflowy_flutter/lib/user/presentation/screens/sign_in_screen/widgets/third_party_sign_in_button/third_party_sign_in_button.dart
@@ -110,10 +110,12 @@ class MobileThirdPartySignInButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
     return AFOutlinedIconTextButton.normal(
       text: type.labelText,
       onTap: onTap,
       size: AFButtonSize.l,
+      iconGap: theme.spacing.m,
       iconBuilder: (context, isHovering, disabled) {
         return FlowySvg(
           type.icon,
@@ -137,10 +139,12 @@ class DesktopThirdPartySignInButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = AppFlowyTheme.of(context);
     return AFOutlinedIconTextButton.normal(
       text: type.labelText,
       onTap: onTap,
       size: AFButtonSize.l,
+      iconGap: theme.spacing.m,
       iconBuilder: (context, isHovering, disabled) {
         return FlowySvg(
           type.icon,

--- a/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/button/outlined_button/outlined_icon_text_button.dart
+++ b/frontend/appflowy_flutter/packages/appflowy_ui/lib/src/component/button/outlined_button/outlined_icon_text_button.dart
@@ -20,6 +20,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
     this.size = AFButtonSize.m,
     this.padding,
     this.borderRadius,
+    this.iconGap,
     this.disabled = false,
     this.alignment = MainAxisAlignment.center,
   });
@@ -33,6 +34,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
     AFButtonSize size = AFButtonSize.m,
     EdgeInsetsGeometry? padding,
     double? borderRadius,
+    double? iconGap,
     bool disabled = false,
     MainAxisAlignment alignment = MainAxisAlignment.center,
   }) {
@@ -44,6 +46,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
       size: size,
       padding: padding,
       borderRadius: borderRadius,
+      iconGap: iconGap,
       disabled: disabled,
       alignment: alignment,
       borderColor: (context, isHovering, disabled, isFocused) {
@@ -88,6 +91,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
     AFButtonSize size = AFButtonSize.m,
     EdgeInsetsGeometry? padding,
     double? borderRadius,
+    double? iconGap,
     bool disabled = false,
     MainAxisAlignment alignment = MainAxisAlignment.center,
   }) {
@@ -99,6 +103,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
       size: size,
       padding: padding,
       borderRadius: borderRadius,
+      iconGap: iconGap,
       disabled: disabled,
       alignment: alignment,
       borderColor: (context, isHovering, disabled, isFocused) {
@@ -138,6 +143,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
     AFButtonSize size = AFButtonSize.m,
     EdgeInsetsGeometry? padding,
     double? borderRadius,
+    double? iconGap,
     MainAxisAlignment alignment = MainAxisAlignment.center,
   }) {
     return AFOutlinedIconTextButton._(
@@ -148,6 +154,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
       size: size,
       padding: padding,
       borderRadius: borderRadius,
+      iconGap: iconGap,
       disabled: true,
       alignment: alignment,
       textColor: (context, isHovering, disabled) {
@@ -185,6 +192,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
   final AFButtonSize size;
   final EdgeInsetsGeometry? padding;
   final double? borderRadius;
+  final double? iconGap;
   final MainAxisAlignment alignment;
 
   final AFOutlinedIconBuilder iconBuilder;
@@ -211,7 +219,7 @@ class AFOutlinedIconTextButton extends StatelessWidget {
           mainAxisAlignment: alignment,
           children: [
             iconBuilder(context, isHovering, disabled),
-            SizedBox(width: theme.spacing.s),
+            SizedBox(width: iconGap ?? theme.spacing.s),
             Text(
               text,
               style: size.buildTextStyle(context).copyWith(


### PR DESCRIPTION
fixes #8042 

Properly added spacing in the "choose activity" of up menu during sign in

## Summary by Sourcery

Adjust spacing between icons and text in outlined icon text buttons and apply consistent spacing to third-party sign-in buttons on the sign-in screen.

Enhancements:
- Add configurable icon-text gap to AFOutlinedIconTextButton with a sensible default based on the theme spacing.
- Use the new configurable icon gap to standardize spacing in mobile and desktop third-party sign-in buttons during sign-in.