### PR TITLE
fix: preserve event duration when dragging ranged calendar events

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/event_handler.rs
+++ b/frontend/rust-lib/flowy-database2/src/event_handler.rs
@@ -998,19 +998,15 @@ pub(crate) async fn move_calendar_event_handler(
   let manager = upgrade_manager(manager)?;
   let data = data.into_inner();
   let cell_id: CellIdParams = data.cell_path.try_into()?;
-  let cell_changeset = DateCellChangeset {
-    timestamp: Some(data.timestamp),
-    ..Default::default()
-  };
   let database_editor = manager
     .get_database_editor_with_view_id(&cell_id.view_id)
     .await?;
   database_editor
-    .update_cell_with_changeset(
+    .move_calendar_event(
       &cell_id.view_id,
       &cell_id.row_id,
       &cell_id.field_id,
-      BoxAny::new(cell_changeset),
+      data.timestamp,
     )
     .await?;
   Ok(())

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
@@ -1405,7 +1405,7 @@ impl DatabaseEditor {
   /// Moves a calendar event to `new_timestamp`. If the event's date cell spans a range
   /// (start + end date), the end date is shifted by the same amount as the start date so the
   /// event keeps its original duration, instead of collapsing to a single day.
-  #[tracing::instrument(level = "trace", skip_all)]
+  #[tracing::instrument(level = "trace", skip_all, err)]
   pub async fn move_calendar_event(
     &self,
     view_id: &str,

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
@@ -9,6 +9,7 @@ use crate::services::database_view::{
   DatabaseViewChanged, DatabaseViewEditor, DatabaseViewOperation, DatabaseViews, EditorByViewId,
 };
 use crate::services::field::checklist_filter::ChecklistCellChangeset;
+use crate::services::field::date_filter::DateCellChangeset;
 use crate::services::field::type_option_transform::transform_type_option;
 use crate::services::field::{
   SelectOptionCellChangeset, StringCellData, TypeOptionCellDataHandler, TypeOptionCellExt,
@@ -26,6 +27,7 @@ use collab::core::collab_plugin::CollabPluginType;
 use collab::lock::RwLock;
 use collab_database::database::Database;
 use collab_database::entity::DatabaseView;
+use collab_database::fields::date_type_option::DateCellData;
 use collab_database::fields::media_type_option::MediaCellData;
 use collab_database::fields::relation_type_option::RelationTypeOption;
 use collab_database::fields::{Field, TypeOptionData};
@@ -1398,6 +1400,38 @@ impl DatabaseEditor {
       .await
       .ok()?;
     view.v_get_calendar_event(row_id).await
+  }
+
+  /// Moves a calendar event to `new_timestamp`. If the event's date cell spans a range
+  /// (start + end date), the end date is shifted by the same amount as the start date so the
+  /// event keeps its original duration, instead of collapsing to a single day.
+  #[tracing::instrument(level = "trace", skip_all)]
+  pub async fn move_calendar_event(
+    &self,
+    view_id: &str,
+    row_id: &RowId,
+    field_id: &str,
+    new_timestamp: i64,
+  ) -> FlowyResult<()> {
+    let old_cell_data = self
+      .get_cell(field_id, row_id)
+      .await
+      .map(|cell| DateCellData::from(&cell));
+    let end_timestamp = old_cell_data
+      .filter(|old| old.is_range)
+      .and_then(|old| old.timestamp.zip(old.end_timestamp))
+      .map(|(old_timestamp, old_end_timestamp)| {
+        old_end_timestamp + (new_timestamp - old_timestamp)
+      });
+
+    let cell_changeset = DateCellChangeset {
+      timestamp: Some(new_timestamp),
+      end_timestamp,
+      ..Default::default()
+    };
+    self
+      .update_cell_with_changeset(view_id, row_id, field_id, BoxAny::new(cell_changeset))
+      .await
   }
 
   #[tracing::instrument(level = "trace", skip_all, err)]

--- a/frontend/rust-lib/flowy-database2/tests/database/cell_test/test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/cell_test/test.rs
@@ -204,3 +204,72 @@ async fn time_cell_data_test() {
     assert_eq!(cell.0.unwrap_or_default(), 75);
   }
 }
+
+#[tokio::test]
+async fn move_calendar_event_shifts_ranged_end_date_test() {
+  let test = DatabaseCellTest::new().await;
+  let date_field = test.get_first_field(FieldType::DateTime).await;
+  let row_id = test.rows[0].id.clone();
+
+  // start: 2024-01-01T00:00:00Z, end: two days later
+  let start = 1704067200;
+  let end = start + 2 * 86400;
+  test
+    .update_cell(
+      &test.view_id,
+      &date_field.id,
+      &row_id,
+      BoxAny::new(DateCellChangeset {
+        timestamp: Some(start),
+        end_timestamp: Some(end),
+        is_range: Some(true),
+        ..Default::default()
+      }),
+    )
+    .await;
+
+  // drag the event forward by one day
+  let new_start = start + 86400;
+  test
+    .editor
+    .move_calendar_event(&test.view_id, &row_id, &date_field.id, new_start)
+    .await
+    .unwrap();
+
+  let cell = test.editor.get_cell(&date_field.id, &row_id).await.unwrap();
+  let cell_data = DateCellData::from(&cell);
+  assert_eq!(cell_data.timestamp, Some(new_start));
+  assert_eq!(cell_data.end_timestamp, Some(end + 86400));
+}
+
+#[tokio::test]
+async fn move_calendar_event_single_date_test() {
+  let test = DatabaseCellTest::new().await;
+  let date_field = test.get_first_field(FieldType::DateTime).await;
+  let row_id = test.rows[0].id.clone();
+
+  let start = 1704067200;
+  test
+    .update_cell(
+      &test.view_id,
+      &date_field.id,
+      &row_id,
+      BoxAny::new(DateCellChangeset {
+        timestamp: Some(start),
+        ..Default::default()
+      }),
+    )
+    .await;
+
+  let new_start = start + 86400;
+  test
+    .editor
+    .move_calendar_event(&test.view_id, &row_id, &date_field.id, new_start)
+    .await
+    .unwrap();
+
+  let cell = test.editor.get_cell(&date_field.id, &row_id).await.unwrap();
+  let cell_data = DateCellData::from(&cell);
+  assert_eq!(cell_data.timestamp, Some(new_start));
+  assert_eq!(cell_data.end_timestamp, None);
+}

--- a/frontend/rust-lib/flowy-database2/tests/database/cell_test/test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/cell_test/test.rs
@@ -240,6 +240,45 @@ async fn move_calendar_event_shifts_ranged_end_date_test() {
   let cell_data = DateCellData::from(&cell);
   assert_eq!(cell_data.timestamp, Some(new_start));
   assert_eq!(cell_data.end_timestamp, Some(end + 86400));
+  assert!(cell_data.is_range);
+}
+
+#[tokio::test]
+async fn move_calendar_event_shifts_ranged_end_date_backward_test() {
+  let test = DatabaseCellTest::new().await;
+  let date_field = test.get_first_field(FieldType::DateTime).await;
+  let row_id = test.rows[0].id.clone();
+
+  // start: 2024-01-02T00:00:00Z, end: two days later
+  let start = 1704067200 + 86400;
+  let end = start + 2 * 86400;
+  test
+    .update_cell(
+      &test.view_id,
+      &date_field.id,
+      &row_id,
+      BoxAny::new(DateCellChangeset {
+        timestamp: Some(start),
+        end_timestamp: Some(end),
+        is_range: Some(true),
+        ..Default::default()
+      }),
+    )
+    .await;
+
+  // drag the event backward by one day
+  let new_start = start - 86400;
+  test
+    .editor
+    .move_calendar_event(&test.view_id, &row_id, &date_field.id, new_start)
+    .await
+    .unwrap();
+
+  let cell = test.editor.get_cell(&date_field.id, &row_id).await.unwrap();
+  let cell_data = DateCellData::from(&cell);
+  assert_eq!(cell_data.timestamp, Some(new_start));
+  assert_eq!(cell_data.end_timestamp, Some(end - 86400));
+  assert!(cell_data.is_range);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Feature Preview

N/A (bug fix, not a new feature).

fixes https://github.com/AppFlowy-IO/AppFlowy/issues/8859

### What's wrong

Dragging a Calendar card that has an **End Date** toggled does nothing — the UI shows the drop is accepted, but the card snaps back and the row is unchanged. Cards without an End Date drag/drop fine.

### Root cause

`DateTypeOption::apply_changeset` (in `date_type_option.rs`) rejects a changeset on a ranged (`is_range`) date cell unless `timestamp` and `end_timestamp` are supplied together — a guard added in #6582 to catch accidental partial updates coming from the date-picker widget.

The calendar drag handler (`MoveCalendarEventPB` → `move_calendar_event_handler`) only ever sends `timestamp`. For a ranged event this trips that guard and the whole changeset is silently dropped, which matches the reported symptom exactly.

### Fix

Added `DatabaseEditor::move_calendar_event()`, which loads the cell being moved first. If it's ranged, it shifts `end_timestamp` by the same delta as the new start `timestamp`, so the event keeps its original duration (matching the Notion-like behavior shown in the issue) instead of tripping the single-field-update guard. Non-ranged cells are unaffected — only `timestamp` is sent, same as before.

### Tests

Added two integration tests in `flowy-database2/tests/database/cell_test/test.rs`:
- a 2-day ranged event shifts both start and end together when dragged
- a single-date event is unaffected (end stays unset)

---

#### PR Checklist

- [x] My code adheres to [AppFlowy's Conventions](https://docs.appflowy.io/docs/documentation/software-contributions/conventions)
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added a test(s) to validate changes in this PR, or this PR only contains semantic changes.
- [ ] All existing tests are passing. *(This environment doesn't have the Rust toolchain installed, so I could not run the suite locally — verified by manual code tracing against existing call sites instead. Leaving this open pending CI.)*

## Summary by Sourcery

Preserve the duration of ranged calendar events when they are moved, and route calendar drag operations through a new database editor helper that adjusts end dates consistently.

Bug Fixes:
- Fix ranged calendar events failing to move when dragged by ensuring both start and end timestamps are updated together.

Enhancements:
- Add a dedicated DatabaseEditor::move_calendar_event helper to encapsulate calendar event movement logic and duration preservation.

Tests:
- Add integration tests to verify that dragging a ranged calendar event shifts both start and end timestamps while keeping the duration, and that single-date events remain without an end date when moved.