### PR TITLE
feat(editor): add copy text action for toggle and list blocks

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_configuration.dart
@@ -167,6 +167,7 @@ List<OptionAction> _buildOptionActions(BuildContext context, String type) {
     standardActions.add(OptionAction.copyLinkToBlock);
   }
 
+  standardActions.add(OptionAction.copyText);
   standardActions.add(OptionAction.turnInto);
 
   if (SimpleTableBlockKeys.type == type) {

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_cubit.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/block_action_option_cubit.dart
@@ -44,6 +44,9 @@ class BlockActionOptionCubit extends Cubit<BlockActionOptionState> {
       case OptionAction.copyLinkToBlock:
         await _copyLinkToBlock(node);
         break;
+      case OptionAction.copyText:
+        await _copyText(node);
+        break;
       case OptionAction.setToPageWidth:
         await _setToPageWidth(node);
         break;
@@ -257,6 +260,29 @@ class BlockActionOptionCubit extends Cubit<BlockActionOptionState> {
     );
 
     emit(BlockActionOptionState()); // Emit a new state to trigger UI update
+  }
+
+  Future<void> _copyText(Node node) async {
+    List<Node> nodes = [node];
+
+    final selection = editorState.selection;
+    final selectionType = editorState.selectionType;
+    
+    if (selectionType == SelectionType.block && selection != null) {
+      nodes = editorState.getNodesInSelection(selection.normalized);
+    }
+
+    final text = nodes.map((n) {
+      final delta = n.delta;
+      if (delta == null) return '';
+      return delta.toPlainText();
+    }).join('\n');
+
+    await getIt<ClipboardService>().setData(
+      ClipboardServiceData(plainText: text),
+    );
+
+    emit(BlockActionOptionState());
   }
 
   static Future<bool> turnIntoBlock(

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option/option_actions.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/actions/option/option_actions.dart
@@ -64,7 +64,7 @@ enum OptionAction {
   moveUp,
   moveDown,
   copyLinkToBlock,
-
+  copyText,
   /// callout background color
   color,
   divider,
@@ -99,6 +99,8 @@ enum OptionAction {
         return FlowySvgs.tag_s;
       case OptionAction.copyLinkToBlock:
         return FlowySvgs.share_tab_copy_s;
+      case OptionAction.copyText:            
+        return FlowySvgs.text_s;
       case OptionAction.setToPageWidth:
         return FlowySvgs.table_set_to_page_width_s;
       case OptionAction.distributeColumnsEvenly:
@@ -126,6 +128,8 @@ enum OptionAction {
         return LocaleKeys.document_plugins_optionAction_depth.tr();
       case OptionAction.copyLinkToBlock:
         return LocaleKeys.document_plugins_optionAction_copyLinkToBlock.tr();
+      case OptionAction.copyText:
+        return 'Copy text';
       case OptionAction.divider:
         throw UnsupportedError('Divider does not have description');
       case OptionAction.setToPageWidth:


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

Adds a "Copy text" action to the block menu for toggle, bulleted list, and numbered list blocks.

Users can copy the block text directly from the 3-dot menu, similar to Notion.

Fixes #8800


---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [x] All existing tests are passing.

## Summary by Sourcery

Add a block menu action to copy the plain text content of selected blocks in the editor.

New Features:
- Introduce a Copy text option in the block action menu for applicable editor blocks to copy their text content to the clipboard.

Enhancements:
- Ensure Copy text operates on the current block or all blocks in a block selection and normalizes their text content before copying.