### PR TITLE
fix: trigger filter recalculation on remote row updates (Android #8806)

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
@@ -97,7 +97,6 @@ impl DatabaseEditor {
     // Receive database sync state and send to frontend via the notification
     observe_sync_state(&database_id, &database).await;
     // observe_field_change(&database_id, &database).await;
-    observe_rows_change(&database_id, &database, &notification_sender).await;
 
     // Used to cache the view of the database for fast access.
     let editor_by_view_id = Arc::new(RwLock::new(EditorByViewId::default()));
@@ -147,6 +146,7 @@ impl DatabaseEditor {
     });
     observe_block_event(&database_id, &this).await;
     observe_view_change(&database_id, &this).await;
+    observe_rows_change(&database_id.to_string(), &this, &notification_sender).await;
     Ok(this)
   }
 
@@ -1054,7 +1054,7 @@ impl DatabaseEditor {
     Ok(())
   }
 
-  async fn did_update_row(
+  pub(crate) async fn did_update_row(
     &self,
     view_id: &str,
     row_id: &RowId,

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
@@ -40,13 +40,13 @@ pub(crate) async fn observe_sync_state(database_id: &str, database: &Arc<RwLock<
 
 pub(crate) async fn observe_rows_change(
   database_id: &str,
-  database: &Arc<RwLock<Database>>,
+  database_editor: &Arc<DatabaseEditor>,
   notification_sender: &Arc<DebounceNotificationSender>,
 ) {
   let notification_sender = notification_sender.clone();
   let database_id = database_id.to_string();
-  let weak_database = Arc::downgrade(database);
-  let sub = database.read().await.subscribe_row_change();
+  let weak_editor = Arc::downgrade(database_editor);
+  let sub = database_editor.database.read().await.subscribe_row_change();
   if let Some(mut row_change) = sub {
     tokio::spawn(async move {
       while let Ok(row_change) = row_change.recv().await {
@@ -54,7 +54,7 @@ pub(crate) async fn observe_rows_change(
           "[Database Observe]: {} row change:{:?}",
           database_id, row_change
         );
-        if let Some(database) = weak_database.upgrade() {
+        if let Some(editor) = weak_editor.upgrade() {
           match row_change {
             RowChange::DidUpdateCell {
               field_id,
@@ -64,9 +64,12 @@ pub(crate) async fn observe_rows_change(
               let cell_id = format!("{}:{}", row_id, field_id);
               notify_cell(&notification_sender, &cell_id);
 
-              let views = database.read().await.get_all_database_views_meta();
+              let views = editor.database.read().await.get_all_database_views_meta();
               for view in views {
                 notify_row(&notification_sender, &view.id, &field_id, &row_id);
+                editor
+                  .did_update_row(&view.id, &row_id, &field_id, None)
+                  .await;
               }
             },
             _ => {

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
@@ -12,7 +12,7 @@ use collab_database::rows::{RowChange, RowId};
 use collab_database::views::{DatabaseViewChange, RowOrder};
 use dashmap::DashMap;
 use flowy_notification::{DebounceNotificationSender, NotificationBuilder};
-use futures::StreamExt;
+use futures::{StreamExt, future::join_all};
 
 use std::sync::Arc;
 use tracing::{error, trace, warn};
@@ -64,13 +64,23 @@ pub(crate) async fn observe_rows_change(
               let cell_id = format!("{}:{}", row_id, field_id);
               notify_cell(&notification_sender, &cell_id);
 
-              let views = editor.database.read().await.get_all_database_views_meta();
-              for view in views {
-                notify_row(&notification_sender, &view.id, &field_id, &row_id);
-                editor
-                  .did_update_row(&view.id, &row_id, &field_id, None)
-                  .await;
+              let view_ids = editor
+                .database
+                .read()
+                .await
+                .get_all_database_views_meta()
+                .into_iter()
+                .map(|view| view.id)
+                .collect::<Vec<_>>();
+              for view_id in &view_ids {
+                notify_row(&notification_sender, view_id, &field_id, &row_id);
               }
+              join_all(
+                view_ids
+                  .iter()
+                  .map(|view_id| editor.did_update_row(view_id, &row_id, &field_id, None)),
+              )
+              .await;
             },
             _ => {
               warn!("unhandled row change: {:?}", row_change);

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/mod.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/mod.rs
@@ -3,6 +3,7 @@ mod checkbox_filter_test;
 mod checklist_filter_test;
 mod date_filter_test;
 mod number_filter_test;
+mod remote_row_update_test;
 mod script;
 mod select_option_filter_test;
 mod text_filter_test;

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/remote_row_update_test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/remote_row_update_test.rs
@@ -1,0 +1,173 @@
+use std::time::Duration;
+
+use lib_infra::box_any::BoxAny;
+
+use flowy_database2::entities::{FieldType, SelectOptionFilterConditionPB, SelectOptionFilterPB};
+use flowy_database2::services::cell::insert_select_option_cell;
+use flowy_database2::services::database_view::DatabaseViewChanged;
+use flowy_database2::services::filter::FilterResultNotification;
+
+use crate::database::filter_test::script::{DatabaseFilterTest, FilterRowChanged};
+use crate::database::mock_data::{COMPLETED, PLANNED};
+
+/// A cell that is modified without going through `DatabaseEditor::update_cell`,
+/// e.g. when a remote user's edit is applied through synchronization, must still
+/// trigger a filter recalculation so that the filtered view refreshes.
+///
+/// See https://github.com/AppFlowy-IO/AppFlowy/issues/8806.
+///
+/// `DatabaseEditor::update_row` writes the cell directly to the underlying
+/// collab document, bypassing the local edit path. Both this and a synced remote
+/// edit reach the database editor exclusively through the row-change observer,
+/// making it a faithful stand-in for a remote update.
+#[tokio::test]
+async fn remote_cell_update_shows_row_in_filtered_view_test() {
+  let mut test = DatabaseFilterTest::new().await;
+  let row_count = test.rows.len();
+  let expected = 2;
+
+  // Create a "Status is Completed" filter. Rows 2 and 3 are Completed.
+  let field = test.get_first_field(FieldType::SingleSelect).await;
+  let options = test.get_single_select_type_option(&field.id).await;
+  let completed_option_id = options
+    .iter()
+    .find(|option| option.name == COMPLETED)
+    .unwrap()
+    .id
+    .clone();
+  test
+    .create_data_filter(
+      None,
+      FieldType::SingleSelect,
+      BoxAny::new(SelectOptionFilterPB {
+        condition: SelectOptionFilterConditionPB::OptionIs,
+        option_ids: vec![completed_option_id.clone()],
+      }),
+      Some(FilterRowChanged {
+        showing_num_of_rows: 0,
+        hiding_num_of_rows: row_count - expected,
+      }),
+    )
+    .await;
+  test.assert_number_of_visible_rows(expected).await;
+  // Let the initial filter task settle before subscribing.
+  test.wait(300).await;
+
+  // Simulate a remote edit: assign "Completed" to row 0 (whose status is empty)
+  // by writing the cell directly to the underlying collab document, bypassing
+  // the DatabaseEditor::update_cell path.
+  let row_id = test.rows[0].id.clone();
+  let cell = insert_select_option_cell(vec![completed_option_id], &field);
+  let recv = test
+    .editor
+    .subscribe_view_changed(&test.view_id)
+    .await
+    .unwrap();
+  test
+    .editor
+    .update_row(row_id.clone(), |row_update| {
+      row_update.update_cells(|cell_update| {
+        cell_update.insert(&field.id, cell);
+      });
+    })
+    .await
+    .unwrap();
+
+  // The filtered view must be notified that the row became visible.
+  let notification = wait_for_filter_notification(recv).await;
+  assert_eq!(
+    notification.visible_rows.len(),
+    1,
+    "expected the remotely updated row to become visible"
+  );
+  assert_eq!(notification.visible_rows[0].row_meta.id, row_id.to_string());
+  assert!(notification.invisible_rows.is_empty());
+}
+
+/// The counterpart of the test above: a remote cell update that makes a row stop
+/// matching the filter must hide the row in the filtered view.
+#[tokio::test]
+async fn remote_cell_update_hides_row_in_filtered_view_test() {
+  let mut test = DatabaseFilterTest::new().await;
+  let row_count = test.rows.len();
+  let expected = 2;
+
+  // Create a "Status is Completed" filter. Rows 2 and 3 are Completed.
+  let field = test.get_first_field(FieldType::SingleSelect).await;
+  let options = test.get_single_select_type_option(&field.id).await;
+  let completed_option_id = options
+    .iter()
+    .find(|option| option.name == COMPLETED)
+    .unwrap()
+    .id
+    .clone();
+  let planned_option_id = options
+    .iter()
+    .find(|option| option.name == PLANNED)
+    .unwrap()
+    .id
+    .clone();
+  test
+    .create_data_filter(
+      None,
+      FieldType::SingleSelect,
+      BoxAny::new(SelectOptionFilterPB {
+        condition: SelectOptionFilterConditionPB::OptionIs,
+        option_ids: vec![completed_option_id],
+      }),
+      Some(FilterRowChanged {
+        showing_num_of_rows: 0,
+        hiding_num_of_rows: row_count - expected,
+      }),
+    )
+    .await;
+  test.assert_number_of_visible_rows(expected).await;
+  // Let the initial filter task settle before subscribing.
+  test.wait(300).await;
+
+  // Simulate a remote edit: change row 2 from "Completed" to "Planned" by
+  // writing the cell directly to the underlying collab document, bypassing the
+  // DatabaseEditor::update_cell path.
+  let row_id = test.rows[2].id.clone();
+  let cell = insert_select_option_cell(vec![planned_option_id], &field);
+  let recv = test
+    .editor
+    .subscribe_view_changed(&test.view_id)
+    .await
+    .unwrap();
+  test
+    .editor
+    .update_row(row_id.clone(), |row_update| {
+      row_update.update_cells(|cell_update| {
+        cell_update.insert(&field.id, cell);
+      });
+    })
+    .await
+    .unwrap();
+
+  // The filtered view must be notified that the row became invisible.
+  let notification = wait_for_filter_notification(recv).await;
+  assert_eq!(
+    notification.invisible_rows.len(),
+    1,
+    "expected the remotely updated row to become invisible"
+  );
+  assert_eq!(notification.invisible_rows[0], row_id);
+  assert!(notification.visible_rows.is_empty());
+}
+
+async fn wait_for_filter_notification(
+  mut recv: tokio::sync::broadcast::Receiver<DatabaseViewChanged>,
+) -> FilterResultNotification {
+  tokio::time::timeout(Duration::from_secs(2), async move {
+    loop {
+      match recv.recv().await {
+        Ok(DatabaseViewChanged::FilterNotification(notification)) => break notification,
+        Ok(_) => continue,
+        Err(err) => panic!("view changed channel closed: {:?}", err),
+      }
+    }
+  })
+  .await
+  .expect("the filter was not recalculated after a remote row update")
+}

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/remote_row_update_test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/remote_row_update_test.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use collab_database::rows::RowId;
 use lib_infra::box_any::BoxAny;
 
 use flowy_database2::entities::{FieldType, SelectOptionFilterConditionPB, SelectOptionFilterPB};
@@ -7,7 +8,7 @@ use flowy_database2::services::cell::insert_select_option_cell;
 use flowy_database2::services::database_view::DatabaseViewChanged;
 use flowy_database2::services::filter::FilterResultNotification;
 
-use crate::database::filter_test::script::{DatabaseFilterTest, FilterRowChanged};
+use crate::database::filter_test::script::DatabaseFilterTest;
 use crate::database::mock_data::{COMPLETED, PLANNED};
 
 /// A cell that is modified without going through `DatabaseEditor::update_cell`,
@@ -23,7 +24,6 @@ use crate::database::mock_data::{COMPLETED, PLANNED};
 #[tokio::test]
 async fn remote_cell_update_shows_row_in_filtered_view_test() {
   let mut test = DatabaseFilterTest::new().await;
-  let row_count = test.rows.len();
   let expected = 2;
 
   // Create a "Status is Completed" filter. Rows 2 and 3 are Completed.
@@ -43,15 +43,10 @@ async fn remote_cell_update_shows_row_in_filtered_view_test() {
         condition: SelectOptionFilterConditionPB::OptionIs,
         option_ids: vec![completed_option_id.clone()],
       }),
-      Some(FilterRowChanged {
-        showing_num_of_rows: 0,
-        hiding_num_of_rows: row_count - expected,
-      }),
+      None,
     )
     .await;
   test.assert_number_of_visible_rows(expected).await;
-  // Let the initial filter task settle before subscribing.
-  test.wait(300).await;
 
   // Simulate a remote edit: assign "Completed" to row 0 (whose status is empty)
   // by writing the cell directly to the underlying collab document, bypassing
@@ -74,7 +69,7 @@ async fn remote_cell_update_shows_row_in_filtered_view_test() {
     .unwrap();
 
   // The filtered view must be notified that the row became visible.
-  let notification = wait_for_filter_notification(recv).await;
+  let notification = wait_for_filter_notification(recv, &row_id, true).await;
   assert_eq!(
     notification.visible_rows.len(),
     1,
@@ -89,7 +84,6 @@ async fn remote_cell_update_shows_row_in_filtered_view_test() {
 #[tokio::test]
 async fn remote_cell_update_hides_row_in_filtered_view_test() {
   let mut test = DatabaseFilterTest::new().await;
-  let row_count = test.rows.len();
   let expected = 2;
 
   // Create a "Status is Completed" filter. Rows 2 and 3 are Completed.
@@ -115,15 +109,10 @@ async fn remote_cell_update_hides_row_in_filtered_view_test() {
         condition: SelectOptionFilterConditionPB::OptionIs,
         option_ids: vec![completed_option_id],
       }),
-      Some(FilterRowChanged {
-        showing_num_of_rows: 0,
-        hiding_num_of_rows: row_count - expected,
-      }),
+      None,
     )
     .await;
   test.assert_number_of_visible_rows(expected).await;
-  // Let the initial filter task settle before subscribing.
-  test.wait(300).await;
 
   // Simulate a remote edit: change row 2 from "Completed" to "Planned" by
   // writing the cell directly to the underlying collab document, bypassing the
@@ -146,7 +135,7 @@ async fn remote_cell_update_hides_row_in_filtered_view_test() {
     .unwrap();
 
   // The filtered view must be notified that the row became invisible.
-  let notification = wait_for_filter_notification(recv).await;
+  let notification = wait_for_filter_notification(recv, &row_id, false).await;
   assert_eq!(
     notification.invisible_rows.len(),
     1,
@@ -158,11 +147,27 @@ async fn remote_cell_update_hides_row_in_filtered_view_test() {
 
 async fn wait_for_filter_notification(
   mut recv: tokio::sync::broadcast::Receiver<DatabaseViewChanged>,
+  row_id: &RowId,
+  expect_visible: bool,
 ) -> FilterResultNotification {
+  let row_id = row_id.clone();
+  let row_id_string = row_id.to_string();
   tokio::time::timeout(Duration::from_secs(2), async move {
     loop {
       match recv.recv().await {
-        Ok(DatabaseViewChanged::FilterNotification(notification)) => break notification,
+        Ok(DatabaseViewChanged::FilterNotification(notification)) => {
+          if expect_visible
+            && notification
+              .visible_rows
+              .iter()
+              .any(|row| row.row_meta.id == row_id_string)
+          {
+            break notification;
+          }
+          if !expect_visible && notification.invisible_rows.iter().any(|id| id == &row_id) {
+            break notification;
+          }
+        },
         Ok(_) => continue,
         Err(err) => panic!("view changed channel closed: {:?}", err),
       }


### PR DESCRIPTION
Fixes #8806

## Why

Remote Select/Status cell updates refreshed the row data but did not run the view-layer recalculation used by local edits. Filtered mobile views could therefore remain stale after a desktop edit synced to the device.

## How

- Pass the DatabaseEditor into the remote row observer.
- Call did_update_row for every active view after a remote cell update.
- Add regression coverage for rows entering and leaving a filtered view after a remote update.

## Testing

- cargo test -p flowy-database2 --test main filter_test
- Result: 52 passed, 0 failed (including both new remote-row tests).

Manual Android/Desktop cross-device verification was not available in this environment.

---

#### PR Checklist

- [x] My code adheres to AppFlowy's conventions.
- [x] I've listed at least one issue that this PR fixes in the description above.
- [x] I've added tests to validate the changes in this PR.
- [x] The relevant existing filter test suite is passing.

## Summary by Sourcery

Ensure database view filters are recalculated when rows are updated via remote or non-local edit paths so filtered views stay in sync across devices.

Bug Fixes:
- Trigger view-level row update handling for each view when a remote cell update is observed, keeping filtered views consistent with remote changes.

Enhancements:
- Route row-change observation through DatabaseEditor to reuse existing view update logic for both local and remote edits.

Tests:
- Add regression tests verifying that remotely updated rows correctly enter or leave filtered views based on select-option status changes.