### PR TITLE
docs: update translation editor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ the community, **Congratulations!** You are now an official contributor to AppFl
 
 ## Translations 🌎🗺
 
-[![translation badge](https://inlang.com/badge?url=github.com/AppFlowy-IO/AppFlowy)](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy?ref=badge)
+[Translate AppFlowy with Fink](https://fink.inlang.com/github.com/AppFlowy-IO/AppFlowy?ref=badge)
 
 To add translations, you can manually edit the JSON translation files in `/frontend/resources/translations`, use
-the [inlang online editor](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy), or
+the [Fink online editor](https://fink.inlang.com/github.com/AppFlowy-IO/AppFlowy), or
 run `npx inlang machine translate` to add missing translations.
 
 ## Join the community to build AppFlowy together


### PR DESCRIPTION
## Summary

- replace the broken Inlang badge/editor links in the README translation section with the current Fink workspace URL
- remove the dead badge image because the Inlang badge endpoint now returns 404

Fixes #8849.

## Source proof

- README.md linked to https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy?ref=badge and https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy.
- curl -sSIL returned 404 for the old editor URL and 404 for https://inlang.com/badge?url=github.com/AppFlowy-IO/AppFlowy.
- curl -sSIL returned 200 for https://fink.inlang.com/github.com/AppFlowy-IO/AppFlowy.

## Verification

- curl -sSIL https://fink.inlang.com/github.com/AppFlowy-IO/AppFlowy?ref=badge -> 200
- curl -sSIL https://fink.inlang.com/github.com/AppFlowy-IO/AppFlowy -> 200
- rg -n "inlang.com/(badge|editor)|fink.inlang.com|Translations" README.md
- git diff --check

## Summary by Sourcery

Documentation:
- Refresh README translation instructions and links to point to the Fink online editor and remove the obsolete Inlang badge link.