### PR TITLE
chore: revert en-US i18n change

### DIFF
--- a/frontend/resources/translations/en-US.json
+++ b/frontend/resources/translations/en-US.json
@@ -635,7 +635,7 @@
         "logoutLabel": "Log out"
       },
       "isUpToDate": "@:appName is up to date!",
-      "officialVersion": "Version {version} (官方構建)"
+      "officialVersion": "Version {version} (Official build)"
     },
     "workspacePage": {
       "menuLabel": "Workspace",


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to AppFlowy. The team will dedicate their best efforts to reviewing and approving your pull request. If you have any questions about the project or feedback for us, please join our [Discord](https://discord.gg/wdjWUXXhtw).
-->

<!---
If your pull request adds a new feature, please drag and drop a video into this section to showcase what you've done! If not, you may delete this section.
-->

### Feature Preview

<!---
List at least one issue here that this PR addresses. If it fixes the issue, please use the [fixes](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) keyword to close the issue. For example:
fixes https://github.com/AppFlowy-IO/AppFlowy/pull/2106
-->

---

<!---
Before you mark this PR ready for review, run through this checklist!
-->

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [ ] I've listed at least one issue that this PR fixes in the description above.
- [ ] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing.

## Summary by Sourcery

Enhancements:
- Restore the prior en-US JSON translation content by reverting a recent localization update.