### PR TITLE
feat: show and adjust app zoom level in workspace settings

### DIFF
--- a/frontend/appflowy_flutter/integration_test/desktop/settings/settings_runner.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/settings/settings_runner.dart
@@ -4,6 +4,7 @@ import 'notifications_settings_test.dart' as notifications_settings_test;
 import 'settings_billing_test.dart' as settings_billing_test;
 import 'shortcuts_settings_test.dart' as shortcuts_settings_test;
 import 'sign_in_page_settings_test.dart' as sign_in_page_settings_test;
+import 'workspace_zoom_test.dart' as workspace_zoom_test;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -12,4 +13,5 @@ void main() {
   settings_billing_test.main();
   shortcuts_settings_test.main();
   sign_in_page_settings_test.main();
+  workspace_zoom_test.main();
 }

--- a/frontend/appflowy_flutter/integration_test/desktop/settings/workspace_zoom_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/settings/workspace_zoom_test.dart
@@ -1,0 +1,53 @@
+import 'package:appflowy/startup/tasks/app_window_size_manager.dart';
+import 'package:appflowy/workspace/application/settings/settings_dialog_bloc.dart';
+import 'package:appflowy/workspace/presentation/home/hotkeys.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../shared/util.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('App zoom setting:', () {
+    Future<void> resetAppFlowyScaleFactor(
+      WindowSizeManager windowSizeManager,
+    ) async {
+      appflowyScaleFactor = 1.0;
+      await windowSizeManager.setScaleFactor(1.0);
+    }
+
+    testWidgets('zoom in, out and reset from the workspace settings',
+        (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      // this value can't be defined in the setUp method, because the
+      // windowSizeManager is not initialized yet.
+      final windowSizeManager = WindowSizeManager();
+      await resetAppFlowyScaleFactor(windowSizeManager);
+
+      await tester.openSettings();
+      await tester.openSettingsPage(SettingsPage.workspace);
+      await tester.pumpAndSettle();
+
+      // zoom in twice -> 120%
+      for (var i = 0; i < 2; i++) {
+        await tester.tapButton(find.byKey(const Key('ZoomIncreaseButton')));
+      }
+      expect(appflowyScaleFactor, 1.2);
+      expect(await windowSizeManager.getScaleFactor(), 1.2);
+
+      // zoom out once -> 110%
+      await tester.tapButton(find.byKey(const Key('ZoomDecreaseButton')));
+      expect(appflowyScaleFactor, 1.1);
+      expect(await windowSizeManager.getScaleFactor(), 1.1);
+
+      // reset -> 100%
+      await tester.tapButton(find.byKey(const Key('ZoomResetButton')));
+      expect(appflowyScaleFactor, 1.0);
+      expect(await windowSizeManager.getScaleFactor(), 1.0);
+    });
+  });
+}

--- a/frontend/appflowy_flutter/integration_test/desktop/settings/workspace_zoom_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/settings/workspace_zoom_test.dart
@@ -2,8 +2,11 @@ import 'package:appflowy/startup/tasks/app_window_size_manager.dart';
 import 'package:appflowy/workspace/application/settings/settings_dialog_bloc.dart';
 import 'package:appflowy/workspace/presentation/home/hotkeys.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:universal_platform/universal_platform.dart';
 
 import '../../shared/util.dart';
 
