### PR TITLE
fix: give row documents a real parent so nested pages keep breadcrumbs

### DIFF
--- a/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/widgets/row_page_button.dart
+++ b/frontend/appflowy_flutter/lib/mobile/presentation/database/card/card_detail/widgets/row_page_button.dart
@@ -138,6 +138,7 @@ class _OpenRowPageButtonState extends State<OpenRowPageButton> {
         name: LocaleKeys.menuAppHeader_defaultNewPageName.tr(),
         viewId: widget.documentId,
         layoutType: ViewLayoutPB.Document,
+        parentViewId: widget.databaseController.viewId,
       );
       view = result.fold((s) => s, (f) => null);
     }

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_document_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_document_bloc.dart
@@ -18,13 +18,14 @@ part 'row_document_bloc.freezed.dart';
 class RowDocumentBloc extends Bloc<RowDocumentEvent, RowDocumentState> {
   RowDocumentBloc({
     required this.rowId,
-    required String viewId,
+    required this.viewId,
   })  : _rowBackendSvc = RowBackendService(viewId: viewId),
         super(RowDocumentState.initial()) {
     _dispatch();
   }
 
   final String rowId;
+  final String viewId;
   final RowBackendService _rowBackendSvc;
 
   void _dispatch() {
@@ -94,12 +95,13 @@ class RowDocumentBloc extends Bloc<RowDocumentEvent, RowDocumentState> {
     );
   }
 
-  Future<ViewPB?> _createRowDocumentView(String viewId) async {
+  Future<ViewPB?> _createRowDocumentView(String documentViewId) async {
     final result = await ViewBackendService.createOrphanView(
-      viewId: viewId,
+      viewId: documentViewId,
       name: LocaleKeys.menuAppHeader_defaultNewPageName.tr(),
       desc: '',
       layoutType: ViewLayoutPB.Document,
+      parentViewId: viewId,
     );
     return result.fold(
       (view) => view,

--- a/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_document_bloc.dart
+++ b/frontend/appflowy_flutter/lib/plugins/database/grid/application/row/row_document_bloc.dart
@@ -95,9 +95,12 @@ class RowDocumentBloc extends Bloc<RowDocumentEvent, RowDocumentState> {
     );
   }
 
-  Future<ViewPB?> _createRowDocumentView(String documentViewId) async {
+  // `rowDocumentViewId` is the id of the row's own document view (becomes the
+  // orphan view's view_id); `viewId` (the bloc's field) is the database view
+  // and is passed as the orphan's parent_view_id for breadcrumb resolution.
+  Future<ViewPB?> _createRowDocumentView(String rowDocumentViewId) async {
     final result = await ViewBackendService.createOrphanView(
-      viewId: documentViewId,
+      viewId: rowDocumentViewId,
       name: LocaleKeys.menuAppHeader_defaultNewPageName.tr(),
       desc: '',
       layoutType: ViewLayoutPB.Document,

--- a/frontend/appflowy_flutter/lib/workspace/application/view/view_service.dart
+++ b/frontend/appflowy_flutter/lib/workspace/application/view/view_service.dart
@@ -83,12 +83,20 @@ class ViewBackendService {
     /// The initial data should be a JSON that represent the DocumentDataPB.
     /// Currently, only support create document with initial data.
     List<int>? initialDataBytes,
+
+    /// The id this orphan view should report as its parent for breadcrumb/
+    /// ancestor purposes. It is never added to that view's visible children.
+    /// Defaults to the orphan view's own id (self-referencing) when omitted.
+    String? parentViewId,
   }) {
     final payload = CreateOrphanViewPayloadPB.create()
       ..viewId = viewId
       ..name = name
       ..layout = layoutType
       ..initialData = initialDataBytes ?? [];
+    if (parentViewId != null) {
+      payload.parentViewId = parentViewId;
+    }
 
     return FolderEventCreateOrphanView(payload).send();
   }

--- a/frontend/rust-lib/event-integration-test/src/folder_event.rs
+++ b/frontend/rust-lib/event-integration-test/src/folder_event.rs
@@ -174,11 +174,26 @@ impl EventIntegrationTest {
   /// Orphan view: the parent_view_id equal to the view_id
   /// Normally, the orphan view will be created in nested database
   pub async fn create_orphan_view(&self, name: &str, view_id: &str, layout: ViewLayoutPB) {
+    self
+      .create_orphan_view_with_parent(name, view_id, None, layout)
+      .await;
+  }
+
+  /// Create an orphan view whose ancestor chain reports `parent_view_id` as
+  /// its parent, without adding it to that view's visible children.
+  pub async fn create_orphan_view_with_parent(
+    &self,
+    name: &str,
+    view_id: &str,
+    parent_view_id: Option<&str>,
+    layout: ViewLayoutPB,
+  ) {
     let payload = CreateOrphanViewPayloadPB {
       name: name.to_string(),
       layout,
       view_id: view_id.to_string(),
       initial_data: vec![],
+      parent_view_id: parent_view_id.map(|id| id.to_string()),
     };
     EventBuilder::new(self.clone())
       .event(FolderEvent::CreateOrphanView)

--- a/frontend/rust-lib/event-integration-test/src/folder_event.rs
+++ b/frontend/rust-lib/event-integration-test/src/folder_event.rs
@@ -171,8 +171,10 @@ impl EventIntegrationTest {
   }
 
   /// Create orphan views in the folder.
-  /// Orphan view: the parent_view_id equal to the view_id
-  /// Normally, the orphan view will be created in nested database
+  /// Orphan view: defaults to a parent_view_id equal to the view_id.
+  /// Normally, the orphan view will be created in nested database.
+  /// Use `create_orphan_view_with_parent` instead if the orphan needs to report
+  /// a real parent (e.g. for ancestor-chain/breadcrumb resolution).
   pub async fn create_orphan_view(&self, name: &str, view_id: &str, layout: ViewLayoutPB) {
     self
       .create_orphan_view_with_parent(name, view_id, None, layout)

--- a/frontend/rust-lib/event-integration-test/tests/folder/local_test/folder_test.rs
+++ b/frontend/rust-lib/event-integration-test/tests/folder/local_test/folder_test.rs
@@ -347,3 +347,42 @@ async fn create_orphan_child_view_and_get_its_ancestors_test() {
   assert_eq!(ancestors[0].name, "Orphan View");
   assert_eq!(ancestors[0].id, view_id);
 }
+
+#[tokio::test]
+async fn create_orphan_view_with_explicit_parent_and_get_its_ancestors_test() {
+  let test = EventIntegrationTest::new_anon().await;
+  let real_parent = test.get_all_workspace_views().await[0].clone();
+
+  let orphan_view_id = Uuid::new_v4().to_string();
+  test
+    .create_orphan_view_with_parent(
+      "Row Document",
+      &orphan_view_id,
+      Some(&real_parent.id),
+      ViewLayoutPB::Document,
+    )
+    .await;
+
+  // the orphan view should report the real view as its parent instead of itself
+  let orphan_ancestors = test.get_view_ancestors(&orphan_view_id).await;
+  assert_eq!(orphan_ancestors.last().unwrap().id, orphan_view_id);
+  assert!(orphan_ancestors.iter().any(|v| v.id == real_parent.id));
+
+  // a normal child view created inside the orphan view should inherit the full ancestor chain
+  let child = test
+    .create_view(&orphan_view_id, "Nested Document".to_string())
+    .await;
+  let child_ancestors = test.get_view_ancestors(&child.id).await;
+  assert_eq!(child_ancestors.last().unwrap().id, child.id);
+  assert!(child_ancestors.iter().any(|v| v.id == orphan_view_id));
+  assert!(child_ancestors.iter().any(|v| v.id == real_parent.id));
+
+  // the orphan view must still stay hidden from the real parent's visible children
+  let real_parent_reloaded = test.get_view(&real_parent.id).await;
+  assert!(
+    !real_parent_reloaded
+      .child_views
+      .iter()
+      .any(|v| v.id == orphan_view_id)
+  );
+}

--- a/frontend/rust-lib/flowy-folder/src/entities/view.rs
+++ b/frontend/rust-lib/flowy-folder/src/entities/view.rs
@@ -365,6 +365,13 @@ pub struct CreateOrphanViewPayloadPB {
 
   #[pb(index = 4)]
   pub initial_data: Vec<u8>,
+
+  /// The id this orphan view should report as its parent when its ancestor
+  /// chain is walked (e.g. for breadcrumbs). It is never added to that
+  /// view's visible children. Defaults to the orphan view's own id, i.e.
+  /// a self-referencing parent, when omitted.
+  #[pb(index = 5, one_of)]
+  pub parent_view_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -423,9 +430,15 @@ impl TryInto<CreateViewParams> for CreateOrphanViewPayloadPB {
   fn try_into(self) -> Result<CreateViewParams, Self::Error> {
     let name = ViewName::parse(self.name)?.0;
     let view_id = Uuid::parse_str(&self.view_id).map_err(|_| ErrorCode::InvalidParams)?;
+    let parent_view_id = match self.parent_view_id {
+      Some(parent_view_id) => {
+        Uuid::parse_str(&parent_view_id).map_err(|_| ErrorCode::InvalidParams)?
+      },
+      None => view_id,
+    };
 
     Ok(CreateViewParams {
-      parent_view_id: view_id,
+      parent_view_id,
       name,
       layout: self.layout,
       view_id,


### PR DESCRIPTION
### What & why

Reported in #8432: creating a page *inside* a database row's own note/document loses its breadcrumb, and its location shows up as "Untitled" wherever it's referenced — basically orphaned.

Root cause: a row's inline document is created as a special "orphan view" whose `parent_view_id` is set to its own id, purely so it stays out of the sidebar. That's intentional for the row document itself — but any page you create *inside* it inherits that self-referencing parent. When the app walks up the ancestor chain to build breadcrumbs, it hits the row document, loops back on itself, and stops. It never reaches the actual database/grid view, the space, or the workspace, so the breadcrumb bar has nothing real to show.

This PR lets the orphan view report the database's own view as its parent for ancestor-chain purposes, without adding it to that view's visible children (sidebar visibility is controlled separately — by whether a view was inserted into a parent's child list — so this doesn't change what shows up under the database). Pages created inside a row's document now resolve their full breadcrumb path again.

### Changes
- `flowy-folder`: `CreateOrphanViewPayloadPB` gains an optional `parent_view_id`; defaults to the old self-referencing behavior when omitted, so nothing else that creates orphan views is affected.
- Desktop (`RowDocumentBloc`) and mobile (`OpenRowPageButton`) now pass the database's view id when creating a row's document.
- Added `create_orphan_view_with_explicit_parent_and_get_its_ancestors_test`, covering: the orphan reports the real parent, a page nested inside it inherits the full ancestor chain, and the orphan still doesn't show up as a visible child of the database view.

### Note
I put this together without a Rust/protoc toolchain on hand, so I haven't been able to run `cargo make code_generation` or the test suite myself. Opening as a draft so CI (or a reviewer) can catch anything I couldn't — will fix up based on results.

fixes https://github.com/AppFlowy-IO/AppFlowy/issues/8432

---

#### PR Checklist

- [ ] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing. *(unverified locally — no toolchain available, relying on CI)*

## Summary by Sourcery

Ensure orphan views can report a real parent for ancestor resolution so nested row documents retain correct breadcrumbs without becoming visible sidebar children.

New Features:
- Allow specifying an explicit parent view when creating orphan views so their ancestor chains can link back to the owning database or workspace.

Enhancements:
- Extend CreateOrphanViewPayloadPB and ViewBackendService to support an optional parent_view_id that defaults to the orphan view’s own id when not provided.
- Wire desktop and mobile row document creation to pass the database view id as the parent for row document orphan views.

Tests:
- Add an integration test verifying that orphan views with explicit parents report the correct ancestor chain, that nested child views inherit the full ancestry, and that the orphan remains hidden from the parent’s visible children.