### PR TITLE
fix: changing block type over a multi-block selection destroys text

### DIFF
--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/heading/heading_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/heading/heading_toolbar_item.dart
@@ -94,7 +94,11 @@ final headingsToolbarItem = ToolbarItem(
                     node.attributes[blockComponentBackgroundColor],
                 blockComponentTextDirection:
                     node.attributes[blockComponentTextDirection],
-                blockComponentDelta: delta,
+                // Per node: this callback runs for every node in the
+                // selection, and the `delta` captured above belongs only to
+                // the block at `selection.start`. The single-node path in the
+                // branch above may keep using it.
+                blockComponentDelta: (node.delta ?? Delta()).toJson(),
               },
             ),
           );

--- a/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_heading_toolbar_item.dart
+++ b/frontend/appflowy_flutter/lib/plugins/document/presentation/editor_plugins/toolbar_item/text_heading_toolbar_item.dart
@@ -229,14 +229,16 @@ enum TextHeadingCommand {
 
 void formatNodeToText(EditorState editorState) {
   final selection = editorState.selection!;
-  final node = editorState.getNodeAtPath(selection.start.path)!;
-  final delta = (node.delta ?? Delta()).toJson();
+  // Read the delta from the node being transformed. `formatNode` runs this
+  // callback for every node in the selection, so reading it once from
+  // `selection.start` wrote the first block's text over every other block and
+  // destroyed their content.
   editorState.formatNode(
     selection,
     (node) => node.copyWith(
       type: ParagraphBlockKeys.type,
       attributes: {
-        blockComponentDelta: delta,
+        blockComponentDelta: (node.delta ?? Delta()).toJson(),
         blockComponentBackgroundColor:
             node.attributes[blockComponentBackgroundColor],
         blockComponentTextDirection:

--- a/frontend/appflowy_flutter/test/unit_test/document/editor_plugins/toolbar_item/multi_block_turn_into_test.dart
+++ b/frontend/appflowy_flutter/test/unit_test/document/editor_plugins/toolbar_item/multi_block_turn_into_test.dart
@@ -1,0 +1,134 @@
+import 'package:appflowy/plugins/document/presentation/editor_plugins/actions/block_action_option_cubit.dart';
+import 'package:appflowy/plugins/document/presentation/editor_plugins/toolbar_item/text_heading_toolbar_item.dart';
+import 'package:appflowy_editor/appflowy_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Changing the block type of a multi-block selection used to leave every block
+// holding the FIRST block's text, destroying the others' content.
+//
+// `formatNodeToText` read the delta once from `selection.start` and reused it
+// inside the `formatNode` callback -- which runs for every node in the
+// selection. The second test below fails on the unfixed code with
+// ['first paragraph', 'first paragraph'].
+//
+// The `turnIntoBlock` cases are guards: that path reads the delta per node
+// already, and these keep it that way.
+
+Document _twoParagraphs() => Document(
+      root: pageNode(
+        children: [
+          paragraphNode(text: 'first paragraph'),
+          paragraphNode(text: 'second paragraph'),
+        ],
+      ),
+    );
+
+/// Selects from the start of the first block to the end of the last.
+Selection _selectAll(EditorState editorState) {
+  final children = editorState.document.root.children;
+  return Selection(
+    start: Position(path: children.first.path),
+    end: Position(
+      path: children.last.path,
+      offset: children.last.delta?.length ?? 0,
+    ),
+  );
+}
+
+List<String> _texts(EditorState editorState) =>
+    editorState.document.root.children
+        .map((n) => n.delta?.toPlainText() ?? '')
+        .toList();
+
+void main() {
+  group('block type change across a multi-block selection', () {
+    test('turning two paragraphs into headings keeps each ones own text',
+        () async {
+      final editorState = EditorState(document: _twoParagraphs());
+      editorState.selection = _selectAll(editorState);
+
+      await BlockActionOptionCubit.turnIntoBlock(
+        HeadingBlockKeys.type,
+        editorState.getNodeAtPath([0])!,
+        editorState,
+        level: 3,
+        keepSelection: true,
+      );
+
+      expect(_texts(editorState), ['first paragraph', 'second paragraph']);
+      expect(
+        editorState.document.root.children.map((n) => n.type),
+        everyElement(HeadingBlockKeys.type),
+      );
+    });
+
+    test('turning two headings back into text keeps each ones own text',
+        () async {
+      final editorState = EditorState(
+        document: Document(
+          root: pageNode(
+            children: [
+              headingNode(level: 3, text: 'first paragraph'),
+              headingNode(level: 3, text: 'second paragraph'),
+            ],
+          ),
+        ),
+      );
+      editorState.selection = _selectAll(editorState);
+
+      formatNodeToText(editorState);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(_texts(editorState), ['first paragraph', 'second paragraph']);
+    });
+
+    test('an alignment attribute does not reintroduce the duplication',
+        () async {
+      final editorState = EditorState(
+        document: Document(
+          root: pageNode(
+            children: [
+              paragraphNode(
+                text: 'first paragraph',
+                attributes: {blockComponentAlign: 'justify'},
+              ),
+              paragraphNode(
+                text: 'second paragraph',
+                attributes: {blockComponentAlign: 'justify'},
+              ),
+            ],
+          ),
+        ),
+      );
+      editorState.selection = _selectAll(editorState);
+
+      await BlockActionOptionCubit.turnIntoBlock(
+        HeadingBlockKeys.type,
+        editorState.getNodeAtPath([0])!,
+        editorState,
+        level: 3,
+        keepSelection: true,
+      );
+      expect(_texts(editorState), ['first paragraph', 'second paragraph']);
+
+      editorState.selection = _selectAll(editorState);
+      formatNodeToText(editorState);
+      await Future<void>.delayed(Duration.zero);
+      expect(_texts(editorState), ['first paragraph', 'second paragraph']);
+    });
+
+    test('a single-block selection is unaffected', () async {
+      final editorState = EditorState(document: _twoParagraphs());
+      editorState.selection = Selection.single(path: [1], startOffset: 0);
+
+      await BlockActionOptionCubit.turnIntoBlock(
+        HeadingBlockKeys.type,
+        editorState.getNodeAtPath([1])!,
+        editorState,
+        level: 1,
+      );
+
+      expect(_texts(editorState), ['first paragraph', 'second paragraph']);
+    });
+  });
+}


### PR DESCRIPTION
### What's wrong

Selecting several blocks and switching them to **Text** — or from heading back to paragraph — leaves **every block holding the first block's text**. The other blocks' content is overwritten and gone.

### Cause

`formatNodeToText` reads the delta once, from the node at `selection.start`, then uses it inside the `formatNode` callback:

```dart
final delta = (node.delta ?? Delta()).toJson();   // read once: the first block
editorState.formatNode(selection, (node) => node.copyWith(
  attributes: {blockComponentDelta: delta},       // written into EVERY block
));
```

`formatNode` runs that callback for every node in the selection, so one block's text is stamped over all the others. `heading_toolbar_item.dart` has the same mistake in its heading → paragraph branch. Both now read the delta from the node being transformed.

The **other** use of the captured delta in `heading_toolbar_item.dart` is deliberately left alone — that branch builds a single node at `selection.start.path`, so the captured value is the correct one there.

### Test

New file: `test/unit_test/document/editor_plugins/toolbar_item/multi_block_turn_into_test.dart`. On current `main` it reports:

```
Expected: ['first paragraph', 'second paragraph']
  Actual: ['first paragraph', 'first paragraph']
```

and passes with the fix. The `turnIntoBlock` cases are guards — that path already reads the delta per node, and these keep it that way.

### Verification, honestly

The failing-then-passing run was done in a checkout whose `formatNodeToText` is byte-identical to this branch's base (the only local delta in that file is an unrelated import and a popover direction, neither inside the function). I could not run the suite against this branch directly — a fresh worktree fails to compile on unrelated pre-existing errors until `cargo make code_generation` has been run in it. **CI here is the first real compile.** `dart format` is clean on all three files.

### Context

Found after it destroyed a paragraph in a real document. The same one-line mistake exists three more times in AppFlowy-IO/appflowy-editor — `heading_toolbar_items.dart`, `paragraph_toolbar_item.dart` and `heading_command_shortcut.dart` — covered by AppFlowy-IO/appflowy-editor#1227. Worth flagging that the editor's heading **keyboard shortcuts** have no single-selection gate at all, so they can hit a selection of any size.

## Summary by Sourcery

Fix multi-block text/heading conversions so each block preserves its own content and add regression tests for these scenarios.

Bug Fixes:
- Ensure converting multiple blocks from headings to text preserves each block's original text instead of duplicating the first block's content.
- Ensure converting multiple paragraphs to headings preserves each block's original text when using the toolbar actions.

Tests:
- Add unit tests covering multi-block conversions between paragraphs and headings, including alignment attributes and single-block selections, to prevent text duplication regressions.