### PR TITLE
fix: filtered/sorted database views don't update on synced row changes (#8806)

### DIFF
--- a/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_editor.rs
@@ -97,7 +97,6 @@ impl DatabaseEditor {
     // Receive database sync state and send to frontend via the notification
     observe_sync_state(&database_id, &database).await;
     // observe_field_change(&database_id, &database).await;
-    observe_rows_change(&database_id, &database, &notification_sender).await;
 
     // Used to cache the view of the database for fast access.
     let editor_by_view_id = Arc::new(RwLock::new(EditorByViewId::default()));
@@ -147,6 +146,7 @@ impl DatabaseEditor {
     });
     observe_block_event(&database_id, &this).await;
     observe_view_change(&database_id, &this).await;
+    observe_rows_change(&database_id, &this, &notification_sender).await;
     Ok(this)
   }
 

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
@@ -77,6 +77,10 @@ pub(crate) async fn observe_rows_change(
               // Required for remote (synced) cell changes, which never go through
               // DatabaseEditor::did_update_row. Redundant-but-harmless on local edits (the
               // Dart RowList applies duplicate show/hide notifications idempotently).
+              // Cheap even with many views: filter_controller/sort_controller only spawn
+              // a recompute task when they actually hold filters/sorts (see their
+              // `did_receive_row_changed`), and the calculation controller looks up the
+              // field's calculation before doing any work.
               for view_editor in database_editor.database_views.editors().await {
                 view_editor
                   .v_did_update_row_from_sync(row_id.clone(), field_id.clone())

--- a/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database/database_observe.rs
@@ -39,14 +39,14 @@ pub(crate) async fn observe_sync_state(database_id: &str, database: &Arc<RwLock<
 }
 
 pub(crate) async fn observe_rows_change(
-  database_id: &str,
-  database: &Arc<RwLock<Database>>,
+  database_id: &Uuid,
+  database_editor: &Arc<DatabaseEditor>,
   notification_sender: &Arc<DebounceNotificationSender>,
 ) {
   let notification_sender = notification_sender.clone();
   let database_id = database_id.to_string();
-  let weak_database = Arc::downgrade(database);
-  let sub = database.read().await.subscribe_row_change();
+  let weak_database_editor = Arc::downgrade(database_editor);
+  let sub = database_editor.database.read().await.subscribe_row_change();
   if let Some(mut row_change) = sub {
     tokio::spawn(async move {
       while let Ok(row_change) = row_change.recv().await {
@@ -54,7 +54,7 @@ pub(crate) async fn observe_rows_change(
           "[Database Observe]: {} row change:{:?}",
           database_id, row_change
         );
-        if let Some(database) = weak_database.upgrade() {
+        if let Some(database_editor) = weak_database_editor.upgrade() {
           match row_change {
             RowChange::DidUpdateCell {
               field_id,
@@ -64,9 +64,23 @@ pub(crate) async fn observe_rows_change(
               let cell_id = format!("{}:{}", row_id, field_id);
               notify_cell(&notification_sender, &cell_id);
 
-              let views = database.read().await.get_all_database_views_meta();
+              let views = database_editor
+                .database
+                .read()
+                .await
+                .get_all_database_views_meta();
               for view in views {
                 notify_row(&notification_sender, &view.id, &field_id, &row_id);
+              }
+
+              // Re-evaluate filters/sorts/calculations for the changed row on every view.
+              // Required for remote (synced) cell changes, which never go through
+              // DatabaseEditor::did_update_row. Redundant-but-harmless on local edits (the
+              // Dart RowList applies duplicate show/hide notifications idempotently).
+              for view_editor in database_editor.database_views.editors().await {
+                view_editor
+                  .v_did_update_row_from_sync(row_id.clone(), field_id.clone())
+                  .await;
               }
             },
             _ => {

--- a/frontend/rust-lib/flowy-database2/src/services/database_view/view_editor.rs
+++ b/frontend/rust-lib/flowy-database2/src/services/database_view/view_editor.rs
@@ -1285,6 +1285,13 @@ impl DatabaseViewEditor {
     }
   }
 
+  /// Re-runs filters/sorts/calculations for a single row whose cell changed via a remote sync.
+  /// There is no local `did_update_row` call on the sync path, so callers observing
+  /// `RowChange::DidUpdateCell` from a synced collab update must trigger this explicitly.
+  pub async fn v_did_update_row_from_sync(&self, row_id: RowId, field_id: String) {
+    self.gen_did_update_row_view_tasks(row_id, Some(field_id)).await;
+  }
+
   async fn gen_did_update_row_view_tasks(&self, row_id: RowId, field_id: Option<String>) {
     let weak_filter_controller = Arc::downgrade(&self.filter_controller);
     let weak_sort_controller = Arc::downgrade(&self.sort_controller);

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/script.rs
@@ -3,6 +3,8 @@
 use std::time::Duration;
 
 use collab_database::rows::RowId;
+use flowy_database2::services::cell::apply_cell_changeset;
+use flowy_database2::services::field::SelectOptionCellChangeset;
 use flowy_database2::services::filter::{FilterChangeset, FilterInner};
 use lib_infra::box_any::BoxAny;
 use tokio::sync::broadcast::Receiver;
@@ -119,6 +121,41 @@ impl DatabaseFilterTest {
     self.assert_future_changed(changed).await;
     self
       .update_single_select_cell(row_id, &option_id)
+      .await
+      .unwrap();
+  }
+
+  /// Simulates a remote (synced) cell change by writing straight to the collab row via
+  /// `DatabaseEditor::update_row`, bypassing `update_cell`/`did_update_row` (the local-edit
+  /// path). This is how a change synced in from another device applies: it mutates the collab
+  /// document directly and never touches the filter-recompute trigger that only the local
+  /// write paths call.
+  pub async fn update_single_select_cell_via_sync(
+    &mut self,
+    row_id: RowId,
+    option_id: String,
+    changed: Option<FilterRowChanged>,
+  ) {
+    self.subscribe_view_changed().await;
+    self.assert_future_changed(changed).await;
+
+    let field = self.get_first_field(FieldType::SingleSelect).await;
+    let old_cell = self.editor.get_cell(&field.id, &row_id).await;
+    let new_cell = apply_cell_changeset(
+      BoxAny::new(SelectOptionCellChangeset::from_insert_option_id(&option_id)),
+      old_cell,
+      &field,
+      Some(self.editor.cell_cache.clone()),
+    )
+    .unwrap();
+
+    self
+      .editor
+      .update_row(row_id, |row_update| {
+        row_update.update_cells(|cell_update| {
+          cell_update.insert(&field.id, new_cell);
+        });
+      })
       .await
       .unwrap();
   }

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/script.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/script.rs
@@ -143,11 +143,16 @@ impl DatabaseFilterTest {
     let old_cell = self.editor.get_cell(&field.id, &row_id).await;
     let new_cell = apply_cell_changeset(
       BoxAny::new(SelectOptionCellChangeset::from_insert_option_id(&option_id)),
-      old_cell,
+      old_cell.clone(),
       &field,
       Some(self.editor.cell_cache.clone()),
     )
     .unwrap();
+    assert_ne!(
+      Some(new_cell.clone()),
+      old_cell,
+      "sync test helper produced a no-op cell change"
+    );
 
     self
       .editor

--- a/frontend/rust-lib/flowy-database2/tests/database/filter_test/select_option_filter_test.rs
+++ b/frontend/rust-lib/flowy-database2/tests/database/filter_test/select_option_filter_test.rs
@@ -145,6 +145,53 @@ async fn grid_filter_single_select_is_test2() {
   test.assert_number_of_visible_rows(2).await;
 }
 
+/// Regression test for #8806: a filtered view must update when a row's cell changes via a
+/// synced (remote) update, not just via a local edit. `update_single_select_cell_via_sync`
+/// writes directly to the collab row, bypassing `update_cell`/`did_update_row` — the same path
+/// a change synced in from another device takes.
+#[tokio::test]
+async fn grid_filter_single_select_is_synced_row_change_test() {
+  let mut test = DatabaseFilterTest::new().await;
+  let field = test.get_first_field(FieldType::SingleSelect).await;
+  let row_details = test.get_rows().await;
+  let mut options = test.get_single_select_type_option(&field.id).await;
+  let option = options.remove(0);
+  let row_count = test.rows.len();
+
+  // Create Single-Select "Is" filter
+  test
+    .create_data_filter(
+      None,
+      FieldType::SingleSelect,
+      BoxAny::new(SelectOptionFilterPB {
+        condition: SelectOptionFilterConditionPB::OptionIs,
+        option_ids: vec![option.id.clone()],
+      }),
+      Some(FilterRowChanged {
+        showing_num_of_rows: 0,
+        hiding_num_of_rows: row_count - 2,
+      }),
+    )
+    .await;
+  test.assert_number_of_visible_rows(2).await;
+
+  // Simulate a row change synced in from another device: it must still trigger the filter to
+  // re-evaluate and emit an incremental FilterNotification showing the row. Asserting via
+  // `assert_future_changed` (not just `assert_number_of_visible_rows`, which re-opens the view
+  // and re-filters from scratch) is what actually exercises the broken notification path.
+  test
+    .update_single_select_cell_via_sync(
+      row_details[1].id.clone(),
+      option.id.clone(),
+      Some(FilterRowChanged {
+        showing_num_of_rows: 1,
+        hiding_num_of_rows: 0,
+      }),
+    )
+    .await;
+  test.assert_number_of_visible_rows(3).await;
+}
+
 #[tokio::test]
 async fn grid_filter_multi_select_contains_test() {
   let mut test = DatabaseFilterTest::new().await;


### PR DESCRIPTION
## What's going on

On Android (or any client), if you have a filter or sort on a database view and someone else edits a row's cell on another device, the change syncs in but the filter/sort never re-runs on it. You'll see the cell's new value in place, but a row that should now be hidden by the filter stays visible (or vice versa).

Traced it down to `observe_rows_change` in `flowy-database2` — this is the handler for cell changes that arrive via sync (as opposed to a local edit). It only re-notifies the cell and the row itself; it never tells the filter/sort/calculation controllers that a row changed. Local edits don't have this problem because `update_cell` explicitly calls `did_update_row` afterwards, which does trigger that re-evaluation — the sync path just never had the equivalent call.

## The fix

Nothing new architecturally, just wiring up what's already there:

- Added `DatabaseViewEditor::v_did_update_row_from_sync`, a thin wrapper over the existing (private) `gen_did_update_row_view_tasks`, which re-runs filters, sorts, and calculations for a row.
- `observe_rows_change` now has access to the full `DatabaseEditor` (previously it only had a weak handle to the raw collab `Database`, so it couldn't reach the view/filter controllers at all — that's why this was never wired up). On a synced cell change, it now calls the new method for every view.
- Moved where `observe_rows_change` gets set up in `DatabaseEditor::new` so it has that access — it now starts after the editor is fully constructed instead of before, alongside the other view-level observers.

One thing worth calling out: local edits already go through the collab write, which independently triggers this same observer. So after this change, a local edit's filter check runs twice (once via `did_update_row`, once via the observer). This turned out to be harmless — checked the Dart side, and `RowList.insert`/`remove` are idempotent, so a duplicate visibility notification is a no-op on the client. Existing filter tests confirm nothing regresses there.

## Testing

Added a regression test that simulates a synced cell change by writing directly to the collab row (via `DatabaseEditor::update_row`, bypassing `update_cell`/`did_update_row` — the same way an incoming sync applies a change) and asserts that the filter's `FilterNotification` actually fires.

Deliberately did *not* rely on `assert_number_of_visible_rows` alone for this — that helper re-opens the view and re-filters from scratch, so it would pass even with the bug still present. The test checks the incremental notification directly instead.

Note: I didn't have a local Rust toolchain to run `cargo test` on this machine, so I'm relying on CI here — flagging that in case the checks turn something up that a local run would've caught first.

## Test plan

- [ ] CI passes (`cargo test -p flowy-database2`)
- [ ] New regression test `grid_filter_single_select_is_synced_row_change_test` passes
- [ ] Existing filter/sort tests still pass (confirms local-edit double-trigger is harmless)
- [ ] Manual: two devices on the same account, filter/sort a database view, edit the filtered/sorted field on the other device, confirm the view updates once the change syncs in

## Summary by Sourcery

Ensure filtered and sorted database views are re-evaluated when rows change via synced (remote) updates, and add coverage to prevent regressions.

Bug Fixes:
- Trigger view-level row update handling for remotely synced cell changes so filters, sorts, and calculations stay consistent across devices.

Enhancements:
- Wire row-change observation through the full DatabaseEditor so synced updates can notify all relevant views.
- Expose a dedicated view editor method for handling row updates originating from sync events.

Tests:
- Add regression test utilities to simulate remote single-select cell changes via direct collab row updates.
- Add a regression test verifying that a filtered single-select view updates correctly when a row changes through a synced update.