@@ -14,7 +17,7 @@ void main() {
     Future<void> resetAppFlowyScaleFactor(
       WindowSizeManager windowSizeManager,
     ) async {
-      appflowyScaleFactor = 1.0;
+      appflowyScaleFactor.value = 1.0;
       await windowSizeManager.setScaleFactor(1.0);
     }
 
@@ -36,18 +39,54 @@ void main() {
       for (var i = 0; i < 2; i++) {
         await tester.tapButton(find.byKey(const Key('ZoomIncreaseButton')));
       }
-      expect(appflowyScaleFactor, 1.2);
+      expect(appflowyScaleFactor.value, 1.2);
       expect(await windowSizeManager.getScaleFactor(), 1.2);
 
       // zoom out once -> 110%
       await tester.tapButton(find.byKey(const Key('ZoomDecreaseButton')));
-      expect(appflowyScaleFactor, 1.1);
+      expect(appflowyScaleFactor.value, 1.1);
       expect(await windowSizeManager.getScaleFactor(), 1.1);
 
       // reset -> 100%
       await tester.tapButton(find.byKey(const Key('ZoomResetButton')));
-      expect(appflowyScaleFactor, 1.0);
+      expect(appflowyScaleFactor.value, 1.0);
       expect(await windowSizeManager.getScaleFactor(), 1.0);
+    });
+
+    testWidgets(
+        'the displayed zoom level updates when zoom is changed via hotkey '
+        'while the settings page is open', (tester) async {
+      await tester.initializeAppFlowy();
+      await tester.tapAnonymousSignInButton();
+
+      final windowSizeManager = WindowSizeManager();
+      await resetAppFlowyScaleFactor(windowSizeManager);
+
+      await tester.openSettings();
+      await tester.openSettingsPage(SettingsPage.workspace);
+      await tester.pumpAndSettle();
+
+      expect(find.text('100%'), findsOneWidget);
+
+      // zoom in via the hotkey (not the settings buttons) while the
+      // settings page is still open, and confirm the label updates.
+      final keycode = zoomInKeyCodes.firstWhere(
+        (keycode) =>
+            !UniversalPlatform.isLinux ||
+            keycode.logicalKey != LogicalKeyboardKey.add,
+      );
+      await tester.simulateKeyEvent(
+        keycode.logicalKey,
+        isControlPressed: !UniversalPlatform.isMacOS,
+        isMetaPressed: UniversalPlatform.isMacOS,
+        physicalKey: keycode.logicalKey == LogicalKeyboardKey.add
+            ? PhysicalKeyboardKey.equal
+            : null,
+      );
+      await tester.pumpAndSettle();
+
+      expect(appflowyScaleFactor.value, 1.1);
+      expect(find.text('110%'), findsOneWidget);
     });
   });
 }

--- a/frontend/appflowy_flutter/integration_test/desktop/uncategorized/zoom_in_out_test.dart
+++ b/frontend/appflowy_flutter/integration_test/desktop/uncategorized/zoom_in_out_test.dart
@@ -16,7 +16,7 @@ void main() {
     Future<void> resetAppFlowyScaleFactor(
       WindowSizeManager windowSizeManager,
     ) async {
-      appflowyScaleFactor = 1.0;
+      appflowyScaleFactor.value = 1.0;
       await windowSizeManager.setScaleFactor(1.0);
     }
 
@@ -61,7 +61,7 @@ void main() {
           );
 
           final scaleFactor = await windowSizeManager.getScaleFactor();
-          expect(currentScaleFactor, appflowyScaleFactor);
+          expect(currentScaleFactor, appflowyScaleFactor.value);
           expect(currentScaleFactor, scaleFactor);
         }
       }
@@ -82,7 +82,7 @@ void main() {
         await tester.pumpAndSettle();
 
         final scaleFactor = await windowSizeManager.getScaleFactor();
-        expect(1.0, appflowyScaleFactor);
+        expect(1.0, appflowyScaleFactor.value);
         expect(1.0, scaleFactor);
       }
     });
@@ -116,7 +116,7 @@ void main() {
           currentScaleFactor -= 0.1;
 
           final scaleFactor = await windowSizeManager.getScaleFactor();
-          expect(currentScaleFactor, appflowyScaleFactor);
+          expect(currentScaleFactor, appflowyScaleFactor.value);
           expect(currentScaleFactor, scaleFactor);
         }
       }

--- a/frontend/appflowy_flutter/integration_test/mobile/settings/scale_factor_test.dart
+++ b/frontend/appflowy_flutter/integration_test/mobile/settings/scale_factor_test.dart
@@ -31,18 +31,18 @@ void main() {
       matching: find.byType(Slider),
     );
     await tester.slideToValue(slider, 0.8);
