### PR TITLE
fix: view listener never updates the cover widget's view field

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/header/document_cover_widget.dart
@@ -133,11 +133,11 @@ class _DocumentCoverWidgetState extends State<DocumentCoverWidget> {
 
     viewListener = ViewListener(viewId: widget.view.id)
       ..start(
-        onViewUpdated: (view) {
+        onViewUpdated: (updatedView) {
           setState(() {
-            viewIcon = EmojiIconData.fromViewIconPB(view.icon);
-            cover = view.cover;
-            view = view;
+            viewIcon = EmojiIconData.fromViewIconPB(updatedView.icon);
+            cover = updatedView.cover;
+            view = updatedView;
           });
         },
       );


### PR DESCRIPTION
### Bug

In `_DocumentCoverWidgetState.initState`, the `onViewUpdated` callback parameter is named `view`, which shadows the state field of the same name:

```dart
viewListener = ViewListener(viewId: widget.view.id)
  ..start(
    onViewUpdated: (view) {
      setState(() {
        viewIcon = EmojiIconData.fromViewIconPB(view.icon);
        cover = view.cover;
        view = view;          // <-- assigns the parameter to itself
      });
    },
  );
```

`view = view` resolves to the parameter on both sides, so the state field is never updated. It keeps the `ViewPB` captured when the widget was first built, for the widget's lifetime.

The field is not unused — it is read in `build()`, most notably by `DocumentCover(view: view)`, which therefore receives a stale view even though the listener exists specifically to keep it current. The two `view.id` reads are unaffected in practice, since a view's id does not change.

### Fix

Rename the parameter to `updatedView` so the assignment does what it reads as. The icon and cover assignments on the surrounding lines are unchanged in behaviour — they already read from the parameter.

Four lines, rename only. No new behaviour, no new imports or identifiers.

### Note on verification

I found this while working in a fork and am reporting it as a latent correctness bug rather than a fix for a specific reproduction: I have not reproduced a user-visible symptom on unmodified `main`, so I have deliberately not claimed one. The defect itself is unambiguous from the code.

I am not able to compile upstream locally (this needs Flutter >= 3.32; I'm pinned to 3.27.4 by another dependency), so CI here will be its first real compile. Happy to adjust the naming or approach if you'd prefer it done differently.

## Summary by Sourcery

Bug Fixes:
- Fix the onViewUpdated callback so the cover widget's view field is correctly updated instead of being shadowed by the parameter.