### PR TITLE
docs: fix broken inlang readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ the community, **Congratulations!** You are now an official contributor to AppFl
 
 ## Translations 🌎🗺
 
-[![translation badge](https://inlang.com/badge?url=github.com/AppFlowy-IO/AppFlowy)](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy?ref=badge)
+[![translation badge](https://inlang.com/badge?url=github.com/AppFlowy-IO/AppFlowy)](./project.inlang/settings.json)
 
 To add translations, you can manually edit the JSON translation files in `/frontend/resources/translations`, use
-the [inlang online editor](https://inlang.com/editor/github.com/AppFlowy-IO/AppFlowy), or
-run `npx inlang machine translate` to add missing translations.
+the checked-in [inlang project settings](./project.inlang/settings.json) with your preferred inlang tool, or run
+`npx inlang machine translate` to add missing translations.
 
 ## Join the community to build AppFlowy together
 


### PR DESCRIPTION
## Summary
- replace the broken inlang editor README links with the checked-in `project.inlang/settings.json` entrypoint
- keep the translation workflow documentation aligned with the repository-local inlang config

## Why
Addresses #8849. The current README points to an inlang editor URL that now returns 404.

## Testing
- verified the previous inlang editor URL returns 404
- not run otherwise (docs-only change)

## Summary by Sourcery

Documentation:
- Adjust README translation badge and instructions to point to the checked-in inlang project settings rather than the deprecated online editor link.