-    expect(appflowyScaleFactor, 0.8);
+    expect(appflowyScaleFactor.value, 0.8);
 
     await tester.slideToValue(slider, 0.9);
-    expect(appflowyScaleFactor, 0.9);
+    expect(appflowyScaleFactor.value, 0.9);
 
     await tester.slideToValue(slider, 1.0);
-    expect(appflowyScaleFactor, 1.0);
+    expect(appflowyScaleFactor.value, 1.0);
 
     await tester.slideToValue(slider, 1.1);
-    expect(appflowyScaleFactor, 1.1);
+    expect(appflowyScaleFactor.value, 1.1);
 
     await tester.slideToValue(slider, 1.2);
-    expect(appflowyScaleFactor, 1.2);
+    expect(appflowyScaleFactor.value, 1.2);
   });
 }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/text_scale_setting.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/text_scale_setting.dart
@@ -1,13 +1,11 @@
 import 'package:appflowy/generated/locale_keys.g.dart';
 import 'package:appflowy/mobile/presentation/bottom_sheet/bottom_sheet.dart';
 import 'package:appflowy/mobile/presentation/setting/widgets/mobile_setting_trailing.dart';
-import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/startup/tasks/app_window_size_manager.dart';
 import 'package:appflowy/workspace/presentation/home/hotkeys.dart';
 import 'package:appflowy/workspace/presentation/widgets/more_view_actions/widgets/font_size_stepper.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:scaled_app/scaled_app.dart';
 
 import '../setting.dart';
 
@@ -71,20 +69,11 @@ class _DisplaySizeSettingState extends State<DisplaySizeSetting> {
   }
 
   Future<void> _setScale(double value) async {
-    if (FlowyRunner.currentMode == IntegrationMode.integrationTest) {
-      // The integration test will fail if we check the scale factor in the test.
-      // #0      ScaledWidgetsFlutterBinding.Eval ()
-      // #1      ScaledWidgetsFlutterBinding.instance (package:scaled_app/scaled_app.dart:66:62)
-      // ignore: invalid_use_of_visible_for_testing_member
-      appflowyScaleFactor = value;
-    } else {
-      ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => value;
-    }
+    await applyAppScaleFactor(value);
     if (mounted) {
       setState(() {
         scaleFactor = value;
       });
     }
-    await windowSizeManager.setScaleFactor(value);
   }
 }

--- a/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/text_scale_setting.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/setting/appearance/text_scale_setting.dart
@@ -69,11 +69,11 @@ class _DisplaySizeSettingState extends State<DisplaySizeSetting> {
   }
 
   Future<void> _setScale(double value) async {
-    await applyAppScaleFactor(value);
     if (mounted) {
       setState(() {
         scaleFactor = value;
       });
     }
+    await applyAppScaleFactor(value);
   }
 }

--- a/frontend/appflowy_flutter/lib/startup/tasks/windows.dart
+++ b/frontend/appflowy_flutter/lib/startup/tasks/windows.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:appflowy/startup/startup.dart';
 import 'package:appflowy/startup/tasks/app_window_size_manager.dart';
+import 'package:appflowy/workspace/presentation/home/hotkeys.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/material.dart';
 import 'package:scaled_app/scaled_app.dart';
@@ -27,6 +28,7 @@ class InitAppWindowTask extends LaunchTask with WindowListener {
     if (UniversalPlatform.isMobile) {
       final scale = await windowSizeManager.getScaleFactor();
       ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => scale;
+      appflowyScaleFactor.value = scale;
       return;
     }
 
@@ -80,9 +82,10 @@ class InitAppWindowTask extends LaunchTask with WindowListener {
     }
 
     unawaited(
-      windowSizeManager.getScaleFactor().then(
-            (v) => ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => v,
-          ),
+      windowSizeManager.getScaleFactor().then((v) {
+        ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => v;
+        appflowyScaleFactor.value = v;
+      }),
     );
   }
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -28,25 +28,34 @@ final zoomOutKeyCodes = [KeyCode.minus, KeyCode.numpadSubtract];
 @visibleForTesting
 final resetZoomKeyCodes = [KeyCode.digit0, KeyCode.numpad0];
 
-// Use a global value to store the zoom level and update it in the hotkeys.
-@visibleForTesting
-double appflowyScaleFactor = 1.0;
+// Use a global notifier to store the zoom level so any widget (e.g. the
+// workspace settings zoom control) can reflect changes made via hotkeys.
+final ValueNotifier<double> appflowyScaleFactor = ValueNotifier(1.0);
 
 /// Applies [scaleFactor] to the running app and persists it.
 ///
 /// This is the single source of truth for changing the app zoom, shared by the
 /// zoom hotkeys and the zoom control in the workspace settings.
 Future<void> applyAppScaleFactor(double scaleFactor) async {
-  if (FlowyRunner.currentMode == IntegrationMode.integrationTest) {
+  final value = double.parse(
+    scaleFactor
+        .clamp(
+          WindowSizeManager.minScaleFactor,
+          WindowSizeManager.maxScaleFactor,
+        )
+        .toStringAsFixed(2),
+  );
+
+  if (FlowyRunner.currentMode != IntegrationMode.integrationTest) {
     // The integration test will fail if we check the scale factor in the test.
     // #0      ScaledWidgetsFlutterBinding.Eval ()
     // #1      ScaledWidgetsFlutterBinding.instance (package:scaled_app/scaled_app.dart:66:62)
-    appflowyScaleFactor = double.parse(scaleFactor.toStringAsFixed(2));
-  } else {
-    ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => scaleFactor;
+    ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => value;
   }
 
-  await WindowSizeManager().setScaleFactor(scaleFactor);
+  appflowyScaleFactor.value = value;
+
+  await WindowSizeManager().setScaleFactor(value);
 }
 
 /// Helper class that utilizes the global [HotKeyManager] to easily
@@ -256,18 +265,11 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
 
   Future<void> _scaleWithStep(double step) async {
     final currentScaleFactor = await windowSizeManager.getScaleFactor();
+    final requestedScale = currentScaleFactor + step;
 
-    double textScale = (currentScaleFactor + step).clamp(
-      WindowSizeManager.minScaleFactor,
-      WindowSizeManager.maxScaleFactor,
-    );
+    Log.info('scale the app from $currentScaleFactor to $requestedScale');
 
-    // only keep 2 decimal places
-    textScale = double.parse(textScale.toStringAsFixed(2));
-
-    Log.info('scale the app from $currentScaleFactor to $textScale');
-
-    await _scale(textScale);
+    await _scale(requestedScale);
   }
 
   Future<void> _scale(double scaleFactor) => applyAppScaleFactor(scaleFactor);

--- a/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/home/hotkeys.dart
@@ -32,6 +32,23 @@ final resetZoomKeyCodes = [KeyCode.digit0, KeyCode.numpad0];
 @visibleForTesting
 double appflowyScaleFactor = 1.0;
 
+/// Applies [scaleFactor] to the running app and persists it.
+///
+/// This is the single source of truth for changing the app zoom, shared by the
+/// zoom hotkeys and the zoom control in the workspace settings.
+Future<void> applyAppScaleFactor(double scaleFactor) async {
+  if (FlowyRunner.currentMode == IntegrationMode.integrationTest) {
+    // The integration test will fail if we check the scale factor in the test.
+    // #0      ScaledWidgetsFlutterBinding.Eval ()
+    // #1      ScaledWidgetsFlutterBinding.instance (package:scaled_app/scaled_app.dart:66:62)
+    appflowyScaleFactor = double.parse(scaleFactor.toStringAsFixed(2));
+  } else {
+    ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => scaleFactor;
+  }
+
+  await WindowSizeManager().setScaleFactor(scaleFactor);
+}
+
 /// Helper class that utilizes the global [HotKeyManager] to easily
 /// add a [HotKey] with different handlers.
 ///
@@ -253,18 +270,7 @@ class _HomeHotKeysState extends State<HomeHotKeys> {
     await _scale(textScale);
   }
 
-  Future<void> _scale(double scaleFactor) async {
-    if (FlowyRunner.currentMode == IntegrationMode.integrationTest) {
-      // The integration test will fail if we check the scale factor in the test.
-      // #0      ScaledWidgetsFlutterBinding.Eval ()
-      // #1      ScaledWidgetsFlutterBinding.instance (package:scaled_app/scaled_app.dart:66:62)
-      appflowyScaleFactor = double.parse(scaleFactor.toStringAsFixed(2));
-    } else {
-      ScaledWidgetsFlutterBinding.instance.scaleFactor = (_) => scaleFactor;
-    }
-
-    await windowSizeManager.setScaleFactor(scaleFactor);
-  }
+  Future<void> _scale(double scaleFactor) => applyAppScaleFactor(scaleFactor);
 
   void colappsedMenus(BuildContext context) {
     final bloc = context.read<HomeSettingBloc>();

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
@@ -1302,90 +1302,62 @@ class _SelectionColorValueWidget extends StatelessWidget {
   }
 }
 
-class _AppZoomSetting extends StatefulWidget {
+class _AppZoomSetting extends StatelessWidget {
   const _AppZoomSetting();
 
   @override
-  State<_AppZoomSetting> createState() => _AppZoomSettingState();
-}
-
-class _AppZoomSettingState extends State<_AppZoomSetting> {
-  final windowSizeManager = WindowSizeManager();
-
-  double _scaleFactor = 1.0;
-
-  @override
-  void initState() {
-    super.initState();
-    // appflowyScaleFactor isn't seeded from persisted storage at startup, so
-    // read the persisted value first, then stay in sync with any further
-    // changes (e.g. from the zoom hotkeys) via the notifier below.
-    windowSizeManager.getScaleFactor().then((value) {
-      if (value != _scaleFactor && mounted) {
-        setState(() => _scaleFactor = value);
-      }
-    });
-    appflowyScaleFactor.addListener(_onAppScaleFactorChanged);
-  }
-
-  @override
-  void dispose() {
-    appflowyScaleFactor.removeListener(_onAppScaleFactorChanged);
-    super.dispose();
-  }
-
-  void _onAppScaleFactorChanged() {
-    if (mounted) {
-      setState(() => _scaleFactor = appflowyScaleFactor.value);
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final canZoomOut = _scaleFactor > WindowSizeManager.minScaleFactor;
-    final canZoomIn = _scaleFactor < WindowSizeManager.maxScaleFactor;
+    return ValueListenableBuilder<double>(
+      valueListenable: appflowyScaleFactor,
+      builder: (context, scaleFactor, _) {
+        final canZoomOut = scaleFactor > WindowSizeManager.minScaleFactor;
+        final canZoomIn = scaleFactor < WindowSizeManager.maxScaleFactor;
 
-    return SettingListTile(
-      label: LocaleKeys.settings_workspacePage_appZoom_label.tr(),
-      resetButtonKey: const Key('ZoomResetButton'),
-      onResetRequested: () => _setScale(1.0),
-      trailing: [
-        FlowyIconButton(
-          key: const Key('ZoomDecreaseButton'),
-          width: 24,
-          icon: FlowySvg(
-            FlowySvgs.minus_s,
-            color: Theme.of(context).iconTheme.color,
-            size: const Size.square(20),
-          ),
-          hoverColor: Theme.of(context).colorScheme.secondaryContainer,
-          iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
-          onPressed: canZoomOut ? () => _setScale(_scaleFactor - 0.1) : null,
-        ),
-        const HSpace(8),
-        FlowyText.medium(
-          '${(_scaleFactor * 100).round()}%',
-          fontSize: 14,
-        ),
-        const HSpace(8),
-        FlowyIconButton(
-          key: const Key('ZoomIncreaseButton'),
-          width: 24,
-          icon: FlowySvg(
-            FlowySvgs.add_s,
-            color: Theme.of(context).iconTheme.color,
-            size: const Size.square(20),
-          ),
-          hoverColor: Theme.of(context).colorScheme.secondaryContainer,
-          iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
-          onPressed: canZoomIn ? () => _setScale(_scaleFactor + 0.1) : null,
-        ),
-        const HSpace(8),
-      ],
+        return SettingListTile(
+          label: LocaleKeys.settings_workspacePage_appZoom_label.tr(),
+          resetButtonKey: const Key('ZoomResetButton'),
+          onResetRequested: () => applyAppScaleFactor(1.0),
+          trailing: [
+            FlowyIconButton(
+              key: const Key('ZoomDecreaseButton'),
+              width: 24,
+              icon: FlowySvg(
+                FlowySvgs.minus_s,
+                color: Theme.of(context).iconTheme.color,
+                size: const Size.square(20),
+              ),
+              hoverColor: Theme.of(context).colorScheme.secondaryContainer,
+              iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
+              onPressed: canZoomOut
+                  ? () => applyAppScaleFactor(scaleFactor - 0.1)
+                  : null,
+            ),
+            const HSpace(8),
+            FlowyText.medium(
+              '${(scaleFactor * 100).round()}%',
+              fontSize: 14,
+            ),
+            const HSpace(8),
+            FlowyIconButton(
+              key: const Key('ZoomIncreaseButton'),
+              width: 24,
+              icon: FlowySvg(
+                FlowySvgs.add_s,
+                color: Theme.of(context).iconTheme.color,
+                size: const Size.square(20),
+              ),
+              hoverColor: Theme.of(context).colorScheme.secondaryContainer,
+              iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
+              onPressed: canZoomIn
+                  ? () => applyAppScaleFactor(scaleFactor + 0.1)
+                  : null,
+            ),
+            const HSpace(8),
+          ],
+        );
+      },
     );
   }
-
-  Future<void> _setScale(double value) => applyAppScaleFactor(value);
 }
 
 class DocumentPaddingSetting extends StatelessWidget {

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
@@ -7,6 +7,7 @@ import 'package:appflowy/plugins/document/application/document_appearance_cubit.
 import 'package:appflowy/plugins/document/presentation/editor_style.dart';
 import 'package:appflowy/shared/af_role_pb_extension.dart';
 import 'package:appflowy/shared/google_fonts_extension.dart';
+import 'package:appflowy/startup/tasks/app_window_size_manager.dart';
 import 'package:appflowy/util/font_family_extension.dart';
 import 'package:appflowy/workspace/application/appearance_defaults.dart';
 import 'package:appflowy/workspace/application/settings/appearance/appearance_cubit.dart';
@@ -14,6 +15,7 @@ import 'package:appflowy/workspace/application/settings/appearance/base_appearan
 import 'package:appflowy/workspace/application/settings/date_time/date_format_ext.dart';
 import 'package:appflowy/workspace/application/settings/date_time/time_format_ext.dart';
 import 'package:appflowy/workspace/application/settings/workspace/workspace_settings_bloc.dart';
+import 'package:appflowy/workspace/presentation/home/hotkeys.dart';
 import 'package:appflowy/workspace/presentation/home/menu/sidebar/space/shared_widget.dart';
 import 'package:appflowy/workspace/presentation/home/menu/sidebar/workspace/_sidebar_workspace_icon.dart';
 import 'package:appflowy/workspace/presentation/home/toast.dart';
@@ -117,6 +119,11 @@ class SettingsWorkspaceView extends StatelessWidget {
               SettingsCategory(
                 title: LocaleKeys.settings_workspacePage_appearance_title.tr(),
                 children: const [AppearanceSelector()],
+              ),
+              const VSpace(16),
+              SettingsCategory(
+                title: LocaleKeys.settings_workspacePage_appZoom_title.tr(),
+                children: const [_AppZoomSetting()],
               ),
               const VSpace(16),
               // const SettingsCategorySpacer(),
@@ -1292,6 +1299,91 @@ class _SelectionColorValueWidget extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class _AppZoomSetting extends StatefulWidget {
+  const _AppZoomSetting();
+
+  @override
+  State<_AppZoomSetting> createState() => _AppZoomSettingState();
+}
+
+class _AppZoomSettingState extends State<_AppZoomSetting> {
+  final windowSizeManager = WindowSizeManager();
+
+  double _scaleFactor = 1.0;
+
+  @override
+  void initState() {
+    super.initState();
+    windowSizeManager.getScaleFactor().then((value) {
+      if (value != _scaleFactor && mounted) {
+        setState(() => _scaleFactor = value);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canZoomOut = _scaleFactor > WindowSizeManager.minScaleFactor;
+    final canZoomIn = _scaleFactor < WindowSizeManager.maxScaleFactor;
+
+    return SettingListTile(
+      label: LocaleKeys.settings_workspacePage_appZoom_label.tr(),
+      resetButtonKey: const Key('ZoomResetButton'),
+      onResetRequested: () => _setScale(1.0),
+      trailing: [
+        FlowyIconButton(
+          key: const Key('ZoomDecreaseButton'),
+          width: 24,
+          icon: FlowySvg(
+            FlowySvgs.minus_s,
+            color: Theme.of(context).iconTheme.color,
+            size: const Size.square(20),
+          ),
+          hoverColor: Theme.of(context).colorScheme.secondaryContainer,
+          iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
+          onPressed: canZoomOut ? () => _setScale(_scaleFactor - 0.1) : null,
+        ),
+        const HSpace(8),
+        FlowyText.medium(
+          '${(_scaleFactor * 100).round()}%',
+          fontSize: 14,
+        ),
+        const HSpace(8),
+        FlowyIconButton(
+          key: const Key('ZoomIncreaseButton'),
+          width: 24,
+          icon: FlowySvg(
+            FlowySvgs.add_s,
+            color: Theme.of(context).iconTheme.color,
+            size: const Size.square(20),
+          ),
+          hoverColor: Theme.of(context).colorScheme.secondaryContainer,
+          iconColorOnHover: Theme.of(context).colorScheme.onPrimary,
+          onPressed: canZoomIn ? () => _setScale(_scaleFactor + 0.1) : null,
+        ),
+        const HSpace(8),
+      ],
+    );
+  }
+
+  Future<void> _setScale(double value) async {
+    final scaleFactor = double.parse(
+      value
+          .clamp(
+            WindowSizeManager.minScaleFactor,
+            WindowSizeManager.maxScaleFactor,
+          )
+          .toStringAsFixed(2),
+    );
+
+    await applyAppScaleFactor(scaleFactor);
+
+    if (mounted) {
+      setState(() => _scaleFactor = scaleFactor);
+    }
   }
 }
 

--- a/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
+++ b/frontend/appflowy_flutter/lib/workspace/presentation/settings/pages/settings_workspace_view.dart
@@ -1317,11 +1317,27 @@ class _AppZoomSettingState extends State<_AppZoomSetting> {
   @override
   void initState() {
     super.initState();
+    // appflowyScaleFactor isn't seeded from persisted storage at startup, so
+    // read the persisted value first, then stay in sync with any further
+    // changes (e.g. from the zoom hotkeys) via the notifier below.
     windowSizeManager.getScaleFactor().then((value) {
       if (value != _scaleFactor && mounted) {
         setState(() => _scaleFactor = value);
       }
     });
+    appflowyScaleFactor.addListener(_onAppScaleFactorChanged);
+  }
+
+  @override
+  void dispose() {
+    appflowyScaleFactor.removeListener(_onAppScaleFactorChanged);
+    super.dispose();
+  }
+
+  void _onAppScaleFactorChanged() {
+    if (mounted) {
+      setState(() => _scaleFactor = appflowyScaleFactor.value);
+    }
   }
 
   @override
@@ -1369,22 +1385,7 @@ class _AppZoomSettingState extends State<_AppZoomSetting> {
     );
   }
 
-  Future<void> _setScale(double value) async {
-    final scaleFactor = double.parse(
-      value
-          .clamp(
-            WindowSizeManager.minScaleFactor,
-            WindowSizeManager.maxScaleFactor,
-          )
-          .toStringAsFixed(2),
-    );
-
-    await applyAppScaleFactor(scaleFactor);
-
-    if (mounted) {
-      setState(() => _scaleFactor = scaleFactor);
-    }
-  }
+  Future<void> _setScale(double value) => applyAppScaleFactor(value);
 }
 
 class DocumentPaddingSetting extends StatelessWidget {

--- a/frontend/resources/translations/en-US.json
+++ b/frontend/resources/translations/en-US.json
@@ -657,6 +657,10 @@
           "dark": "Dark"
         }
       },
+      "appZoom": {
+        "title": "Zoom",
+        "label": "App zoom level"
+      },
       "resetCursorColor": {
         "title": "Reset document cursor color",
         "description": "Are you sure you want to reset the cursor color?"


### PR DESCRIPTION
### What this does

Fixes #5396.

Right now the app zoom can only be changed with the keyboard (`Cmd/Ctrl` + `+` / `-` / `0`), and the current zoom level isn't shown anywhere. If you've nudged the zoom and lost track of where you are, there's no way to tell without resetting.

This adds a small **Zoom** control to **Settings → Workspace**, right under Appearance. It shows the current zoom as a percentage and lets you step it up/down with `−` / `+` buttons or reset it — using the exact same 0.5×–2.0× range and 0.1 step as the existing shortcuts.

### A small cleanup along the way

The logic that actually applies a scale factor (update the binding, or the test-mode value, then persist it) was copy-pasted in two places — the zoom hotkeys and the mobile display-size setting. Rather than add a third copy for this new control, I pulled it into a single `applyAppScaleFactor()` helper that all three now call. Behaviour is unchanged; it's just one source of truth now.

### How it works

- New `applyAppScaleFactor()` in `hotkeys.dart`, next to the existing `appflowyScaleFactor` state it already owns.
- The hotkey handler and the mobile setting now delegate to it.
- New `_AppZoomSetting` widget in `settings_workspace_view.dart`, built from the same `SettingListTile` / `SettingsResetButton` / `FlowyIconButton` pieces used by the neighbouring settings.
- One new English string pair under `settings.workspacePage.appZoom` in `resources/translations/en-US.json`.

### Feature preview

<!-- I couldn't attach a recording from my current setup — happy to add a short GIF if that's preferred before merge. -->
Settings → Workspace now shows: `App zoom level   [ − ]  100%  [ + ]   ⟲`

### Testing

Added an integration test (`integration_test/desktop/settings/workspace_zoom_test.dart`, registered in `settings_runner.dart`) that opens Workspace settings, taps `+` twice → 120%, `−` once → 110%, reset → 100%, asserting both the live scale factor and the persisted value each step — mirroring the existing `zoom_in_out_test.dart`.

Note: I wasn't able to run the analyzer / test suite locally (my machine's Flutter is ahead of the pinned 3.27.4), so I'm relying on CI for the full check and will fix anything it flags.

### PR checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test to validate the changes in this PR.
- [ ] All existing tests are passing. *(deferring to CI — see the testing note above)*

## Summary by Sourcery

Add a configurable app zoom control to workspace settings and centralize zoom scale application logic.

New Features:
- Expose app zoom level in Workspace settings with controls to increase, decrease, and reset the zoom within the existing supported range.

Enhancements:
- Extract shared applyAppScaleFactor helper to unify how zoom scale changes are applied and persisted across hotkeys, desktop settings, and mobile display size settings.

Tests:
- Add an integration test verifying zoom in/out and reset behavior from workspace settings, including both runtime and persisted scale factors.